### PR TITLE
v1.1.0: Lumina dashboard redesign, auto card install, device control modes, tariff calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,20 +345,30 @@ All SEM entities are removed automatically. Your Energy Dashboard and hardware s
 
 ---
 
-## Recent Improvements (v1.0.6)
+## Recent Improvements (v1.1.0)
 
-### New Features
-- **Consumption/solar predictor (#3)** — pure Python hourly EWMA profiles that learn weekday/weekend patterns. Predicts next-hour consumption and solar, daily consumption total, and optimal surplus window. No external dependencies. Cold start to trained in 3 days.
-- **Improved notifications (#47)** — Android notification channels (Charging, Alerts, Summary) for per-category control. Actionable buttons ("Open Dashboard"). HA events (`sem_notification`) fired for automation triggers. Mobile service validation cached.
-- **Integration discovery (#44)** — `async_step_integration_discovery()` enables auto-suggestion when supported inverter integrations are detected
+### Dashboard Lumina Redesign (#56)
+- **Lumina tab headers** on all 7 tabs — SVG glow icons, live stats, dot-grid background
+- **Battery hero card** — SOC arc ring with charge/discharge pulse animation, health metrics
+- **EV status card** — three visual states (disconnected/connected/charging) with animated lightning bolt
+- **Section title styling** — transparent backgrounds with gradient divider lines
+- **Consistent precision** — kWh=1dp, W=0dp, CHF=2dp across all dashboard values
 
-### Quality Scale Improvements (#43, #45, #46)
-- 20+ sensors properly categorized as `EntityCategory.DIAGNOSTIC`
-- Obscure diagnostic sensors disabled by default in entity registry
-- New predictor sensors with full translation support
-- Diagnostics handler with comprehensive state export
+### Auto Card Installation (#55)
+- Card JS files auto-installed to `/config/www/` on every restart (if dashboard exists)
+- No more manual `generate_dashboard` call needed after HACS updates
+- Self-healing: recreates card directory if deleted
 
-### Previous (v1.0.4-1.0.5)
+### Device Control Modes (#49)
+- Every device has a control mode: `off`, `peak_only` (default), `surplus`
+- SEM never turns on devices unless explicitly set to `surplus` mode
+- Mode selector dropdown on Control tab, persists across restarts
+
+### Tariff Calendar (#25)
+- User-defined HT/NT time windows with Swiss provider presets (EKZ, BKW, CKW, ewz)
+- Schedule dashboard card showing 24h timeline (tariff, night, surplus, EV)
+
+### Previous (v1.0.x)
 
 ### Performance
 - Cached forecast source detection and surplus window estimation — reduced CPU overhead per update cycle

--- a/__init__.py
+++ b/__init__.py
@@ -330,6 +330,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
             err
         )
 
+    # Auto-install card JS files to /config/www/ on startup (#55)
+    # Only runs if dashboard was previously generated. On HACS updates,
+    # this ensures new cards are available after restart without manual action.
+    try:
+        await _async_install_card_assets(hass, entry)
+    except Exception as err:
+        _LOGGER.debug("Card asset installation skipped: %s", err)
+
     # Register options update listener
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
@@ -1066,6 +1074,69 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
 
     except Exception as e:
         _LOGGER.debug("Frontend resource registration skipped: %s", e)
+
+
+async def _async_install_card_assets(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Auto-install card JS files to /config/www/ on startup (#55).
+
+    Only runs if the SEM dashboard was previously generated, detected by:
+    1. Config entry flag `_install_dashboard_generated` (set by install flow)
+    2. Dashboard storage file `.storage/lovelace.sem-dashboard` (set by service)
+
+    On first install (no dashboard yet): skip — generate_dashboard handles it.
+    On HACS update: auto-copy new/changed cards so restart is sufficient.
+    Self-healing: recreates www dir if deleted but dashboard still exists.
+    """
+    import shutil
+
+    component_dir = os.path.dirname(__file__)
+    card_src_dir = os.path.join(component_dir, "dashboard", "card")
+    card_www_dir = os.path.join(
+        hass.config.config_dir, "www",
+        "custom_components", DOMAIN, "dashboard", "card",
+    )
+
+    # Check if dashboard was ever generated
+    dashboard_generated = False
+
+    # Method 1: Config entry flag (set during install flow)
+    if entry.options.get("_install_dashboard_generated"):
+        dashboard_generated = True
+
+    # Method 2: Dashboard storage file (set by generate_dashboard service)
+    dashboard_storage = os.path.join(
+        hass.config.config_dir, ".storage", "lovelace.sem-dashboard"
+    )
+    if os.path.exists(dashboard_storage):
+        dashboard_generated = True
+
+    if not dashboard_generated:
+        _LOGGER.debug(
+            "SEM dashboard not yet generated — skipping card auto-install. "
+            "Run the generate_dashboard service after setup."
+        )
+        return
+
+    def _copy_cards() -> list:
+        os.makedirs(card_www_dir, exist_ok=True)
+        cards = []
+        if os.path.isdir(card_src_dir):
+            for fname in os.listdir(card_src_dir):
+                if fname.endswith(".js"):
+                    src = os.path.join(card_src_dir, fname)
+                    dst = os.path.join(card_www_dir, fname)
+                    if not os.path.exists(dst) or os.path.getmtime(src) > os.path.getmtime(dst):
+                        shutil.copy2(src, dst)
+                        cards.append(fname)
+        return cards
+
+    updated = await hass.async_add_executor_job(_copy_cards)
+    if updated:
+        _LOGGER.info("Auto-installed %d updated card(s): %s", len(updated), updated)
+    else:
+        _LOGGER.debug("All card assets up to date")
 
 
 async def _async_register_phase_services(

--- a/__init__.py
+++ b/__init__.py
@@ -1008,6 +1008,9 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
         solar_summary_base = f"{static_path}/card/sem-solar-summary-card.js"
         weather_base = f"{static_path}/card/sem-weather-card.js"
         flow_base = f"{static_path}/card/sem-flow-card.js"
+        tab_header_base = f"{static_path}/card/sem-tab-header.js"
+        battery_card_base = f"{static_path}/card/sem-battery-card.js"
+        ev_status_base = f"{static_path}/card/sem-ev-status-card.js"
         schedule_base = f"{static_path}/card/sem-schedule-card.js"
         shared_url = f"{shared_base}?v={version}"
         card_url = f"{card_base}?v={version}"
@@ -1017,6 +1020,9 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
         solar_summary_url = f"{solar_summary_base}?v={version}"
         weather_url = f"{weather_base}?v={version}"
         flow_url = f"{flow_base}?v={version}"
+        tab_header_url = f"{tab_header_base}?v={version}"
+        battery_card_url = f"{battery_card_base}?v={version}"
+        ev_status_url = f"{ev_status_base}?v={version}"
         schedule_url = f"{schedule_base}?v={version}"
         try:
             from homeassistant.components.lovelace.resources import ResourceStorageCollection
@@ -1039,6 +1045,9 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
                 (solar_summary_base, solar_summary_url),
                 (weather_base, weather_url),
                 (flow_base, flow_url),
+                (tab_header_base, tab_header_url),
+                (battery_card_base, battery_card_url),
+                (ev_status_base, ev_status_url),
                 (schedule_base, schedule_url),
             ):
                 item = existing_by_base.get(base)

--- a/dashboard/card/sem-battery-card.js
+++ b/dashboard/card/sem-battery-card.js
@@ -1,0 +1,389 @@
+/**
+ * SEM Battery Card — Lumina-styled battery hero card
+ *
+ * Replaces the mushroom-template-card on the Battery tab with
+ * a themed card matching the system diagram aesthetic (dot grid,
+ * radial glow, SOC arc ring, tabular-nums typography).
+ *
+ * Config:
+ *   type: custom:sem-battery-card
+ *   entity_prefix: sensor.sem_   # default
+ */
+
+class SEMBatteryCard extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this._rendered = false;
+    }
+
+    setConfig(config) {
+        this.config = config;
+        this._prefix = config.entity_prefix || 'sensor.sem_';
+    }
+
+    set hass(hass) {
+        this._hass = hass;
+        const key = [
+            'battery_soc', 'battery_power', 'battery_status',
+            'battery_health_score', 'battery_cycles_estimated',
+            'daily_battery_charge_energy', 'daily_battery_discharge_energy',
+            'daily_battery_savings',
+        ].map(s => this._hass?.states[`${this._prefix}${s}`]?.state || '').join(',');
+        if (key === this._lastKey) return;
+        this._lastKey = key;
+        this._update();
+    }
+
+    _state(suffix, fallback) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        if (!e || e.state === 'unavailable' || e.state === 'unknown') return fallback;
+        return parseFloat(e.state) || fallback;
+    }
+
+    _stateStr(suffix) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        return e?.state || '—';
+    }
+
+    _fmt(val, decimals = 1) {
+        if (val == null || isNaN(val)) return '—';
+        return val.toFixed(decimals);
+    }
+
+    _fmtPower(w) {
+        if (w == null || isNaN(w)) return '— W';
+        if (Math.abs(w) >= 1000) return (w / 1000).toFixed(1) + ' kW';
+        return Math.round(w) + ' W';
+    }
+
+    _update() {
+        if (!this._hass) return;
+
+        const soc = this._state('battery_soc', 0);
+        const power = this._state('battery_power', 0);
+        const chargePower = this._state('battery_charge_power', 0);
+        const dischargePower = this._state('battery_discharge_power', 0);
+        const statusRaw = this._stateStr('battery_status');
+        const health = this._state('battery_health_score', 0);
+        const cycles = this._state('battery_cycles_estimated', 0);
+        const dailyCharge = this._state('daily_battery_charge_energy', 0);
+        const dailyDischarge = this._state('daily_battery_discharge_energy', 0);
+        const dailySavings = this._state('daily_battery_savings', 0);
+
+        // Determine status
+        const isCharging = statusRaw === 'charging' || chargePower > 10;
+        const isDischarging = statusRaw === 'discharging' || dischargePower > 10;
+        const status = isCharging ? 'Charging' : isDischarging ? 'Discharging' : 'Idle';
+
+        // Temperature: try battery_temperature sensor
+        const tempEntity = this._hass?.states[`${this._prefix}battery_temperature`];
+        const temp = (tempEntity && tempEntity.state !== 'unavailable' && tempEntity.state !== 'unknown')
+            ? parseFloat(tempEntity.state) : null;
+
+        if (!this._rendered) {
+            this._renderSkeleton();
+            this._rendered = true;
+        }
+
+        const $ = (sel) => this.shadowRoot.querySelector(sel);
+        const setVal = (sel, text) => { const el = $(sel); if (el) el.textContent = text; };
+
+        // SOC arc
+        const circumference = 2 * Math.PI * 42;
+        const arc = $('.soc-arc');
+        if (arc) {
+            const pct = Math.min(Math.max(soc / 100, 0), 1);
+            arc.style.strokeDashoffset = (circumference * (1 - pct)).toFixed(1);
+            arc.style.stroke = isCharging ? '#f06292' : '#4db6ac';
+            arc.style.animation = (isCharging || isDischarging)
+                ? 'socPulse 2s ease-in-out infinite' : 'none';
+        }
+
+        // Glow ring color
+        const glowRing = $('.glow-ring');
+        if (glowRing) {
+            const intensity = (isCharging || isDischarging) ? 0.5 : 0.2;
+            glowRing.style.opacity = intensity;
+            glowRing.style.stroke = isCharging ? '#f06292' : '#4db6ac';
+        }
+
+        // Glow filter flood color
+        const flood = $('.glow-flood');
+        if (flood) flood.setAttribute('flood-color', isCharging ? '#f06292' : '#4db6ac');
+
+        // Center SOC text
+        setVal('.soc-value', `${soc.toFixed(0)}%`);
+        const socEl = $('.soc-value');
+        if (socEl) socEl.style.color = isCharging ? '#f06292' : '#4db6ac';
+
+        // Metrics
+        setVal('.m-soc', `${soc.toFixed(1)}%`);
+        setVal('.m-power', this._fmtPower(power));
+        setVal('.m-status', status);
+        setVal('.m-health', `${this._fmt(health, 1)}%`);
+        setVal('.m-cycles', this._fmt(cycles, 1));
+        setVal('.m-temp', temp != null ? `${this._fmt(temp, 1)}°C` : '—');
+
+        // Status color
+        const statusEl = $('.m-status');
+        if (statusEl) {
+            statusEl.style.color = isCharging ? '#f06292' : isDischarging ? '#4db6ac' : '#888';
+        }
+
+        // Bottom chips
+        setVal('.chip-charge', this._fmt(dailyCharge, 2) + ' kWh');
+        setVal('.chip-discharge', this._fmt(dailyDischarge, 2) + ' kWh');
+        setVal('.chip-savings', this._fmt(dailySavings, 2) + ' CHF');
+    }
+
+    _renderSkeleton() {
+        const circumference = (2 * Math.PI * 42).toFixed(1);
+
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host { display: block; }
+                .wrap {
+                    padding: 16px 20px;
+                    position: relative;
+                    background:
+                        radial-gradient(ellipse 70% 60% at 50% 30%, rgba(77,182,172,0.06) 0%, transparent 100%),
+                        radial-gradient(circle at 2px 2px, rgba(128,128,128,0.05) 0.7px, transparent 0.7px);
+                    background-size: 100% 100%, 50px 50px;
+                    font-family: 'Segoe UI','Roboto',sans-serif;
+                    color: #e0e0e0;
+                }
+                .glow-svg { position: absolute; width: 0; height: 0; }
+
+                /* Hero layout */
+                .hero {
+                    display: flex;
+                    align-items: center;
+                    gap: 20px;
+                }
+                @media (max-width: 400px) {
+                    .hero {
+                        flex-direction: column;
+                        gap: 12px;
+                    }
+                }
+
+                /* Battery ring */
+                .battery-ring {
+                    position: relative;
+                    width: 100px;
+                    height: 100px;
+                    flex-shrink: 0;
+                }
+                .battery-ring svg {
+                    width: 100%;
+                    height: 100%;
+                    transform: rotate(-90deg);
+                }
+                .ring-bg {
+                    fill: none;
+                    stroke: rgba(77,182,172,0.12);
+                    stroke-width: 5;
+                }
+                .soc-arc {
+                    fill: none;
+                    stroke: #4db6ac;
+                    stroke-width: 5;
+                    stroke-linecap: round;
+                    transition: stroke-dashoffset 1.5s cubic-bezier(0.4,0,0.2,1);
+                    filter: url(#batt-glow);
+                }
+                .glow-ring {
+                    fill: none;
+                    stroke: #4db6ac;
+                    stroke-width: 8;
+                    opacity: 0.2;
+                    filter: url(#batt-glow-soft);
+                }
+                @keyframes socPulse {
+                    0%, 100% { opacity: 1; }
+                    50% { opacity: 0.6; }
+                }
+
+                .ring-center {
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                    text-align: center;
+                    pointer-events: none;
+                }
+                .battery-icon {
+                    display: block;
+                    margin: 0 auto 2px;
+                }
+                .soc-value {
+                    font-size: 18px;
+                    font-weight: 700;
+                    font-variant-numeric: tabular-nums;
+                    color: #4db6ac;
+                    text-shadow: 0 0 8px rgba(77,182,172,0.3);
+                }
+
+                /* Metrics column */
+                .metrics-col {
+                    flex: 1;
+                    min-width: 0;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 3px;
+                }
+                .metric-row {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: baseline;
+                    padding: 2px 0;
+                }
+                .metric-label {
+                    font-size: 12px;
+                    color: #999;
+                    font-weight: 500;
+                }
+                .metric-val {
+                    font-size: 13px;
+                    font-weight: 600;
+                    font-variant-numeric: tabular-nums;
+                    color: #4db6ac;
+                }
+
+                /* Bottom chips */
+                .chips {
+                    display: flex;
+                    gap: 8px;
+                    margin-top: 14px;
+                    flex-wrap: wrap;
+                }
+                .chip {
+                    flex: 1;
+                    min-width: 80px;
+                    background:
+                        radial-gradient(ellipse 80% 60% at 50% 50%, rgba(200,220,240,0.03) 0%, transparent 100%),
+                        rgba(40, 40, 55, 0.4);
+                    border: 1px solid rgba(255,255,255,0.05);
+                    border-radius: 10px;
+                    padding: 8px 10px;
+                    text-align: center;
+                    transition: border-color 0.3s cubic-bezier(0.4,0,0.2,1);
+                }
+                .chip:hover {
+                    border-color: rgba(255,255,255,0.12);
+                }
+                .chip-label {
+                    font-size: 10px;
+                    color: #888;
+                    font-weight: 500;
+                    letter-spacing: 0.3px;
+                    margin-bottom: 3px;
+                }
+                .chip-value {
+                    font-size: 13px;
+                    font-weight: 600;
+                    font-variant-numeric: tabular-nums;
+                }
+                .c-charge { color: #f06292; }
+                .c-discharge { color: #4db6ac; }
+                .c-savings { color: #8DC892; }
+            </style>
+
+            <svg class="glow-svg">
+                <defs>
+                    <filter id="batt-glow" x="-50%" y="-50%" width="200%" height="200%">
+                        <feGaussianBlur stdDeviation="4" result="blur"/>
+                        <feFlood class="glow-flood" flood-color="#4db6ac" flood-opacity="0.25" result="color"/>
+                        <feComposite in="color" in2="blur" operator="in" result="glow"/>
+                        <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+                    </filter>
+                    <filter id="batt-glow-soft" x="-50%" y="-50%" width="200%" height="200%">
+                        <feGaussianBlur stdDeviation="6" result="blur"/>
+                        <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+                    </filter>
+                </defs>
+            </svg>
+
+            <ha-card>
+                <div class="wrap">
+                    <div class="hero">
+                        <div class="battery-ring">
+                            <svg viewBox="0 0 100 100">
+                                <circle class="glow-ring" cx="50" cy="50" r="42">
+                                    <animate attributeName="r" values="42;45;42" dur="3s" repeatCount="indefinite"/>
+                                    <animate attributeName="opacity" values="0.2;0.08;0.2" dur="3s" repeatCount="indefinite"/>
+                                </circle>
+                                <circle class="ring-bg" cx="50" cy="50" r="42"/>
+                                <circle class="soc-arc" cx="50" cy="50" r="42"
+                                    stroke-dasharray="${circumference}"
+                                    stroke-dashoffset="${circumference}"/>
+                            </svg>
+                            <div class="ring-center">
+                                <svg class="battery-icon" width="20" height="28" viewBox="0 0 20 30" fill="none" stroke="#4db6ac" stroke-width="1.8" opacity="0.7">
+                                    <rect x="2" y="4" width="16" height="26" rx="3"/>
+                                    <rect x="6" y="0" width="8" height="5" rx="2" fill="#4db6ac" opacity="0.5" stroke="none"/>
+                                </svg>
+                                <div class="soc-value">0%</div>
+                            </div>
+                        </div>
+                        <div class="metrics-col">
+                            <div class="metric-row">
+                                <span class="metric-label">SOC</span>
+                                <span class="metric-val m-soc">—</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Power</span>
+                                <span class="metric-val m-power">—</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Status</span>
+                                <span class="metric-val m-status" style="color:#888">—</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Health</span>
+                                <span class="metric-val m-health">—</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Cycles</span>
+                                <span class="metric-val m-cycles">—</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Temperature</span>
+                                <span class="metric-val m-temp">—</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="chips">
+                        <div class="chip">
+                            <div class="chip-label">Charge today</div>
+                            <div class="chip-value c-charge chip-charge">—</div>
+                        </div>
+                        <div class="chip">
+                            <div class="chip-label">Discharge today</div>
+                            <div class="chip-value c-discharge chip-discharge">—</div>
+                        </div>
+                        <div class="chip">
+                            <div class="chip-label">Savings today</div>
+                            <div class="chip-value c-savings chip-savings">—</div>
+                        </div>
+                    </div>
+                </div>
+            </ha-card>
+        `;
+    }
+
+    getCardSize() { return 3; }
+
+    static getStubConfig() { return {}; }
+}
+
+customElements.define('sem-battery-card', SEMBatteryCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: 'sem-battery-card',
+    name: 'SEM Battery',
+    description: 'Lumina-styled battery hero card with SOC arc ring and key metrics',
+});

--- a/dashboard/card/sem-ev-status-card.js
+++ b/dashboard/card/sem-ev-status-card.js
@@ -1,0 +1,469 @@
+/**
+ * SEM EV Status Card — Lumina-styled EV charging hero card
+ *
+ * Animated charging visualization with glow ring, lightning bolt,
+ * and key EV metrics. Replaces mushroom-template-card on EV tab.
+ *
+ * Config:
+ *   type: custom:sem-ev-status-card
+ *   entity_prefix: sensor.sem_   # default
+ */
+
+class SEMEVStatusCard extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this._rendered = false;
+    }
+
+    setConfig(config) {
+        this.config = config;
+        this._prefix = config.entity_prefix || 'sensor.sem_';
+    }
+
+    set hass(hass) {
+        this._hass = hass;
+        const key = [
+            'ev_connected', 'ev_charging', 'ev_power', 'calculated_current',
+            'session_energy', 'session_solar_share', 'session_cost',
+            'daily_ev_energy', 'charging_state'
+        ].map(s => {
+            const pfx = s.startsWith('ev_connected') || s.startsWith('ev_charging')
+                ? 'binary_sensor.sem_' : this._prefix;
+            return this._hass?.states[`${pfx}${s}`]?.state || '';
+        }).join(',');
+        if (key === this._lastKey) return;
+        this._lastKey = key;
+        this._update();
+    }
+
+    _binaryState(suffix) {
+        const e = this._hass?.states[`binary_sensor.sem_${suffix}`];
+        return e?.state === 'on';
+    }
+
+    _state(suffix, fallback) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        if (!e || e.state === 'unavailable' || e.state === 'unknown') return fallback;
+        return parseFloat(e.state) || fallback;
+    }
+
+    _stateStr(suffix) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        return e?.state || '';
+    }
+
+    _fmt(val, decimals = 1) {
+        if (val == null || isNaN(val)) return '\u2014';
+        return val.toFixed(decimals);
+    }
+
+    _fmtPower(w) {
+        if (w == null || isNaN(w)) return '\u2014 W';
+        if (Math.abs(w) >= 1000) return (w / 1000).toFixed(1) + ' kW';
+        return Math.round(w) + ' W';
+    }
+
+    _update() {
+        if (!this._hass) return;
+
+        const connected = this._binaryState('ev_connected');
+        const charging = this._binaryState('ev_charging');
+        const power = this._state('ev_power', 0);
+        const current = this._state('calculated_current', 0);
+        const sessionEnergy = this._state('session_energy', 0);
+        const solarShare = this._state('session_solar_share', 0);
+        const sessionCost = this._state('session_cost', 0);
+        const dailyEnergy = this._state('daily_ev_energy', 0);
+        const strategy = this._stateStr('charging_state');
+
+        if (!this._rendered) {
+            this._renderSkeleton();
+            this._rendered = true;
+        }
+
+        const $ = (sel) => this.shadowRoot.querySelector(sel);
+        const setVal = (sel, text) => { const el = $(sel); if (el) el.textContent = text; };
+
+        // Determine visual state
+        const wrap = $('.wrap');
+        if (wrap) {
+            wrap.classList.toggle('state-charging', charging);
+            wrap.classList.toggle('state-connected', connected && !charging);
+            wrap.classList.toggle('state-disconnected', !connected);
+        }
+
+        // Status text
+        const statusEl = $('.status-value');
+        if (statusEl) {
+            if (charging) {
+                statusEl.textContent = 'Charging';
+                statusEl.className = 'status-value charging';
+            } else if (connected) {
+                statusEl.textContent = 'Connected';
+                statusEl.className = 'status-value connected';
+            } else {
+                statusEl.textContent = 'Disconnected';
+                statusEl.className = 'status-value disconnected';
+            }
+        }
+
+        // Power (only shown when charging)
+        const powerRow = $('.power-row');
+        if (powerRow) powerRow.style.display = charging ? 'flex' : 'none';
+        setVal('.power-value', this._fmtPower(power));
+
+        // Current
+        setVal('.current-value', this._fmt(current, 0) + ' A');
+
+        // Session energy
+        setVal('.session-value', this._fmt(sessionEnergy, 1) + ' kWh');
+
+        // Daily energy
+        setVal('.daily-value', this._fmt(dailyEnergy, 1) + ' kWh');
+
+        // Solar share
+        setVal('.solar-share-value', this._fmt(solarShare, 0) + '%');
+
+        // Strategy
+        const strategyEl = $('.strategy-value');
+        if (strategyEl) {
+            const text = strategy || '\u2014';
+            strategyEl.textContent = text.length > 30 ? text.substring(0, 28) + '\u2026' : text;
+        }
+
+        // Bottom chips
+        setVal('.cost-chip-value', this._fmt(sessionCost, 2) + ' CHF');
+
+        // Glow ring animation state
+        const ring = $('.glow-ring');
+        if (ring) {
+            ring.style.opacity = charging ? '0.6' : (connected ? '0.25' : '0.08');
+        }
+
+        // Lightning bolt visibility
+        const bolt = $('.lightning-bolt');
+        if (bolt) bolt.style.opacity = charging ? '1' : '0';
+    }
+
+    _renderSkeleton() {
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host { display: block; }
+                .wrap {
+                    padding: 16px 20px;
+                    position: relative;
+                    background:
+                        radial-gradient(ellipse 70% 60% at 50% 30%, rgba(141,200,146,0.06) 0%, transparent 100%),
+                        radial-gradient(circle at 2px 2px, rgba(128,128,128,0.05) 0.7px, transparent 0.7px);
+                    background-size: 100% 100%, 50px 50px;
+                    font-family: 'Segoe UI','Roboto',sans-serif;
+                    color: #e0e0e0;
+                    min-height: 108px;
+                    overflow: hidden;
+                }
+
+                /* SVG glow filter */
+                .glow-svg { position: absolute; width: 0; height: 0; }
+
+                /* Hero layout */
+                .hero {
+                    display: flex;
+                    align-items: center;
+                    gap: 20px;
+                }
+
+                /* Icon area */
+                .ev-icon-area {
+                    position: relative;
+                    width: 90px;
+                    height: 90px;
+                    flex-shrink: 0;
+                }
+                .ev-icon-area svg {
+                    width: 100%;
+                    height: 100%;
+                }
+
+                /* Glow ring */
+                .glow-ring {
+                    fill: none;
+                    stroke: #8DC892;
+                    stroke-width: 6;
+                    opacity: 0.08;
+                    filter: url(#ev-glow-soft);
+                    transition: opacity 0.6s ease;
+                }
+                .state-charging .glow-ring {
+                    animation: pulse-ring 2s ease-in-out infinite;
+                }
+                @keyframes pulse-ring {
+                    0%, 100% { stroke-width: 6; opacity: 0.5; }
+                    50% { stroke-width: 10; opacity: 0.7; }
+                }
+
+                .ring-bg {
+                    fill: none;
+                    stroke: rgba(141,200,146,0.12);
+                    stroke-width: 3;
+                }
+                .ring-fill {
+                    fill: rgba(141,200,146,0.07);
+                }
+
+                /* Charger icon inside circle */
+                .charger-icon {
+                    stroke: #8DC892;
+                    fill: none;
+                    stroke-width: 1.8;
+                    stroke-linecap: round;
+                    stroke-linejoin: round;
+                    opacity: 0.7;
+                    transition: opacity 0.4s ease;
+                }
+                .state-disconnected .charger-icon {
+                    stroke: #666;
+                    opacity: 0.35;
+                }
+                .state-disconnected .ring-bg { stroke: rgba(100,100,100,0.12); }
+                .state-disconnected .ring-fill { fill: rgba(100,100,100,0.05); }
+                .state-disconnected .glow-ring { stroke: #666; }
+
+                /* Lightning bolt */
+                .lightning-bolt {
+                    fill: #8DC892;
+                    opacity: 0;
+                    transition: opacity 0.4s ease;
+                    filter: url(#ev-glow);
+                }
+                .state-charging .lightning-bolt {
+                    animation: bolt-pulse 1.5s ease-in-out infinite;
+                }
+                @keyframes bolt-pulse {
+                    0%, 100% { opacity: 0.9; }
+                    50% { opacity: 0.5; }
+                }
+
+                /* Indicator dot */
+                .indicator-dot {
+                    fill: #666;
+                    opacity: 0.3;
+                    transition: fill 0.4s ease, opacity 0.4s ease;
+                }
+                .state-connected .indicator-dot { fill: #8DC892; opacity: 0.5; }
+                .state-charging .indicator-dot {
+                    fill: #8DC892;
+                    opacity: 1;
+                    animation: dot-blink 1s ease-in-out infinite;
+                }
+                @keyframes dot-blink {
+                    0%, 100% { opacity: 1; }
+                    50% { opacity: 0.3; }
+                }
+
+                /* Metrics column */
+                .metrics-col {
+                    flex: 1;
+                    min-width: 0;
+                    display: flex;
+                    flex-direction: column;
+                    gap: 2px;
+                }
+                .metric-row {
+                    display: flex;
+                    justify-content: space-between;
+                    align-items: baseline;
+                    padding: 1.5px 0;
+                }
+                .metric-label {
+                    font-size: 11px;
+                    color: #999;
+                    font-weight: 500;
+                }
+                .metric-value {
+                    font-size: 12px;
+                    font-weight: 600;
+                    font-variant-numeric: tabular-nums;
+                    color: #e0e0e0;
+                }
+
+                /* Status text colors */
+                .status-value {
+                    font-size: 13px;
+                    font-weight: 700;
+                    font-variant-numeric: tabular-nums;
+                }
+                .status-value.charging { color: #8DC892; text-shadow: 0 0 8px rgba(141,200,146,0.4); }
+                .status-value.connected { color: #8DC892; }
+                .status-value.disconnected { color: #777; }
+
+                /* Power value (large) */
+                .power-row .metric-value {
+                    font-size: 16px;
+                    font-weight: 700;
+                    color: #8DC892;
+                    text-shadow: 0 0 6px rgba(141,200,146,0.3);
+                }
+                .power-row .metric-label {
+                    font-size: 12px;
+                }
+
+                /* Solar share color */
+                .solar-share-value { color: #ff9800 !important; }
+
+                /* Strategy text */
+                .strategy-value {
+                    font-size: 10px;
+                    color: #8DC892;
+                    opacity: 0.7;
+                    font-weight: 500;
+                    white-space: nowrap;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                }
+
+                /* Bottom bar */
+                .bottom-bar {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    margin-top: 10px;
+                    flex-wrap: wrap;
+                }
+                .chip {
+                    display: inline-flex;
+                    align-items: center;
+                    gap: 4px;
+                    background: rgba(40, 40, 55, 0.5);
+                    border: 1px solid rgba(141,200,146,0.12);
+                    border-radius: 12px;
+                    padding: 3px 10px;
+                    font-size: 11px;
+                    font-weight: 500;
+                    color: #ccc;
+                    font-variant-numeric: tabular-nums;
+                }
+                .chip-label { color: #888; }
+                .chip-value { color: #e0e0e0; }
+                .cost-chip-value { color: #f06292; }
+
+                /* Responsive: stack on narrow */
+                @media (max-width: 400px) {
+                    .hero {
+                        flex-direction: column;
+                        align-items: center;
+                        text-align: center;
+                    }
+                    .ev-icon-area {
+                        width: 80px;
+                        height: 80px;
+                    }
+                    .metric-row {
+                        justify-content: center;
+                        gap: 8px;
+                    }
+                    .metrics-col {
+                        align-items: center;
+                    }
+                }
+            </style>
+
+            <svg class="glow-svg">
+                <defs>
+                    <filter id="ev-glow" x="-50%" y="-50%" width="200%" height="200%">
+                        <feGaussianBlur stdDeviation="3" result="blur"/>
+                        <feFlood flood-color="#8DC892" flood-opacity="0.3" result="color"/>
+                        <feComposite in="color" in2="blur" operator="in" result="glow"/>
+                        <feMerge><feMergeNode in="glow"/><feMergeNode in="SourceGraphic"/></feMerge>
+                    </filter>
+                    <filter id="ev-glow-soft" x="-50%" y="-50%" width="200%" height="200%">
+                        <feGaussianBlur stdDeviation="6" result="blur"/>
+                        <feMerge><feMergeNode in="blur"/><feMergeNode in="SourceGraphic"/></feMerge>
+                    </filter>
+                </defs>
+            </svg>
+
+            <ha-card>
+                <div class="wrap">
+                    <div class="hero">
+                        <div class="ev-icon-area">
+                            <svg viewBox="0 0 100 100">
+                                <!-- Glow ring -->
+                                <circle class="glow-ring" cx="50" cy="50" r="42"/>
+                                <!-- Background ring -->
+                                <circle class="ring-bg" cx="50" cy="50" r="42"/>
+                                <circle class="ring-fill" cx="50" cy="50" r="39"/>
+
+                                <!-- Charger plug icon -->
+                                <g class="charger-icon" transform="translate(50,46)">
+                                    <rect x="-10" y="-16" width="20" height="26" rx="3"/>
+                                    <rect x="-6.5" y="-11" width="13" height="10" rx="2"/>
+                                    <path d="M-1.5,-1 L0,4 L1.5,-1"/>
+                                    <line x1="0" y1="10" x2="0" y2="15"/>
+                                    <circle class="indicator-dot" cx="0" cy="18" r="2" stroke="none"/>
+                                </g>
+
+                                <!-- Lightning bolt (charging animation) -->
+                                <g class="lightning-bolt" transform="translate(50,42)">
+                                    <path d="M-2,-8 L-4,1 L-0.5,0 L-1,8 L4,-1 L0.5,0 L2,-8Z"
+                                          stroke="none"/>
+                                </g>
+                            </svg>
+                        </div>
+
+                        <div class="metrics-col">
+                            <div class="metric-row">
+                                <span class="metric-label">Status</span>
+                                <span class="status-value disconnected">Disconnected</span>
+                            </div>
+                            <div class="metric-row power-row" style="display:none">
+                                <span class="metric-label">Power</span>
+                                <span class="metric-value power-value">\u2014 W</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Current</span>
+                                <span class="metric-value current-value">\u2014 A</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Session</span>
+                                <span class="metric-value session-value">\u2014 kWh</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Today</span>
+                                <span class="metric-value daily-value">\u2014 kWh</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Solar share</span>
+                                <span class="metric-value solar-share-value">\u2014%</span>
+                            </div>
+                            <div class="metric-row">
+                                <span class="metric-label">Strategy</span>
+                                <span class="strategy-value">\u2014</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="bottom-bar">
+                        <div class="chip">
+                            <span class="chip-label">Session cost</span>
+                            <span class="cost-chip-value">\u2014 CHF</span>
+                        </div>
+                    </div>
+                </div>
+            </ha-card>
+        `;
+    }
+
+    getCardSize() { return 3; }
+
+    static getStubConfig() { return {}; }
+}
+
+customElements.define('sem-ev-status-card', SEMEVStatusCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: 'sem-ev-status-card',
+    name: 'SEM EV Status',
+    description: 'Lumina-styled EV charging hero card with animated charging visualization',
+});

--- a/dashboard/card/sem-tab-header.js
+++ b/dashboard/card/sem-tab-header.js
@@ -1,0 +1,311 @@
+/**
+ * SEM Tab Header Card — Lumina-styled section header with glow icon
+ *
+ * Placed at the top of each dashboard tab to establish the Lumina
+ * visual identity. Shows a custom SVG icon with glow ring, tab title,
+ * subtitle, and dot-grid background.
+ *
+ * Config:
+ *   type: custom:sem-tab-header
+ *   tab: home | energy | battery | ev | control | costs | system
+ *   title: "Home"             # optional override
+ *   subtitle: "Solar overview" # optional override
+ *   entity_prefix: sensor.sem_ # default
+ */
+
+const SEM_TAB_CONFIG = {
+    home: {
+        title: 'Home',
+        subtitle: 'Energy overview',
+        color: '#5BC8D8',
+        icon: (s) => `
+            <path d="M-20,2 L0,-16 L20,2" stroke-width="2.2"/>
+            <rect x="-15" y="2" width="30" height="22" rx="2" stroke-width="2"/>
+            <rect x="-5" y="12" width="10" height="12" stroke-width="1.5"/>`,
+    },
+    energy: {
+        title: 'Energy',
+        subtitle: 'Production & consumption',
+        color: '#ff9800',
+        icon: (s) => `
+            <path d="M-4,-18 L-10,2 L-2,2 L-6,18 L12,-4 L2,-4 L8,-18 Z" stroke-width="1.8"/>`,
+    },
+    battery: {
+        title: 'Battery',
+        subtitle: 'Storage & health',
+        color: '#4db6ac',
+        icon: (s) => `
+            <rect x="-10" y="-16" width="20" height="32" rx="4" stroke-width="2"/>
+            <rect x="-4" y="-20" width="8" height="5" rx="2" fill="currentColor" opacity="0.4" stroke="none"/>
+            <line x1="-5" y1="-4" x2="5" y2="-4" stroke-width="1.5" opacity="0.5"/>
+            <line x1="-5" y1="4" x2="5" y2="4" stroke-width="1.5" opacity="0.5"/>`,
+    },
+    ev: {
+        title: 'EV Charging',
+        subtitle: 'Vehicle & sessions',
+        color: '#8DC892',
+        icon: (s) => `
+            <rect x="-12" y="-14" width="24" height="24" rx="5" stroke-width="2"/>
+            <path d="M-3,-6 L-1,0 L-5,0 L3,8" stroke-width="2.2" fill="none"/>
+            <line x1="0" y1="10" x2="0" y2="16" stroke-width="2"/>
+            <circle cx="0" cy="18" r="2" fill="currentColor" opacity="0.4" stroke="none"/>`,
+    },
+    control: {
+        title: 'Control',
+        subtitle: 'Devices & scheduling',
+        color: '#96CAEE',
+        icon: (s) => `
+            <line x1="-12" y1="-12" x2="-12" y2="12" stroke-width="2"/>
+            <line x1="0" y1="-12" x2="0" y2="12" stroke-width="2"/>
+            <line x1="12" y1="-12" x2="12" y2="12" stroke-width="2"/>
+            <circle cx="-12" cy="-4" r="4" fill="currentColor" opacity="0.6" stroke="none"/>
+            <circle cx="0" cy="4" r="4" fill="currentColor" opacity="0.6" stroke="none"/>
+            <circle cx="12" cy="-8" r="4" fill="currentColor" opacity="0.6" stroke="none"/>`,
+    },
+    costs: {
+        title: 'Costs',
+        subtitle: 'Savings & tariffs',
+        color: '#f06292',
+        icon: (s) => `
+            <circle cx="0" cy="0" r="16" stroke-width="2"/>
+            <text x="0" y="6" text-anchor="middle" font-size="18" font-weight="700"
+                  fill="currentColor" opacity="0.7" stroke="none"
+                  font-family="'Segoe UI','Roboto',sans-serif">$</text>`,
+    },
+    system: {
+        title: 'System',
+        subtitle: 'Health & diagnostics',
+        color: '#96CAEE',
+        icon: (s) => `
+            <path d="M-16,4 L-8,-8 L0,0 L6,-12 L10,-4 L16,4" stroke-width="2.2" fill="none"/>
+            <line x1="-16" y1="8" x2="16" y2="8" stroke-width="1" opacity="0.3"/>`,
+    },
+};
+
+class SEMTabHeader extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this._rendered = false;
+    }
+
+    setConfig(config) {
+        this.config = config;
+        this._tab = config.tab || 'home';
+        this._prefix = config.entity_prefix || 'sensor.sem_';
+    }
+
+    set hass(hass) {
+        this._hass = hass;
+        if (!this._rendered) {
+            this._render();
+            this._rendered = true;
+        }
+        this._updateStats();
+    }
+
+    _getState(suffix, fallback) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        if (!e || e.state === 'unavailable' || e.state === 'unknown') return fallback;
+        return parseFloat(e.state) || fallback;
+    }
+
+    _fmtPower(w) {
+        if (w == null || isNaN(w)) return '—';
+        const abs = Math.abs(w);
+        if (abs >= 1000) return (w / 1000).toFixed(1) + ' kW';
+        return Math.round(w) + ' W';
+    }
+
+    _updateStats() {
+        if (!this._hass) return;
+        const root = this.shadowRoot;
+        const stat1 = root.getElementById('stat1');
+        const stat2 = root.getElementById('stat2');
+        const stat3 = root.getElementById('stat3');
+        if (!stat1) return;
+
+        const tab = this._tab;
+        if (tab === 'home') {
+            stat1.textContent = this._fmtPower(this._getState('solar_power', 0));
+            stat2.textContent = this._getState('autarky_rate', 0).toFixed(0) + '%';
+            stat3.textContent = this._getState('daily_solar_energy', 0).toFixed(1) + ' kWh';
+        } else if (tab === 'energy') {
+            stat1.textContent = this._getState('daily_solar_energy', 0).toFixed(1) + ' kWh';
+            stat2.textContent = this._getState('daily_home_energy', 0).toFixed(1) + ' kWh';
+            stat3.textContent = this._getState('self_consumption_rate', 0).toFixed(0) + '%';
+        } else if (tab === 'battery') {
+            stat1.textContent = this._getState('battery_soc', 0).toFixed(0) + '%';
+            stat2.textContent = this._fmtPower(this._getState('battery_power', 0));
+            stat3.textContent = this._getState('battery_health_score', 100).toFixed(0) + '%';
+        } else if (tab === 'ev') {
+            stat1.textContent = this._fmtPower(this._getState('ev_power', 0));
+            stat2.textContent = this._getState('daily_ev_energy', 0).toFixed(1) + ' kWh';
+            stat3.textContent = this._getState('session_energy', 0).toFixed(1) + ' kWh';
+        } else if (tab === 'control') {
+            stat1.textContent = this._getState('target_peak_limit', 5).toFixed(1) + ' kW';
+            stat2.textContent = this._getState('controllable_devices_count', 0).toFixed(0);
+            stat3.textContent = this._getState('surplus_active_devices', 0).toFixed(0);
+        } else if (tab === 'costs') {
+            stat1.textContent = this._getState('daily_costs', 0).toFixed(2) + ' CHF';
+            stat2.textContent = this._getState('daily_savings', 0).toFixed(2) + ' CHF';
+            stat3.textContent = this._getState('daily_net_cost', 0).toFixed(2) + ' CHF';
+        } else if (tab === 'system') {
+            stat1.textContent = this._getState('energy_optimization_score', 0).toFixed(0);
+            stat2.textContent = this._getState('lifetime_savings', 0).toFixed(0) + ' CHF';
+            stat3.textContent = this._getState('lifetime_co2_avoided', 0).toFixed(0) + ' kg';
+        }
+    }
+
+    _getStatLabels() {
+        const tab = this._tab;
+        if (tab === 'home') return ['Solar', 'Autarky', 'Today'];
+        if (tab === 'energy') return ['Solar', 'Home', 'Self-use'];
+        if (tab === 'battery') return ['SOC', 'Power', 'Health'];
+        if (tab === 'ev') return ['Power', 'Today', 'Session'];
+        if (tab === 'control') return ['Peak', 'Devices', 'Active'];
+        if (tab === 'costs') return ['Cost', 'Saved', 'Net'];
+        if (tab === 'system') return ['Score', 'Saved', 'CO₂'];
+        return ['—', '—', '—'];
+    }
+
+    _render() {
+        const cfg = SEM_TAB_CONFIG[this._tab] || SEM_TAB_CONFIG.home;
+        const title = this.config.title || cfg.title;
+        const subtitle = this.config.subtitle || cfg.subtitle;
+        const color = cfg.color;
+        const labels = this._getStatLabels();
+        const F = "'Segoe UI','Roboto',sans-serif";
+
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host { display: block; }
+                .header-wrap {
+                    display: flex;
+                    align-items: center;
+                    gap: 16px;
+                    padding: 16px 20px;
+                    position: relative;
+                    overflow: hidden;
+                    background:
+                        radial-gradient(ellipse 80% 70% at 20% 50%, ${color}0D 0%, transparent 70%),
+                        radial-gradient(circle at 2px 2px, rgba(128,128,128,0.05) 0.7px, transparent 0.7px);
+                    background-size: 100% 100%, 50px 50px;
+                    font-family: ${F};
+                }
+                .icon-ring {
+                    position: relative;
+                    flex-shrink: 0;
+                    width: 64px;
+                    height: 64px;
+                }
+                .icon-ring svg {
+                    width: 100%;
+                    height: 100%;
+                }
+                .title-area {
+                    flex: 1;
+                    min-width: 0;
+                }
+                .tab-title {
+                    font-size: 20px;
+                    font-weight: 700;
+                    color: ${color};
+                    letter-spacing: 0.5px;
+                    text-shadow: 0 0 12px ${color}40;
+                }
+                .tab-subtitle {
+                    font-size: 12px;
+                    color: #888;
+                    margin-top: 2px;
+                    font-weight: 500;
+                }
+                .stats {
+                    display: flex;
+                    gap: 16px;
+                    flex-shrink: 0;
+                }
+                .stat {
+                    text-align: center;
+                    min-width: 50px;
+                }
+                .stat-value {
+                    font-size: 15px;
+                    font-weight: 700;
+                    font-variant-numeric: tabular-nums;
+                    color: #e0e0e0;
+                }
+                .stat-label {
+                    font-size: 10px;
+                    color: #777;
+                    font-weight: 500;
+                    margin-top: 1px;
+                }
+                @media (max-width: 500px) {
+                    .header-wrap { padding: 12px 14px; gap: 12px; }
+                    .icon-ring { width: 48px; height: 48px; }
+                    .tab-title { font-size: 16px; }
+                    .stats { gap: 10px; }
+                    .stat-value { font-size: 13px; }
+                }
+            </style>
+            <ha-card>
+                <div class="header-wrap">
+                    <div class="icon-ring">
+                        <svg viewBox="-34 -34 68 68" xmlns="http://www.w3.org/2000/svg">
+                            <defs>
+                                <filter id="glow-${this._tab}" x="-40%" y="-40%" width="180%" height="180%">
+                                    <feGaussianBlur stdDeviation="4" result="blur"/>
+                                    <feFlood flood-color="${color}" flood-opacity="0.3"/>
+                                    <feComposite in2="blur" operator="in"/>
+                                    <feMerge><feMergeNode/><feMergeNode in="SourceGraphic"/></feMerge>
+                                </filter>
+                            </defs>
+                            <!-- Glow ring -->
+                            <circle r="28" fill="none" stroke="${color}" stroke-width="1.2" opacity="0.25">
+                                <animate attributeName="r" values="28;31;28" dur="3s" repeatCount="indefinite"/>
+                                <animate attributeName="opacity" values="0.25;0.10;0.25" dur="3s" repeatCount="indefinite"/>
+                            </circle>
+                            <!-- Node circle -->
+                            <circle r="24" fill="${color}0F" stroke="${color}" stroke-width="1.5" filter="url(#glow-${this._tab})"/>
+                            <!-- Icon -->
+                            <g stroke="${color}" fill="none" opacity="0.75" stroke-linecap="round" stroke-linejoin="round">
+                                ${cfg.icon()}
+                            </g>
+                        </svg>
+                    </div>
+                    <div class="title-area">
+                        <div class="tab-title">${title}</div>
+                        <div class="tab-subtitle">${subtitle}</div>
+                    </div>
+                    <div class="stats">
+                        <div class="stat">
+                            <div class="stat-value" id="stat1">—</div>
+                            <div class="stat-label">${labels[0]}</div>
+                        </div>
+                        <div class="stat">
+                            <div class="stat-value" id="stat2">—</div>
+                            <div class="stat-label">${labels[1]}</div>
+                        </div>
+                        <div class="stat">
+                            <div class="stat-value" id="stat3">—</div>
+                            <div class="stat-label">${labels[2]}</div>
+                        </div>
+                    </div>
+                </div>
+            </ha-card>
+        `;
+    }
+
+    getCardSize() { return 1; }
+    static getStubConfig() { return { tab: 'home' }; }
+}
+
+customElements.define('sem-tab-header', SEMTabHeader);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: 'sem-tab-header',
+    name: 'SEM Tab Header',
+    description: 'Lumina-styled tab header with glow icon and live stats',
+});

--- a/dashboard/sem_dashboard_template.yaml
+++ b/dashboard/sem_dashboard_template.yaml
@@ -69,41 +69,9 @@ views:
                     box-shadow: 0 4px 24px rgba(244,67,54,0.18), inset 0 1px 0 rgba(255,255,255,0.05) !important;
                   }
 
-          # ── Welcome Intro (collapsed) ──
-          - type: entities
-            card_mod:
-              style: |
-                ha-card {
-                  background:
-                    radial-gradient(ellipse 70% 60% at 50% 40%, rgba(200,220,240,0.07) 0%, transparent 100%),
-                    radial-gradient(circle at 2px 2px, rgba(128,128,128,0.06) 0.7px, transparent 0.7px) !important;
-                  background-size: 100% 100%, 50px 50px !important;
-                  backdrop-filter: blur(18px) saturate(160%) !important;
-                  -webkit-backdrop-filter: blur(18px) saturate(160%) !important;
-                  border: 1px solid rgba(255,255,255,0.08) !important;
-                  border-radius: 16px !important;
-                  box-shadow: 0 4px 24px rgba(0,0,0,0.35), inset 0 1px 0 rgba(255,255,255,0.06) !important;
-                  font-family: 'Segoe UI','Roboto',sans-serif !important;
-                  transition: box-shadow 0.3s cubic-bezier(0.4,0,0.2,1), border-color 0.3s cubic-bezier(0.4,0,0.2,1) !important;
-                }
-                ha-card:hover {
-                  border-color: rgba(255,255,255,0.14) !important;
-                  box-shadow: 0 6px 32px rgba(0,0,0,0.4), inset 0 1px 0 rgba(255,255,255,0.08) !important;
-                }
-            entities:
-              - type: custom:fold-entity-row
-                head:
-                  type: section
-                  label: "Welcome to SEM"
-                open: false
-                entities:
-                  - type: custom:mushroom-template-card
-                    primary: Solar Energy Management
-                    secondary: >-
-                      Monitoring solar, battery, grid & EV.
-                      Use the tabs above to explore energy flows, costs, and controls.
-                    icon: mdi:solar-power-variant
-                    icon_color: amber
+          # ── Lumina Tab Header ──
+          - type: custom:sem-tab-header
+            tab: home
 
           # ── Status Chips Bar ──
           - type: custom:mushroom-chips-card
@@ -310,7 +278,7 @@ views:
                   {% set p = states('sensor.sem_current_vs_peak_percentage') | float(0) %}
                   Peak Load · {% if p > 90 %}Critical{% elif p > 70 %}Warning{% else %}Safe{% endif %}
                 secondary: >-
-                  {{ states('sensor.sem_consecutive_peak_15min') | float(0) | round(2) }} / {{ states('sensor.sem_target_peak_limit') | float(0) | round(1) }} kW
+                  {{ states('sensor.sem_consecutive_peak_15min') | float(0) | round(1) }} / {{ states('sensor.sem_target_peak_limit') | float(0) | round(1) }} kW
                   ({{ states('sensor.sem_current_vs_peak_percentage') | float(0) | round(0) }}%)
                 icon: mdi:flash-alert
                 icon_color: >-
@@ -419,6 +387,8 @@ views:
     cards:
       - type: vertical-stack
         cards:
+          - type: custom:sem-tab-header
+            tab: energy
           # ── Sankey Energy Flow ──
           - type: custom:sankey-chart
             show_names: true
@@ -549,18 +519,23 @@ views:
               - entity: sensor.sem_flow_solar_to_home_energy
                 name: Solar > Home
                 color: "#ff9800"
+                float_precision: 1
               - entity: sensor.sem_flow_grid_to_home_energy
                 name: Grid > Home
                 color: "#488fc2"
+                float_precision: 1
               - entity: sensor.sem_flow_battery_to_home_energy
                 name: Battery > Home
                 color: "#4db6ac"
+                float_precision: 1
               - entity: sensor.sem_daily_ev_energy
                 name: EV Charging
                 color: "#8DC892"
+                float_precision: 1
               - entity: sensor.sem_daily_grid_export_energy
                 name: Export
                 color: "#8353d1"
+                float_precision: 1
             apex_config:
               chart:
                 background: transparent
@@ -583,8 +558,12 @@ views:
                         show: true
                         label: Total
                         color: "#9e9e9e"
+                        formatter: |
+                          EVAL:function(w) { return w.globals.seriesTotals.reduce(function(a,b){return a+b},0).toFixed(1); }
                       value:
                         color: "#e0e0e0"
+                        formatter: |
+                          EVAL:function(val) { return parseFloat(val).toFixed(1); }
             card_mod:
               style: *glass_card
 
@@ -903,83 +882,11 @@ views:
     cards:
       - type: vertical-stack
         cards:
-          # ── Battery SOC ──
-          - type: custom:mushroom-template-card
-            primary: >-
-              {{ states('sensor.sem_battery_soc') | float(0) | round(0) }}%
-            secondary: >-
-              {% set b = states('sensor.sem_battery_power') | float(0) %}
-              {% if b > 50 %}Charging {{ (b / 1000) | round(1) }} kW
-              {% elif b < -50 %}Discharging {{ (b | abs / 1000) | round(1) }} kW
-              {% else %}Idle{% endif %}
-            icon: >-
-              {% set soc = states('sensor.sem_battery_soc') | float(0) %}
-              {% if soc >= 90 %}mdi:battery
-              {% elif soc >= 70 %}mdi:battery-80
-              {% elif soc >= 50 %}mdi:battery-60
-              {% elif soc >= 30 %}mdi:battery-40
-              {% elif soc >= 10 %}mdi:battery-20
-              {% else %}mdi:battery-outline{% endif %}
-            icon_color: >-
-              {% set soc = states('sensor.sem_battery_soc') | float(0) %}
-              {% if soc >= 70 %}green{% elif soc >= 30 %}amber{% else %}red{% endif %}
-            layout: vertical
-            tap_action:
-              action: more-info
-              entity: sensor.sem_battery_soc
-            card_mod:
-              style: *glass_card
-          # ── Battery Power & Status ──
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-template-card
-                primary: >-
-                  {% set b = states('sensor.sem_battery_power') | float(0) %}
-                  {% if b > 50 %}Charging {{ b | round(0) }}W
-                  {% elif b < -50 %}Discharging {{ (-b) | round(0) }}W
-                  {% else %}Idle{% endif %}
-                secondary: >-
-                  {{ states('sensor.sem_battery_status') }}
-                icon: >-
-                  {% set b = states('sensor.sem_battery_power') | float(0) %}
-                  {% if b > 50 %}mdi:battery-charging
-                  {% elif b < -50 %}mdi:battery-minus
-                  {% else %}mdi:battery{% endif %}
-                icon_color: >-
-                  {% set b = states('sensor.sem_battery_power') | float(0) %}
-                  {% if b > 50 %}green{% elif b < -50 %}orange{% else %}grey{% endif %}
-                card_mod:
-                  style: *glass_card
-              - type: custom:mushroom-template-card
-                primary: SOC Strategy
-                secondary: >-
-                  {{ states('sensor.sem_battery_priority_status') }}
-                  · Floor {{ states('number.sem_battery_assist_floor_soc') | float(0) | round(0) }}%
-                icon: mdi:shield-half-full
-                icon_color: cyan
-                card_mod:
-                  style: *glass_card
-
-          # ── Battery Health ──
-          - type: custom:mushroom-template-card
-            primary: Battery Health
-            secondary: >-
-              {% set h = states('sensor.sem_battery_health_score') %}
-              {% set c = states('sensor.sem_battery_cycles_estimated') %}
-              {% set t = states('sensor.sem_battery_temperature') %}
-              Health {{ h if h not in ('unavailable','unknown') else '—' }}%
-              · Cycles {{ c if c not in ('unavailable','unknown') else '—' }}
-              · {{ t if t not in ('unavailable','unknown') else '—' }}°C
-            icon: mdi:battery-heart-variant
-            icon_color: >-
-              {% set h = states('sensor.sem_battery_health_score') | float(100) %}
-              {% if h > 80 %}green{% elif h > 60 %}amber{% else %}red{% endif %}
-            multiline_secondary: true
-            tap_action:
-              action: more-info
-              entity: sensor.sem_battery_health_score
-            card_mod:
-              style: *glass_card
+          - type: custom:sem-tab-header
+            tab: battery
+          # ── Battery Hero (Lumina) ──
+          - type: custom:sem-battery-card
+            entity_prefix: sensor.sem_
 
           # ── Daily Battery Energy ──
           - type: custom:mushroom-chips-card
@@ -1084,6 +991,26 @@ views:
               Priority < {{ states('number.sem_battery_priority_soc') | float(0) | round(0) }}% ·
               Buffer {{ states('number.sem_battery_buffer_soc') | float(0) | round(0) }}% ·
               Auto-start {{ states('number.sem_battery_auto_start_soc') | float(0) | round(0) }}%
+            card_mod:
+              style: &lumina_title |
+                ha-card {
+                  background: transparent !important;
+                  border: none !important;
+                  box-shadow: none !important;
+                  padding: 8px 0 0 0 !important;
+                  --title-font-size: 16px;
+                  --title-font-weight: 600;
+                  --title-letter-spacing: 0.5px;
+                  --subtitle-font-size: 12px;
+                  font-family: 'Segoe UI','Roboto',sans-serif !important;
+                }
+                ha-card::after {
+                  content: '';
+                  display: block;
+                  height: 1px;
+                  margin: 4px 16px 0;
+                  background: linear-gradient(90deg, rgba(150,202,238,0.25) 0%, transparent 70%);
+                }
           - type: horizontal-stack
             cards:
               - type: custom:mushroom-number-card
@@ -1145,37 +1072,11 @@ views:
     cards:
       - type: vertical-stack
         cards:
-          # ── EV Hero Card ──
-          - type: custom:mushroom-template-card
-            primary: >-
-              {% if is_state('binary_sensor.sem_ev_charging', 'on') %}Charging
-              {% elif is_state('binary_sensor.sem_ev_connected', 'on') %}Connected
-              {% else %}Disconnected{% endif %}
-            secondary: >-
-              {% if is_state('binary_sensor.sem_ev_charging', 'on') %}
-              {{ states('sensor.sem_ev_power') | float(0) | round(0) }}W · {{ states('sensor.sem_calculated_current') | float(0) | round(0) }}A
-              {% set remaining = (states('number.sem_daily_ev_target') | float(10)) - (states('sensor.sem_daily_ev_energy') | float(0)) %}
-              {% set power = states('sensor.sem_ev_power') | float(0) %}
-              {% if power > 100 and remaining > 0 %}
-              · ~{{ (remaining / (power / 1000)) | round(1) }}h remaining
-              {% endif %}
-              {% elif is_state('binary_sensor.sem_ev_connected', 'on') %}
-              {{ states('sensor.sem_charging_state') }} · {{ states('sensor.sem_charging_strategy') }}
-              {% else %}
-              No vehicle connected
-              {% endif %}
-            icon: >-
-              {% if is_state('binary_sensor.sem_ev_charging', 'on') %}mdi:car-electric
-              {% elif is_state('binary_sensor.sem_ev_connected', 'on') %}mdi:car-connected
-              {% else %}mdi:car{% endif %}
-            icon_color: >-
-              {% if is_state('binary_sensor.sem_ev_charging', 'on') %}green
-              {% elif is_state('binary_sensor.sem_ev_connected', 'on') %}cyan
-              {% else %}disabled{% endif %}
-            layout: horizontal
-            multiline_secondary: true
-            card_mod:
-              style: *glass_card
+          - type: custom:sem-tab-header
+            tab: ev
+          # ── EV Hero (Lumina) ──
+          - type: custom:sem-ev-status-card
+            entity_prefix: sensor.sem_
 
           # ── Vehicle SOC (conditional) ──
           - type: conditional
@@ -1300,6 +1201,8 @@ views:
 
           # ── Charging Controls ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Charging Settings
           - type: horizontal-stack
             cards:
@@ -1341,6 +1244,8 @@ views:
 
           # ── Lifetime Stats ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Lifetime EV Statistics
           - type: custom:mushroom-chips-card
             alignment: center
@@ -1378,6 +1283,8 @@ views:
     cards:
       - type: vertical-stack
         cards:
+          - type: custom:sem-tab-header
+            tab: control
           # ── Observer Mode Warning ──
           - type: conditional
             conditions:
@@ -1405,6 +1312,8 @@ views:
 
           # ── EV Charging ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: EV Charging
             subtitle: >-
               {{ states('sensor.sem_charging_state') }} · {{ states('sensor.sem_daily_ev_energy') | float(0) | round(1) }}/{{ states('number.sem_daily_ev_target') | float(10) | round(0) }} kWh
@@ -1471,6 +1380,8 @@ views:
 
           # ── Surplus Control ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Surplus Control
             subtitle: >-
               {{ states('sensor.sem_surplus_active_devices') | float(0) | round(0) }}/{{ states('sensor.sem_surplus_total_devices') | float(0) | round(0) }} devices · {{ states('sensor.sem_surplus_allocated_w') | float(0) | round(0) }}W allocated
@@ -1503,6 +1414,8 @@ views:
 
           # ── Battery Settings ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Battery Management
             subtitle: >-
               SOC {{ states('sensor.sem_battery_soc') | float(0) | round(0) }}% · {{ states('sensor.sem_battery_status') }}
@@ -1533,6 +1446,8 @@ views:
 
           # ── Heat Pump & Hot Water ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Heat Pump & Hot Water
             subtitle: >-
               {{ states('sensor.sem_heat_pump_mode') }} · SG-Ready {{ states('sensor.sem_heat_pump_sg_ready_state') }}
@@ -1573,6 +1488,8 @@ views:
 
           # ── Solar & Power ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Solar & Power
           - type: horizontal-stack
             cards:
@@ -1589,6 +1506,8 @@ views:
 
           # ── Tariff & Pricing ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Tariff & Pricing
             subtitle: >-
               {{ states('sensor.sem_tariff_provider') }} · {{ states('sensor.sem_tariff_price_level') }}
@@ -1614,12 +1533,16 @@ views:
           # ── Load Priority (drag-and-drop device management) ──
           # ── Schedule Timeline ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Today's Schedule
             subtitle: Tariff windows · Night charging · Surplus forecast
           - type: custom:sem-schedule-card
             entity_prefix: sensor.sem_
 
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Load Management
             subtitle: >-
               Device priority · {{ states('sensor.sem_controllable_devices_count') }} devices
@@ -1628,9 +1551,11 @@ views:
 
           # ── Peak / Load Management ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Peak & Load Management
             subtitle: >-
-              Peak {{ states('sensor.sem_consecutive_peak_15min') | float(0) | round(2) }} kW · Monthly {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(2) }} kW
+              Peak {{ states('sensor.sem_consecutive_peak_15min') | float(0) | round(1) }} kW · Monthly {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(1) }} kW
           - type: custom:mushroom-template-card
             primary: >-
               {{ states('sensor.sem_current_vs_peak_percentage') | float(0) | round(0) }}% of limit
@@ -1647,7 +1572,7 @@ views:
               - type: custom:mushroom-template-card
                 primary: Peak Margin
                 secondary: >-
-                  {{ states('sensor.sem_peak_margin') | float(0) | round(2) }} kW
+                  {{ states('sensor.sem_peak_margin') | float(0) | round(1) }} kW
                 icon: mdi:shield-check
                 icon_color: green
                 card_mod:
@@ -1655,7 +1580,7 @@ views:
               - type: custom:mushroom-template-card
                 primary: Sheddable
                 secondary: >-
-                  {{ states('sensor.sem_available_load_reduction') | float(0) | round(2) }} kW · {{ states('sensor.sem_controllable_devices_count') }} devices
+                  {{ states('sensor.sem_available_load_reduction') | float(0) | round(1) }} kW · {{ states('sensor.sem_controllable_devices_count') }} devices
                 icon: mdi:power-plug-off
                 icon_color: orange
                 card_mod:
@@ -1663,6 +1588,8 @@ views:
 
           # ── System Mode ──
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: System
           - type: custom:mushroom-entity-card
             entity: switch.sem_observer_mode
@@ -1684,11 +1611,15 @@ views:
     cards:
       - type: vertical-stack
         cards:
+          - type: custom:sem-tab-header
+            tab: costs
 
           # ══════════════════════════════════════════════════════
           # 1. HEADER & KPI
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Cost Tracking
             subtitle: >-
               {{ states('sensor.sem_tariff_provider') }} · {{ states('sensor.sem_tariff_price_level') }} · {{ states('sensor.sem_tariff_current_import_rate') | float(0) | round(2) }}/kWh
@@ -1698,6 +1629,8 @@ views:
               - type: vertical-stack
                 cards:
                   - type: custom:mushroom-title-card
+                    card_mod:
+                      style: *lumina_title
                     title: Today
                   - type: custom:mushroom-chips-card
                     alignment: center
@@ -1737,6 +1670,8 @@ views:
               - type: vertical-stack
                 cards:
                   - type: custom:mushroom-title-card
+                    card_mod:
+                      style: *lumina_title
                     title: This Month
                   - type: custom:mushroom-chips-card
                     alignment: center
@@ -1778,6 +1713,8 @@ views:
           # 2. THIS YEAR
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: This Year
             subtitle: >-
               Net {{ states('sensor.sem_yearly_net_cost') | float(0) | round(2) }} CHF
@@ -1863,6 +1800,8 @@ views:
           # 7. ROI — RETURN ON INVESTMENT
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Return on Investment
             subtitle: >-
               {% set roi = states('sensor.sem_roi_percentage') | float(0) %}
@@ -1962,14 +1901,16 @@ views:
           # 8. DEMAND CHARGE
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Demand Charge
             subtitle: >-
-              Monthly peak: {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(2) }} kW
+              Monthly peak: {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(1) }} kW
           - type: horizontal-stack
             cards:
               - type: custom:mushroom-template-card
                 primary: >-
-                  {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(2) }} kW
+                  {{ states('sensor.sem_monthly_consecutive_peak') | float(0) | round(1) }} kW
                 secondary: Monthly Peak
                 icon: mdi:flash-triangle
                 icon_color: orange
@@ -1993,6 +1934,8 @@ views:
           # 8. TARIFF RATES
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: Tariff Rates
           - type: horizontal-stack
             cards:
@@ -2057,11 +2000,15 @@ views:
     cards:
       - type: vertical-stack
         cards:
+          - type: custom:sem-tab-header
+            tab: system
 
           # ══════════════════════════════════════════════════════
           # 1. HEALTH OVERVIEW — traffic light + sensor status
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-title-card
+            card_mod:
+              style: *lumina_title
             title: System Health
             subtitle: >-
               {% set critical = [

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.0.15"
+  "version": "1.0.16"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -19,5 +19,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.0.16"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Summary

Major release with full dashboard visual overhaul, improved update workflow, and new features.

### Dashboard Lumina Redesign (#56)
- 3 new custom cards: sem-tab-header, sem-battery-card, sem-ev-status-card
- Lumina tab headers on all 7 tabs with SVG glow icons and live stats
- Battery hero with SOC arc ring and pulse animation
- EV status with 3 visual states and animated lightning bolt
- Section title styling with gradient dividers
- Consistent decimal precision (kWh=1, W=0, CHF=2)

### Auto Card Installation (#55)
- Card JS files auto-install to /config/www/ on every restart
- No more manual generate_dashboard needed after HACS updates
- Self-healing: recreates www directory if deleted
- Skips on first install (generate_dashboard handles initial setup)

### Device Control Modes (#49)
- off / peak_only (default) / surplus per device
- Dashboard mode selector dropdown on Control tab

### Tariff Calendar (#25)
- User-defined HT/NT weekly schedule with Swiss provider presets
- Schedule dashboard card with 24h timeline

## Test plan
- [x] All 7 tabs + mobile: zero error cards (MCP verified)
- [x] Card auto-install: delete www + restart → 12 cards restored
- [x] HA-TEST validated: 205 entities, 0 errors
- [ ] HA-PROD deploy

Closes #25, #49, #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)