### PR TITLE
Dashboard: strip beta diagnostics for stable releases

### DIFF
--- a/dashboard/sem_dashboard_template.yaml
+++ b/dashboard/sem_dashboard_template.yaml
@@ -2110,19 +2110,13 @@ views:
             tab: system
 
           # ══════════════════════════════════════════════════════
-          # 0. QUICK ACTIONS — report issue + docs
+          # 0. QUICK ACTIONS — always visible (docs + community)
           # ══════════════════════════════════════════════════════
           - type: custom:mushroom-chips-card
             alignment: end
             card_mod:
               style: *glass_card
             chips:
-              - type: action
-                icon: mdi:bug
-                content: Report Issue
-                tap_action:
-                  action: url
-                  url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
               - type: action
                 icon: mdi:book-open-variant
                 content: Docs
@@ -2137,43 +2131,68 @@ views:
                   url_path: https://community.home-assistant.io/t/solar-energy-management-sem-smart-solar-ev-battery-orchestration/1003701
 
           # ══════════════════════════════════════════════════════
-          # 0b. DIAGNOSTICS SUMMARY
+          # 0b. BETA DIAGNOSTICS — only shown for pre-release versions
           # ══════════════════════════════════════════════════════
-          - type: horizontal-stack
-            cards:
-              - type: custom:mushroom-template-card
-                primary: System Info
-                secondary: >-
-                  Version: {{ states('sensor.sem_diag_version') or '?' }}
+          - type: conditional
+            conditions:
+              - condition: state
+                entity: sensor.sem_diag_version
+                state_not: ""
+            card:
+              type: vertical-stack
+              cards:
+                - type: conditional
+                  conditions:
+                    - condition: template
+                      value_template: >-
+                        {{ 'beta' in states('sensor.sem_diag_version') or 'rc' in states('sensor.sem_diag_version') }}
+                  card:
+                    type: vertical-stack
+                    cards:
+                      - type: custom:mushroom-chips-card
+                        alignment: end
+                        card_mod:
+                          style: *glass_card
+                        chips:
+                          - type: action
+                            icon: mdi:bug
+                            content: Report Issue
+                            tap_action:
+                              action: url
+                              url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
+                      - type: horizontal-stack
+                        cards:
+                          - type: custom:mushroom-template-card
+                            primary: System Info
+                            secondary: >-
+                              Version: {{ states('sensor.sem_diag_version') or '?' }}
 
-                  Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
-                icon: mdi:information
-                icon_color: cyan
-                multiline_secondary: true
-                card_mod:
-                  style: *glass_card
-              - type: custom:mushroom-template-card
-                primary: Charger & Sensors
-                secondary: >-
-                  Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
+                              Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
+                            icon: mdi:information
+                            icon_color: cyan
+                            multiline_secondary: true
+                            card_mod:
+                              style: *glass_card
+                          - type: custom:mushroom-template-card
+                            primary: Charger & Sensors
+                            secondary: >-
+                              Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
 
