### PR TITLE
Multi-device aggregation: multiple inverters, batteries, grid tariffs

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -140,22 +140,39 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             summary_lines.append("")
 
         if cfg.has_solar:
-            _add("Solar", [
-                ("Power", cfg.solar_power),
-                ("Energy", cfg.solar_energy),
-            ])
+            if len(cfg.solar_power_list) > 1:
+                fields = [(f"Power ({i+1})", p) for i, p in enumerate(cfg.solar_power_list)]
+                fields += [(f"Energy ({i+1})", e) for i, e in enumerate(cfg.solar_energy_list)]
+                _add(f"Solar ({len(cfg.solar_power_list)} inverters)", fields)
+            else:
+                _add("Solar", [
+                    ("Power", cfg.solar_power),
+                    ("Energy", cfg.solar_energy),
+                ])
         if cfg.has_grid:
-            _add("Grid", [
-                ("Power", cfg.grid_import_power),
-                ("Import energy", cfg.grid_import_energy),
-                ("Export energy", cfg.grid_export_energy),
-            ])
+            if len(cfg.grid_import_energy_list) > 1:
+                fields = [(f"Import energy ({i+1})", e) for i, e in enumerate(cfg.grid_import_energy_list)]
+                fields += [(f"Export energy ({i+1})", e) for i, e in enumerate(cfg.grid_export_energy_list)]
+                fields.insert(0, ("Power", cfg.grid_import_power))
+                _add(f"Grid ({len(cfg.grid_import_energy_list)} tariffs)", fields)
+            else:
+                _add("Grid", [
+                    ("Power", cfg.grid_import_power),
+                    ("Import energy", cfg.grid_import_energy),
+                    ("Export energy", cfg.grid_export_energy),
+                ])
         if cfg.has_battery:
-            _add("Battery", [
-                ("Power", cfg.battery_power),
-                ("Charge energy", cfg.battery_charge_energy),
-                ("Discharge energy", cfg.battery_discharge_energy),
-            ])
+            if len(cfg.battery_power_list) > 1:
+                fields = [(f"Power ({i+1})", p) for i, p in enumerate(cfg.battery_power_list)]
+                fields += [(f"Charge energy ({i+1})", e) for i, e in enumerate(cfg.battery_charge_energy_list)]
+                fields += [(f"Discharge energy ({i+1})", e) for i, e in enumerate(cfg.battery_discharge_energy_list)]
+                _add(f"Battery ({len(cfg.battery_power_list)} units)", fields)
+            else:
+                _add("Battery", [
+                    ("Power", cfg.battery_power),
+                    ("Charge energy", cfg.battery_charge_energy),
+                    ("Discharge energy", cfg.battery_discharge_energy),
+                ])
         if cfg.has_ev:
             _add("EV", [
                 ("Power", cfg.ev_power),

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -275,13 +275,19 @@ class SensorReader:
 
         return self._battery_sign_inverted
 
+    def _read_sensors_sum(self, entity_ids: list, name: str) -> float:
+        """Sum values from multiple sensors of the same type."""
+        return sum(self._read_sensor(eid, name) for eid in entity_ids)
+
     def _read_from_energy_dashboard(self) -> PowerReadings:
         """Read power values from Energy Dashboard configured sensors."""
         ed = self._energy_dashboard_config
         readings = PowerReadings()
 
-        # Solar power
-        if ed.solar_power:
+        # Solar power — sum all inverters if multiple configured
+        if len(ed.solar_power_list) > 1:
+            readings.solar_power = self._read_sensors_sum(ed.solar_power_list, "solar")
+        elif ed.solar_power:
             readings.solar_power = self._read_sensor(ed.solar_power, "solar")
 
         # Grid power from Energy Dashboard.
@@ -292,20 +298,22 @@ class SensorReader:
         if ed.grid_import_power:
             readings.grid_power = self._read_sensor(ed.grid_import_power, "grid")
 
-        # Battery power — pass through the source sensor unchanged.
-        # Sign auto-detection (in read_power → _detect_battery_sign) handles
-        # inverters with opposite conventions (Enphase, GoodWe, Powerwall,
-        # Sunsynk/DEYE) by comparing against charge/discharge energy counters.
-        if ed.battery_power:
+        # Battery power — sum all battery units if multiple configured.
+        # Sign auto-detection (in read_power → _detect_battery_sign) uses the
+        # primary sensor and assumes all units share the same sign convention.
+        if len(ed.battery_power_list) > 1:
+            readings.battery_power = self._read_sensors_sum(ed.battery_power_list, "battery")
+        elif ed.battery_power:
             readings.battery_power = self._read_sensor(ed.battery_power, "battery")
 
-        # Battery SOC - from config or auto-detect from battery power sensor prefix
+        # Battery SOC — from config, or auto-detect and average across all units
         if self.config.battery_soc_sensor:
             readings.battery_soc = self._read_sensor(
                 self.config.battery_soc_sensor, "battery_soc"
             )
+        elif len(ed.battery_power_list) > 1:
+            readings.battery_soc = self._read_battery_soc_average(ed.battery_power_list)
         elif ed.battery_power:
-            # Auto-detect SOC from same device as battery power sensor
             soc_entity = self._auto_detect_battery_soc(ed.battery_power)
             if soc_entity:
                 readings.battery_soc = self._read_sensor(soc_entity, "battery_soc")
@@ -331,6 +339,23 @@ class SensorReader:
             )
 
         return readings
+
+    def _read_battery_soc_average(self, battery_power_entities: list) -> float:
+        """Average SOC across multiple battery units.
+
+        Auto-detects the SOC sensor for each battery power sensor and
+        returns the simple average of all valid readings.
+        """
+        soc_values = []
+        for batt_power in battery_power_entities:
+            soc_entity = self._auto_detect_battery_soc(batt_power)
+            if soc_entity:
+                val = self._read_sensor(soc_entity, "battery_soc")
+                if val > 0:
+                    soc_values.append(val)
+        if soc_values:
+            return sum(soc_values) / len(soc_values)
+        return 0.0
 
     def _read_from_legacy_config(self) -> PowerReadings:
         """Read power values from legacy configuration."""

--- a/ha_energy_reader.py
+++ b/ha_energy_reader.py
@@ -36,6 +36,16 @@ class EnergyDashboardConfig:
     battery_discharge_energy: Optional[str] = None
     ev_energy: Optional[str] = None
 
+    # Multi-device lists (all sources, not just first)
+    solar_power_list: List[str] = field(default_factory=list)
+    solar_energy_list: List[str] = field(default_factory=list)
+    battery_power_list: List[str] = field(default_factory=list)
+    battery_charge_energy_list: List[str] = field(default_factory=list)
+    battery_discharge_energy_list: List[str] = field(default_factory=list)
+    grid_import_energy_list: List[str] = field(default_factory=list)
+    grid_export_energy_list: List[str] = field(default_factory=list)
+    grid_power_list: List[str] = field(default_factory=list)
+
     # Additional device consumption entries (for EV detection)
     device_consumption: List[Dict[str, str]] = field(default_factory=list)
 
@@ -137,10 +147,10 @@ async def read_energy_dashboard_config(hass: HomeAssistant) -> Optional[EnergyDa
         _extract_ev_from_devices(device_consumption, config)
 
         _LOGGER.info(
-            "Read Energy Dashboard config: solar=%s, grid=%s, battery=%s, ev=%s",
-            config.has_solar,
-            config.has_grid,
-            config.has_battery,
+            "Read Energy Dashboard config: solar=%s (%d sources), grid=%s (%d import, %d export), battery=%s (%d units), ev=%s",
+            config.has_solar, len(config.solar_power_list),
+            config.has_grid, len(config.grid_import_energy_list), len(config.grid_export_energy_list),
+            config.has_battery, len(config.battery_power_list),
             config.has_ev,
         )
 
@@ -155,20 +165,31 @@ async def read_energy_dashboard_config(hass: HomeAssistant) -> Optional[EnergyDa
 
 
 def _extract_solar_config(source: Dict[str, Any], config: EnergyDashboardConfig) -> None:
-    """Extract solar configuration from energy source."""
-    # Energy sensor
-    config.solar_energy = source.get("stat_energy_from")
+    """Extract solar configuration from energy source.
 
-    # Power sensor (HA 2025.12+ uses "stat_rate", fallback to "stat_power")
-    config.solar_power = source.get("stat_rate") or source.get("stat_power")
+    Called once per solar source in the Energy Dashboard. Appends to lists
+    and sets the primary (single) field from the first source only.
+    """
+    energy = source.get("stat_energy_from")
+    power = source.get("stat_rate") or source.get("stat_power")
 
-    config.has_solar = bool(config.solar_energy or config.solar_power)
+    if energy:
+        config.solar_energy_list.append(energy)
+        if not config.solar_energy:
+            config.solar_energy = energy
+    if power:
+        config.solar_power_list.append(power)
+        if not config.solar_power:
+            config.solar_power = power
 
-    if config.has_solar:
+    config.has_solar = bool(config.solar_energy_list or config.solar_power_list)
+
+    if energy or power:
         _LOGGER.debug(
-            "Found solar: energy=%s, power=%s",
-            config.solar_energy,
-            config.solar_power,
+            "Found solar source #%d: energy=%s, power=%s",
+            len(config.solar_power_list),
+            energy,
+            power,
         )
 
 
@@ -177,76 +198,114 @@ def _extract_grid_config(source: Dict[str, Any], config: EnergyDashboardConfig) 
 
     Grid uses separate flow_from (import) and flow_to (export) arrays for energy.
     Power is configured in a separate "power" array with "stat_rate" field.
+    Arrays may contain multiple entries (e.g. dual-tariff metering in NL/BE).
 
     HA 2025.12 grid power convention:
     - Single combined sensor: positive=import, negative=export
     - Huawei Solar is OPPOSITE: positive=export, negative=import
     - User may have created a template sensor to invert the sign
     """
-    # Grid import energy — try flow_from array first, then direct field
+    # Grid import energy — collect ALL flow_from entries
     flow_from = source.get("flow_from", [])
     if flow_from:
-        first_import = flow_from[0]
-        config.grid_import_energy = first_import.get("stat_energy_from")
+        for entry in flow_from:
+            eid = entry.get("stat_energy_from")
+            if eid:
+                config.grid_import_energy_list.append(eid)
+                if not config.grid_import_energy:
+                    config.grid_import_energy = eid
     elif source.get("stat_energy_from"):
-        config.grid_import_energy = source.get("stat_energy_from")
+        eid = source.get("stat_energy_from")
+        config.grid_import_energy_list.append(eid)
+        if not config.grid_import_energy:
+            config.grid_import_energy = eid
 
-    # Grid export energy — try flow_to array first, then direct field
+    # Grid export energy — collect ALL flow_to entries
     flow_to = source.get("flow_to", [])
     if flow_to:
-        first_export = flow_to[0]
-        config.grid_export_energy = first_export.get("stat_energy_to")
+        for entry in flow_to:
+            eid = entry.get("stat_energy_to")
+            if eid:
+                config.grid_export_energy_list.append(eid)
+                if not config.grid_export_energy:
+                    config.grid_export_energy = eid
     elif source.get("stat_energy_to"):
-        config.grid_export_energy = source.get("stat_energy_to")
+        eid = source.get("stat_energy_to")
+        config.grid_export_energy_list.append(eid)
+        if not config.grid_export_energy:
+            config.grid_export_energy = eid
 
-    # Grid power — try "power" array first, then direct stat_rate field
+    # Grid power — collect ALL power entries
     power_config = source.get("power", [])
     if power_config:
-        first_power = power_config[0]
-        config.grid_import_power = first_power.get("stat_rate")
+        for entry in power_config:
+            eid = entry.get("stat_rate")
+            if eid:
+                config.grid_power_list.append(eid)
+                if not config.grid_import_power:
+                    config.grid_import_power = eid
     elif source.get("stat_rate"):
-        config.grid_import_power = source.get("stat_rate")
+        eid = source.get("stat_rate")
+        config.grid_power_list.append(eid)
+        if not config.grid_import_power:
+            config.grid_import_power = eid
 
     config.has_grid = bool(
-        config.grid_import_energy
-        or config.grid_import_power
-        or config.grid_export_energy
+        config.grid_import_energy_list
+        or config.grid_power_list
+        or config.grid_export_energy_list
     )
 
     if config.has_grid:
         _LOGGER.debug(
-            "Found grid: import_energy=%s, export_energy=%s, power=%s",
-            config.grid_import_energy,
-            config.grid_export_energy,
-            config.grid_import_power,
+            "Found grid: %d import energy, %d export energy, %d power sensors",
+            len(config.grid_import_energy_list),
+            len(config.grid_export_energy_list),
+            len(config.grid_power_list),
         )
 
 
 def _extract_battery_config(source: Dict[str, Any], config: EnergyDashboardConfig) -> None:
     """Extract battery configuration from energy source.
 
+    Called once per battery source in the Energy Dashboard. Appends to lists
+    and sets the primary (single) field from the first source only.
+
     Battery uses:
     - stat_energy_from: discharge energy
     - stat_energy_to: charge energy
     - stat_rate/stat_power: combined power (positive=charge, negative=discharge in HA 2025.12)
     """
-    config.battery_discharge_energy = source.get("stat_energy_from")
-    config.battery_charge_energy = source.get("stat_energy_to")
-    # HA 2025.12 uses "stat_rate", fallback to "stat_power"
-    config.battery_power = source.get("stat_rate") or source.get("stat_power")
+    discharge_energy = source.get("stat_energy_from")
+    charge_energy = source.get("stat_energy_to")
+    power = source.get("stat_rate") or source.get("stat_power")
+
+    if discharge_energy:
+        config.battery_discharge_energy_list.append(discharge_energy)
+        if not config.battery_discharge_energy:
+            config.battery_discharge_energy = discharge_energy
+    if charge_energy:
+        config.battery_charge_energy_list.append(charge_energy)
+        if not config.battery_charge_energy:
+            config.battery_charge_energy = charge_energy
+    if power:
+        config.battery_power_list.append(power)
+        if not config.battery_power:
+            config.battery_power = power
 
     config.has_battery = bool(
-        config.battery_discharge_energy
-        or config.battery_charge_energy
-        or config.battery_power
+        config.battery_discharge_energy_list
+        or config.battery_charge_energy_list
+        or config.battery_power_list
     )
 
-    if config.has_battery:
+    if discharge_energy or charge_energy or power:
         _LOGGER.debug(
-            "Found battery: charge_energy=%s, discharge_energy=%s, power=%s",
-            config.battery_charge_energy,
-            config.battery_discharge_energy,
-            config.battery_power,
+            "Found battery source #%d: charge_energy=%s, discharge_energy=%s, power=%s",
+            len(config.battery_power_list),
+            charge_energy,
+            discharge_energy,
+            power,
         )
 
 

--- a/tests/test_ha_energy_reader.py
+++ b/tests/test_ha_energy_reader.py
@@ -110,6 +110,8 @@ class TestExtractSolarConfig:
         assert config.solar_energy == "sensor.solar_energy"
         assert config.solar_power == "sensor.solar_power"
         assert config.has_solar is True
+        assert config.solar_power_list == ["sensor.solar_power"]
+        assert config.solar_energy_list == ["sensor.solar_energy"]
 
     def test_extract_solar_config_stat_rate(self):
         """Prefers stat_rate over stat_power."""
@@ -138,6 +140,44 @@ class TestExtractSolarConfig:
         _extract_solar_config(source, config)
         assert config.has_solar is True
         assert config.solar_power is None
+
+    def test_extract_solar_two_inverters(self):
+        """Two solar sources — both in list, primary = first."""
+        config = EnergyDashboardConfig()
+        source1 = {
+            "stat_energy_from": "sensor.inverter1_energy",
+            "stat_rate": "sensor.inverter1_power",
+        }
+        source2 = {
+            "stat_energy_from": "sensor.inverter2_energy",
+            "stat_rate": "sensor.inverter2_power",
+        }
+        _extract_solar_config(source1, config)
+        _extract_solar_config(source2, config)
+        # Primary is first
+        assert config.solar_power == "sensor.inverter1_power"
+        assert config.solar_energy == "sensor.inverter1_energy"
+        # Lists have both
+        assert config.solar_power_list == [
+            "sensor.inverter1_power",
+            "sensor.inverter2_power",
+        ]
+        assert config.solar_energy_list == [
+            "sensor.inverter1_energy",
+            "sensor.inverter2_energy",
+        ]
+        assert config.has_solar is True
+
+    def test_extract_solar_three_inverters(self):
+        """Three solar sources — all in list."""
+        config = EnergyDashboardConfig()
+        for i in range(1, 4):
+            _extract_solar_config({
+                "stat_energy_from": f"sensor.inv{i}_energy",
+                "stat_rate": f"sensor.inv{i}_power",
+            }, config)
+        assert len(config.solar_power_list) == 3
+        assert config.solar_power == "sensor.inv1_power"
 
 
 class TestExtractGridConfig:
@@ -174,6 +214,49 @@ class TestExtractGridConfig:
         _extract_grid_config(source, config)
         assert config.has_grid is False
 
+    def test_extract_grid_multiple_flow_from(self):
+        """Dutch dual-tariff: 2 flow_from entries."""
+        config = EnergyDashboardConfig()
+        source = {
+            "flow_from": [
+                {"stat_energy_from": "sensor.grid_import_tarief_1"},
+                {"stat_energy_from": "sensor.grid_import_tarief_2"},
+            ],
+            "flow_to": [
+                {"stat_energy_to": "sensor.grid_export_tarief_1"},
+                {"stat_energy_to": "sensor.grid_export_tarief_2"},
+            ],
+            "power": [{"stat_rate": "sensor.grid_power"}],
+        }
+        _extract_grid_config(source, config)
+        # Primary is first
+        assert config.grid_import_energy == "sensor.grid_import_tarief_1"
+        assert config.grid_export_energy == "sensor.grid_export_tarief_1"
+        # Lists have both
+        assert config.grid_import_energy_list == [
+            "sensor.grid_import_tarief_1",
+            "sensor.grid_import_tarief_2",
+        ]
+        assert config.grid_export_energy_list == [
+            "sensor.grid_export_tarief_1",
+            "sensor.grid_export_tarief_2",
+        ]
+        assert config.grid_power_list == ["sensor.grid_power"]
+        assert config.has_grid is True
+
+    def test_extract_grid_single_flow_backward_compat(self):
+        """Single flow_from — list has one entry, same as primary."""
+        config = EnergyDashboardConfig()
+        source = {
+            "flow_from": [{"stat_energy_from": "sensor.grid_import"}],
+            "flow_to": [{"stat_energy_to": "sensor.grid_export"}],
+            "power": [{"stat_rate": "sensor.grid_power"}],
+        }
+        _extract_grid_config(source, config)
+        assert config.grid_import_energy == "sensor.grid_import"
+        assert config.grid_import_energy_list == ["sensor.grid_import"]
+        assert len(config.grid_power_list) == 1
+
 
 class TestExtractBatteryConfig:
     """Test _extract_battery_config()."""
@@ -200,6 +283,52 @@ class TestExtractBatteryConfig:
         _extract_battery_config(source, config)
         assert config.battery_power == "sensor.batt_power_old"
         assert config.has_battery is True
+
+    def test_extract_battery_two_units(self):
+        """Two battery sources — both in list, primary = first."""
+        config = EnergyDashboardConfig()
+        source1 = {
+            "stat_energy_from": "sensor.sessy1_discharged",
+            "stat_energy_to": "sensor.sessy1_charged",
+            "stat_rate": "sensor.sessy1_power",
+        }
+        source2 = {
+            "stat_energy_from": "sensor.sessy2_discharged",
+            "stat_energy_to": "sensor.sessy2_charged",
+            "stat_rate": "sensor.sessy2_power",
+        }
+        _extract_battery_config(source1, config)
+        _extract_battery_config(source2, config)
+        # Primary is first
+        assert config.battery_power == "sensor.sessy1_power"
+        assert config.battery_discharge_energy == "sensor.sessy1_discharged"
+        assert config.battery_charge_energy == "sensor.sessy1_charged"
+        # Lists have both
+        assert config.battery_power_list == [
+            "sensor.sessy1_power",
+            "sensor.sessy2_power",
+        ]
+        assert config.battery_charge_energy_list == [
+            "sensor.sessy1_charged",
+            "sensor.sessy2_charged",
+        ]
+        assert config.battery_discharge_energy_list == [
+            "sensor.sessy1_discharged",
+            "sensor.sessy2_discharged",
+        ]
+        assert config.has_battery is True
+
+    def test_extract_battery_single_backward_compat(self):
+        """Single battery — list has one entry, same as primary."""
+        config = EnergyDashboardConfig()
+        source = {
+            "stat_energy_from": "sensor.batt_discharge",
+            "stat_energy_to": "sensor.batt_charge",
+            "stat_rate": "sensor.batt_power",
+        }
+        _extract_battery_config(source, config)
+        assert config.battery_power == "sensor.batt_power"
+        assert config.battery_power_list == ["sensor.batt_power"]
 
 
 class TestExtractEvFromDevices:
@@ -305,6 +434,113 @@ class TestReadEnergyDashboardConfig:
                 config = await read_energy_dashboard_config(hass)
 
         assert config is None
+
+
+SAMPLE_MULTI_DEVICE_DATA = {
+    "data": {
+        "energy_sources": [
+            {
+                "type": "solar",
+                "stat_energy_from": "sensor.inverter1_energy",
+                "stat_rate": "sensor.inverter1_power",
+            },
+            {
+                "type": "solar",
+                "stat_energy_from": "sensor.inverter2_energy",
+                "stat_rate": "sensor.inverter2_power",
+            },
+            {
+                "type": "grid",
+                "flow_from": [
+                    {"stat_energy_from": "sensor.grid_import_tarief_1"},
+                    {"stat_energy_from": "sensor.grid_import_tarief_2"},
+                ],
+                "flow_to": [
+                    {"stat_energy_to": "sensor.grid_export_tarief_1"},
+                    {"stat_energy_to": "sensor.grid_export_tarief_2"},
+                ],
+                "power": [{"stat_rate": "sensor.grid_power"}],
+            },
+            {
+                "type": "battery",
+                "stat_energy_from": "sensor.sessy1_discharged",
+                "stat_energy_to": "sensor.sessy1_charged",
+                "stat_rate": "sensor.sessy1_power",
+            },
+            {
+                "type": "battery",
+                "stat_energy_from": "sensor.sessy2_discharged",
+                "stat_energy_to": "sensor.sessy2_charged",
+                "stat_rate": "sensor.sessy2_power",
+            },
+        ],
+        "device_consumption": [
+            {
+                "stat_consumption": "sensor.wallbox_links_energy",
+                "stat_rate": "sensor.wallbox_links_power",
+            },
+            {
+                "stat_consumption": "sensor.wallbox_rechts_energy",
+                "stat_rate": "sensor.wallbox_rechts_power",
+            },
+        ],
+    }
+}
+
+
+class TestReadMultiDeviceConfig:
+    """Test read_energy_dashboard_config() with multi-device setups."""
+
+    @pytest.mark.asyncio
+    async def test_multi_device_full(self, hass):
+        """Full multi-device setup: 2 inverters, 2 tariffs, 2 batteries, 2 wallboxes."""
+        async def run_func(func):
+            return func()
+
+        hass.async_add_executor_job = AsyncMock(side_effect=run_func)
+
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(SAMPLE_MULTI_DEVICE_DATA))):
+                config = await read_energy_dashboard_config(hass)
+
+        assert config is not None
+        # Solar: 2 inverters
+        assert config.has_solar is True
+        assert len(config.solar_power_list) == 2
+        assert config.solar_power == "sensor.inverter1_power"
+        assert config.solar_power_list[1] == "sensor.inverter2_power"
+        # Grid: 2 tariffs
+        assert config.has_grid is True
+        assert len(config.grid_import_energy_list) == 2
+        assert config.grid_import_energy == "sensor.grid_import_tarief_1"
+        # Battery: 2 units
+        assert config.has_battery is True
+        assert len(config.battery_power_list) == 2
+        assert config.battery_power == "sensor.sessy1_power"
+        assert config.battery_power_list[1] == "sensor.sessy2_power"
+        # EV: first wallbox matched
+        assert config.has_ev is True
+        assert config.ev_power == "sensor.wallbox_links_power"
+
+    @pytest.mark.asyncio
+    async def test_single_device_backward_compat(self, hass):
+        """Single-device setup still works — lists have exactly one entry."""
+        async def run_func(func):
+            return func()
+
+        hass.async_add_executor_job = AsyncMock(side_effect=run_func)
+
+        with patch("os.path.exists", return_value=True):
+            with patch("builtins.open", mock_open(read_data=json.dumps(SAMPLE_ENERGY_DATA))):
+                config = await read_energy_dashboard_config(hass)
+
+        assert config is not None
+        assert len(config.solar_power_list) == 1
+        assert config.solar_power_list[0] == config.solar_power
+        assert len(config.battery_power_list) == 1
+        assert config.battery_power_list[0] == config.battery_power
+        assert len(config.grid_import_energy_list) == 1
+        assert config.grid_import_energy_list[0] == config.grid_import_energy
 
 
 class TestGetAllIndividualDevices:

--- a/tests/test_multi_device_aggregation.py
+++ b/tests/test_multi_device_aggregation.py
@@ -1,0 +1,358 @@
+"""Tests for multi-device aggregation in sensor_reader.py.
+
+Verifies that SEM correctly sums power from multiple inverters, batteries,
+and grid tariffs when the Energy Dashboard has multiple sources (#112).
+"""
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.solar_energy_management.coordinator.sensor_reader import (
+    SensorReader,
+    SensorConfig,
+)
+from custom_components.solar_energy_management.ha_energy_reader import (
+    EnergyDashboardConfig,
+)
+
+
+def _make_state(value, unit="W"):
+    """Create a mock HA state object."""
+    state = MagicMock()
+    state.state = str(value)
+    state.attributes = {"unit_of_measurement": unit}
+    return state
+
+
+def _make_reader(hass, config=None):
+    """Create a SensorReader with mocked hass."""
+    reader = SensorReader(hass, config or {})
+    return reader
+
+
+class TestReadSensorsSum:
+    """Test _read_sensors_sum helper."""
+
+    def test_sum_two_sensors(self, hass):
+        def mock_get(entity_id):
+            return {
+                "sensor.inv1_power": _make_state(3000),
+                "sensor.inv2_power": _make_state(2000),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+        total = reader._read_sensors_sum(
+            ["sensor.inv1_power", "sensor.inv2_power"], "solar"
+        )
+        assert total == 5000.0
+
+    def test_sum_three_sensors(self, hass):
+        def mock_get(entity_id):
+            return {
+                "sensor.inv1_power": _make_state(1000),
+                "sensor.inv2_power": _make_state(2000),
+                "sensor.inv3_power": _make_state(3000),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+        total = reader._read_sensors_sum(
+            ["sensor.inv1_power", "sensor.inv2_power", "sensor.inv3_power"], "solar"
+        )
+        assert total == 6000.0
+
+    def test_sum_with_unavailable_sensor(self, hass):
+        """Unavailable sensor contributes 0, others still counted."""
+        def mock_get(entity_id):
+            if entity_id == "sensor.inv2_power":
+                state = MagicMock()
+                state.state = "unavailable"
+                state.attributes = {}
+                return state
+            return {
+                "sensor.inv1_power": _make_state(3000),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+        total = reader._read_sensors_sum(
+            ["sensor.inv1_power", "sensor.inv2_power"], "solar"
+        )
+        assert total == 3000.0
+
+    def test_sum_with_kw_conversion(self, hass):
+        """Sensors in kW are converted to W before summing."""
+        def mock_get(entity_id):
+            return {
+                "sensor.inv1_power": _make_state(3.0, "kW"),
+                "sensor.inv2_power": _make_state(2.5, "kW"),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+        total = reader._read_sensors_sum(
+            ["sensor.inv1_power", "sensor.inv2_power"], "solar"
+        )
+        assert total == 5500.0
+
+    def test_sum_empty_list(self, hass):
+        reader = _make_reader(hass)
+        total = reader._read_sensors_sum([], "solar")
+        assert total == 0.0
+
+    def test_sum_single_sensor_same_as_read(self, hass):
+        """Single sensor in list gives same result as _read_sensor."""
+        hass.states.get = MagicMock(return_value=_make_state(4200))
+        reader = _make_reader(hass)
+        sum_result = reader._read_sensors_sum(["sensor.inv1_power"], "solar")
+        single_result = reader._read_sensor("sensor.inv1_power", "solar")
+        assert sum_result == single_result == 4200.0
+
+
+class TestMultiSolarAggregation:
+    """Test solar power aggregation with multiple inverters."""
+
+    def test_two_inverters_summed(self, hass):
+        """Two solar inverters → power is summed."""
+        def mock_get(entity_id):
+            return {
+                "sensor.inverter1_power": _make_state(3000),
+                "sensor.inverter2_power": _make_state(2000),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            solar_power="sensor.inverter1_power",
+            solar_power_list=["sensor.inverter1_power", "sensor.inverter2_power"],
+            solar_energy_list=["sensor.inv1_energy", "sensor.inv2_energy"],
+            has_solar=True,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        assert readings.solar_power == 5000.0
+
+    def test_single_inverter_unchanged(self, hass):
+        """Single inverter → same behavior as before."""
+        hass.states.get = MagicMock(return_value=_make_state(4000))
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            solar_power="sensor.solar_power",
+            solar_power_list=["sensor.solar_power"],
+            has_solar=True,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        assert readings.solar_power == 4000.0
+
+
+class TestMultiBatteryAggregation:
+    """Test battery power aggregation with multiple battery units."""
+
+    def test_two_batteries_summed(self, hass):
+        """Two batteries → power is summed."""
+        def mock_get(entity_id):
+            return {
+                "sensor.sessy1_power": _make_state(500),
+                "sensor.sessy2_power": _make_state(300),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.sessy1_power",
+            battery_power_list=["sensor.sessy1_power", "sensor.sessy2_power"],
+            battery_charge_energy="sensor.sessy1_charged",
+            battery_discharge_energy="sensor.sessy1_discharged",
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        assert readings.battery_power == 800.0
+
+    def test_two_batteries_one_charging_one_discharging(self, hass):
+        """Mixed: one battery charging (+500), one discharging (-300)."""
+        def mock_get(entity_id):
+            return {
+                "sensor.sessy1_power": _make_state(500),
+                "sensor.sessy2_power": _make_state(-300),
+            }.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.sessy1_power",
+            battery_power_list=["sensor.sessy1_power", "sensor.sessy2_power"],
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        # Net: 500 + (-300) = 200W charging
+        assert readings.battery_power == 200.0
+
+    def test_single_battery_unchanged(self, hass):
+        """Single battery → same behavior as before."""
+        hass.states.get = MagicMock(return_value=_make_state(-400))
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.battery_power",
+            battery_power_list=["sensor.battery_power"],
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        assert readings.battery_power == -400.0
+
+
+class TestBatterySocAverage:
+    """Test battery SOC averaging across multiple units."""
+
+    def test_two_batteries_soc_averaged(self, hass):
+        """Two batteries with auto-detected SOC → averaged."""
+        def mock_get(entity_id):
+            states = {
+                "sensor.sessy_1_power": _make_state(500),
+                "sensor.sessy_2_power": _make_state(300),
+                "sensor.sessy_1_soc": _make_state(80, "%"),
+                "sensor.sessy_2_soc": _make_state(60, "%"),
+            }
+            return states.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.sessy_1_power",
+            battery_power_list=["sensor.sessy_1_power", "sensor.sessy_2_power"],
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        # Average of 80 and 60
+        assert readings.battery_soc == 70.0
+
+    def test_soc_with_one_unavailable(self, hass):
+        """One SOC unavailable → uses the available one only."""
+        def mock_get(entity_id):
+            states = {
+                "sensor.sessy_1_power": _make_state(500),
+                "sensor.sessy_2_power": _make_state(300),
+                "sensor.sessy_1_soc": _make_state(80, "%"),
+                # sessy_2_soc missing
+            }
+            return states.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.sessy_1_power",
+            battery_power_list=["sensor.sessy_1_power", "sensor.sessy_2_power"],
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        assert readings.battery_soc == 80.0
+
+    def test_config_soc_overrides_average(self, hass):
+        """Explicit SOC config takes precedence over averaging."""
+        def mock_get(entity_id):
+            states = {
+                "sensor.sessy_1_power": _make_state(500),
+                "sensor.sessy_2_power": _make_state(300),
+                "sensor.custom_soc": _make_state(55, "%"),
+            }
+            return states.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass, {"battery_soc_sensor": "sensor.custom_soc"})
+
+        ed = EnergyDashboardConfig(
+            battery_power="sensor.sessy_1_power",
+            battery_power_list=["sensor.sessy_1_power", "sensor.sessy_2_power"],
+            has_battery=True,
+            has_solar=False,
+            has_grid=False,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+        # Config SOC overrides auto-detect average
+        assert readings.battery_soc == 55.0
+
+
+class TestFullMultiDeviceSetup:
+    """Integration test: full multi-device setup like issue #112."""
+
+    def test_issue_112_growatt_sessy_wallbox(self, hass):
+        """Simulate the #112 user: 2 Growatt inverters + 2 Sessy batteries."""
+        def mock_get(entity_id):
+            states = {
+                # 2 Growatt inverters
+                "sensor.growatt1_pv_power": _make_state(3500),
+                "sensor.growatt2_pv_power": _make_state(2800),
+                # 2 Sessy batteries
+                "sensor.sessy_1_power": _make_state(400),
+                "sensor.sessy_2_power": _make_state(350),
+                "sensor.sessy_1_soc": _make_state(72, "%"),
+                "sensor.sessy_2_soc": _make_state(68, "%"),
+                # Grid
+                "sensor.grid_power": _make_state(-1500),
+                # Wallbox
+                "sensor.wallbox_links_power": _make_state(4000),
+            }
+            return states.get(entity_id)
+
+        hass.states.get = MagicMock(side_effect=mock_get)
+        reader = _make_reader(hass)
+
+        ed = EnergyDashboardConfig(
+            # Primary (first) sensors
+            solar_power="sensor.growatt1_pv_power",
+            battery_power="sensor.sessy_1_power",
+            grid_import_power="sensor.grid_power",
+            ev_power="sensor.wallbox_links_power",
+            # Multi-device lists
+            solar_power_list=[
+                "sensor.growatt1_pv_power",
+                "sensor.growatt2_pv_power",
+            ],
+            battery_power_list=[
+                "sensor.sessy_1_power",
+                "sensor.sessy_2_power",
+            ],
+            grid_power_list=["sensor.grid_power"],
+            has_solar=True,
+            has_grid=True,
+            has_battery=True,
+            has_ev=True,
+        )
+        reader.set_energy_dashboard_config(ed)
+        readings = reader._read_from_energy_dashboard()
+
+        # Solar: 3500 + 2800 = 6300
+        assert readings.solar_power == 6300.0
+        # Battery: 400 + 350 = 750
+        assert readings.battery_power == 750.0
+        # SOC: avg(72, 68) = 70
+        assert readings.battery_soc == 70.0
+        # Grid: single sensor, unchanged
+        assert readings.grid_power == -1500.0
+        # EV: single sensor, unchanged
+        assert readings.ev_power == 4000.0


### PR DESCRIPTION
## Summary
- SEM now reads **all** sources from the HA Energy Dashboard instead of only the first (#112)
- Multiple solar inverters → power summed
- Multiple battery units → power summed, SOC averaged
- Multiple grid tariff entries → all collected (Dutch/Belgian dual-tariff support)
- Config flow shows device counts (e.g. "Solar (2 inverters)", "Battery (2 units)")
- Single-device setups unchanged — fully backward compatible

## Scope
- Read-only aggregation only — no multi-EV control or per-battery discharge control
- EV control stays single-charger, battery control stays single-unit

## Test plan
- [x] 71 tests pass (53 ha_energy_reader + 18 battery sign detection)
- [x] 15 new multi-device aggregation tests
- [x] Deployed to HA-TEST — 219 entities, 0 errors, clean startup
- [x] Backward compat verified on single-device Huawei setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)