-                  Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
-                icon: mdi:ev-station
-                icon_color: >-
-                  {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
-                multiline_secondary: true
-                card_mod:
-                  style: *glass_card
-
-          # Copy-friendly diagnostics for bug reports
-          - type: markdown
-            content: >-
-              **Copy for bug report:**
+                              Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
+                            icon: mdi:ev-station
+                            icon_color: >-
+                              {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
+                            multiline_secondary: true
+                            card_mod:
+                              style: *glass_card
+                      - type: markdown
+                        content: >-
+                          **Copy for bug report:**
 
 
-              `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
-            card_mod:
-              style: *glass_card
+                          `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
+                        card_mod:
+                          style: *glass_card
 
           # ══════════════════════════════════════════════════════
           # 1. HEALTH OVERVIEW — traffic light + sensor status

--- a/dashboard/sem_dashboard_template.yaml
+++ b/dashboard/sem_dashboard_template.yaml
@@ -2132,67 +2132,61 @@ views:
 
           # ══════════════════════════════════════════════════════
           # 0b. BETA DIAGNOSTICS — only shown for pre-release versions
+          # Uses a mushroom-template-card with visibility via card_mod
           # ══════════════════════════════════════════════════════
-          - type: conditional
-            conditions:
-              - condition: state
-                entity: sensor.sem_diag_version
-                state_not: ""
-            card:
-              type: vertical-stack
-              cards:
-                - type: conditional
-                  conditions:
-                    - condition: template
-                      value_template: >-
-                        {{ 'beta' in states('sensor.sem_diag_version') or 'rc' in states('sensor.sem_diag_version') }}
-                  card:
-                    type: vertical-stack
-                    cards:
-                      - type: custom:mushroom-chips-card
-                        alignment: end
-                        card_mod:
-                          style: *glass_card
-                        chips:
-                          - type: action
-                            icon: mdi:bug
-                            content: Report Issue
-                            tap_action:
-                              action: url
-                              url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
-                      - type: horizontal-stack
-                        cards:
-                          - type: custom:mushroom-template-card
-                            primary: System Info
-                            secondary: >-
-                              Version: {{ states('sensor.sem_diag_version') or '?' }}
+          - type: vertical-stack
+            card_mod:
+              style: >-
+                :host {
+                  {% if 'beta' not in states('sensor.sem_diag_version') and 'rc' not in states('sensor.sem_diag_version') %}
+                  display: none !important;
+                  {% endif %}
+                }
+            cards:
+              - type: custom:mushroom-chips-card
+                alignment: end
+                card_mod:
+                  style: *glass_card
+                chips:
+                  - type: action
+                    icon: mdi:bug
+                    content: Report Issue
+                    tap_action:
+                      action: url
+                      url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
+              - type: horizontal-stack
+                cards:
+                  - type: custom:mushroom-template-card
+                    primary: System Info
+                    secondary: >-
+                      Version: {{ states('sensor.sem_diag_version') or '?' }}
 
-                              Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
-                            icon: mdi:information
-                            icon_color: cyan
-                            multiline_secondary: true
-                            card_mod:
-                              style: *glass_card
-                          - type: custom:mushroom-template-card
-                            primary: Charger & Sensors
-                            secondary: >-
-                              Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
+                      Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
+                    icon: mdi:information
+                    icon_color: cyan
+                    multiline_secondary: true
+                    card_mod:
+                      style: *glass_card
+                  - type: custom:mushroom-template-card
+                    primary: Charger & Sensors
+                    secondary: >-
+                      Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
 
-                              Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
-                            icon: mdi:ev-station
-                            icon_color: >-
-                              {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
-                            multiline_secondary: true
-                            card_mod:
-                              style: *glass_card
-                      - type: markdown
-                        content: >-
-                          **Copy for bug report:**
+                      Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
+                    icon: mdi:ev-station
+                    icon_color: >-
+                      {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
+                    multiline_secondary: true
+                    card_mod:
+                      style: *glass_card
+              - type: markdown
+                content: >-
+                  **Copy for bug report:**
 
 
-                          `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
-                        card_mod:
-                          style: *glass_card
+                  `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
+                card_mod:
+                  style: *glass_card
 
           # ══════════════════════════════════════════════════════
           # 1. HEALTH OVERVIEW — traffic light + sensor status

--- a/dashboard/sem_dashboard_template.yaml
+++ b/dashboard/sem_dashboard_template.yaml
@@ -2131,62 +2131,53 @@ views:
                   url_path: https://community.home-assistant.io/t/solar-energy-management-sem-smart-solar-ev-battery-orchestration/1003701
 
           # ══════════════════════════════════════════════════════
-          # 0b. BETA DIAGNOSTICS — only shown for pre-release versions
-          # Uses a mushroom-template-card with visibility via card_mod
-          # ══════════════════════════════════════════════════════
-          - type: vertical-stack
+          # 0b. BETA DIAGNOSTICS — stripped by dashboard generator for stable releases
+          # SEM_BETA_START
+          - type: custom:mushroom-chips-card
+            alignment: end
             card_mod:
-              style: >-
-                :host {
-                  {% if 'beta' not in states('sensor.sem_diag_version') and 'rc' not in states('sensor.sem_diag_version') %}
-                  display: none !important;
-                  {% endif %}
-                }
+              style: *glass_card
+            chips:
+              - type: action
+                icon: mdi:bug
+                content: Report Issue
+                tap_action:
+                  action: url
+                  url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
+          - type: horizontal-stack
             cards:
-              - type: custom:mushroom-chips-card
-                alignment: end
+              - type: custom:mushroom-template-card
+                primary: System Info
+                secondary: >-
+                  Version: {{ states('sensor.sem_diag_version') or '?' }}
+
+                  Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
+                icon: mdi:information
+                icon_color: cyan
+                multiline_secondary: true
                 card_mod:
                   style: *glass_card
-                chips:
-                  - type: action
-                    icon: mdi:bug
-                    content: Report Issue
-                    tap_action:
-                      action: url
-                      url_path: https://github.com/traktore-org/sem-community/issues/new?template=bug_report.yml
-              - type: horizontal-stack
-                cards:
-                  - type: custom:mushroom-template-card
-                    primary: System Info
-                    secondary: >-
-                      Version: {{ states('sensor.sem_diag_version') or '?' }}
+              - type: custom:mushroom-template-card
+                primary: Charger & Sensors
+                secondary: >-
+                  Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
 
-                      Grid: {{ states('sensor.sem_diag_grid_mode') or '?' }} ({{ states('sensor.sem_diag_grid_sign') or '?' }}) · Battery: {{ states('sensor.sem_diag_battery_capacity') or '?' }} kWh · Interval: {{ states('sensor.sem_diag_update_interval') or '?' }}s
-                    icon: mdi:information
-                    icon_color: cyan
-                    multiline_secondary: true
-                    card_mod:
-                      style: *glass_card
-                  - type: custom:mushroom-template-card
-                    primary: Charger & Sensors
-                    secondary: >-
-                      Chargers: {{ states('sensor.sem_ev_charger_count') or '0' }} ({{ states('sensor.sem_diag_charger_control') or '?' }})
-
-                      Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
-                    icon: mdi:ev-station
-                    icon_color: >-
-                      {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
-                    multiline_secondary: true
-                    card_mod:
-                      style: *glass_card
-              - type: markdown
-                content: >-
-                  **Copy for bug report:**
-
-
-                  `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
+                  Observer: {{ states('sensor.sem_diag_observer_mode') or 'off' }} · Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') or '0' }} sensors
+                icon: mdi:ev-station
+                icon_color: >-
+                  {% if states('sensor.sem_diag_sensors_unavailable') | int(0) > 5 %}red{% elif states('sensor.sem_diag_sensors_unavailable') | int(0) > 0 %}amber{% else %}green{% endif %}
+                multiline_secondary: true
                 card_mod:
                   style: *glass_card
+          - type: markdown
+            content: >-
+              **Copy for bug report:**
+
+
+              `SEM {{ states('sensor.sem_diag_version') }} | Grid: {{ states('sensor.sem_diag_grid_mode') }} ({{ states('sensor.sem_diag_grid_sign') }}) | Chargers: {{ states('sensor.sem_ev_charger_count') }} ({{ states('sensor.sem_diag_charger_control') }}) | Battery: {{ states('sensor.sem_diag_battery_capacity') }}kWh | Unavailable: {{ states('sensor.sem_diag_sensors_unavailable') }}`
+            card_mod:
+              style: *glass_card
+          # SEM_BETA_END
 
           # ══════════════════════════════════════════════════════
           # 1. HEALTH OVERVIEW — traffic light + sensor status

--- a/features/dashboard_generator.py
+++ b/features/dashboard_generator.py
@@ -111,12 +111,32 @@ class DashboardGenerator:
         return config
 
     async def _load_comprehensive_dashboard_template(self) -> Optional[Dict[str, Any]]:
-        """Load the comprehensive dashboard template from YAML file."""
+        """Load the comprehensive dashboard template from YAML file.
+
+        For stable releases, strips the beta diagnostics section
+        (between SEM_BETA_START and SEM_BETA_END markers).
+        """
         try:
             if os.path.exists(self._dashboard_template_path):
                 def _read():
                     with open(self._dashboard_template_path, "r", encoding="utf-8") as f:
-                        return yaml.safe_load(f)
+                        content = f.read()
+                    # Strip beta section for stable releases
+                    import re as _re
+                    manifest_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "manifest.json")
+                    try:
+                        import json as _json
+                        with open(manifest_path) as mf:
+                            version = _json.load(mf).get("version", "")
+                        if "beta" not in version and "rc" not in version:
+                            content = _re.sub(
+                                r'^\s*# SEM_BETA_START.*?# SEM_BETA_END\s*$',
+                                '', content, flags=_re.MULTILINE | _re.DOTALL,
+                            )
+                            _LOGGER.info("Stripped beta diagnostics from dashboard (stable release %s)", version)
+                    except Exception as strip_err:
+                        _LOGGER.debug("Beta strip skipped: %s", strip_err)
+                    return yaml.safe_load(content)
                 template = await self.hass.async_add_executor_job(_read)
                 _LOGGER.info("Loaded comprehensive dashboard template from %s", self._dashboard_template_path)
                 return template


### PR DESCRIPTION
Generator strips debug section at template load time based on manifest version