### PR TITLE
Add sem-charger-status-card for multi-charger display (#170)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1175,6 +1175,7 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
         tab_header_base = f"{static_path}/card/sem-tab-header.js"
         battery_card_base = f"{static_path}/card/sem-battery-card.js"
         ev_status_base = f"{static_path}/card/sem-ev-status-card.js"
+        charger_status_base = f"{static_path}/card/sem-charger-status-card.js"
         schedule_base = f"{static_path}/card/sem-schedule-card.js"
         localize_url = f"{localize_base}?v={version}"
         shared_url = f"{shared_base}?v={version}"
@@ -1188,6 +1189,7 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
         tab_header_url = f"{tab_header_base}?v={version}"
         battery_card_url = f"{battery_card_base}?v={version}"
         ev_status_url = f"{ev_status_base}?v={version}"
+        charger_status_url = f"{charger_status_base}?v={version}"
         schedule_url = f"{schedule_base}?v={version}"
         try:
             from homeassistant.components.lovelace.resources import ResourceStorageCollection
@@ -1214,6 +1216,7 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
                 (tab_header_base, tab_header_url),
                 (battery_card_base, battery_card_url),
                 (ev_status_base, ev_status_url),
+                (charger_status_base, charger_status_url),
                 (schedule_base, schedule_url),
             ):
                 item = existing_by_base.get(base)

--- a/dashboard/card/sem-charger-status-card.js
+++ b/dashboard/card/sem-charger-status-card.js
@@ -1,0 +1,254 @@
+/**
+ * SEM Charger Status Card — Multi-charger status display
+ *
+ * Dynamically discovers all SEM charger entities and renders
+ * per-charger tiles with power, session energy, solar share,
+ * and taper status. Fully translatable via semLocalize().
+ *
+ * Config:
+ *   type: custom:sem-charger-status-card
+ *   entity_prefix: sensor.sem_   # optional, default
+ */
+
+class SEMChargerStatusCard extends HTMLElement {
+    constructor() {
+        super();
+        this.attachShadow({ mode: 'open' });
+        this._rendered = false;
+        this._lastKey = '';
+        this._chargers = [];
+    }
+
+    setConfig(config) {
+        this.config = config;
+        this._prefix = config.entity_prefix || 'sensor.sem_';
+    }
+
+    _t(key) {
+        const lang = this._hass?.language;
+        return (typeof semLocalize === 'function') ? semLocalize(key, lang) : key;
+    }
+
+    set hass(hass) {
+        this._hass = hass;
+
+        // Discover chargers dynamically from sensor.sem_charger_*_power
+        const chargers = [];
+        for (const eid of Object.keys(hass.states)) {
+            const match = eid.match(/^sensor\.sem_charger_(.+)_power$/);
+            if (match) {
+                chargers.push(match[1]);
+            }
+        }
+        this._chargers = chargers;
+
+        // Build reactivity key
+        const key = chargers.map(id => [
+            `charger_${id}_power`, `charger_${id}_session_energy`,
+            `charger_${id}_session_solar_share`, `charger_${id}_taper_trend`,
+        ].map(s => hass.states[`${this._prefix}${s}`]?.state || '').join(':')).join('|');
+
+        if (key === this._lastKey) return;
+        this._lastKey = key;
+
+        if (!this._rendered) {
+            this._renderSkeleton();
+            this._rendered = true;
+        }
+        this._update();
+    }
+
+    _state(suffix, fallback = 0) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        if (!e || e.state === 'unavailable' || e.state === 'unknown') return fallback;
+        return parseFloat(e.state) || fallback;
+    }
+
+    _stateStr(suffix) {
+        const e = this._hass?.states[`${this._prefix}${suffix}`];
+        return (e && e.state !== 'unavailable' && e.state !== 'unknown') ? e.state : '';
+    }
+
+    _update() {
+        const grid = this.shadowRoot.querySelector('.charger-grid');
+        if (!grid) return;
+
+        grid.innerHTML = this._chargers.map(id => {
+            const power = this._state(`charger_${id}_power`);
+            const session = this._state(`charger_${id}_session_energy`);
+            const solar = this._state(`charger_${id}_session_solar_share`);
+            const taper = this._stateStr(`charger_${id}_taper_trend`) || 'stable';
+
+            // Derive name from friendly_name or charger id
+            const entity = this._hass?.states[`${this._prefix}charger_${id}_power`];
+            let name = id.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+            if (entity?.attributes?.friendly_name) {
+                name = entity.attributes.friendly_name
+                    .replace(/^SEM\s+/i, '')
+                    .replace(/\s+Power$/i, '');
+            }
+
+            const isCharging = power > 50;
+            const statusColor = isCharging ? '#8DC892' : '#888';
+            const statusText = isCharging ? this._t('charging') : this._t('idle');
+            const glowOpacity = isCharging ? '0.15' : '0';
+
+            return `
+                <div class="charger-tile">
+                    <div class="charger-glow" style="opacity:${glowOpacity}"></div>
+                    <div class="charger-header">
+                        <ha-icon icon="mdi:ev-station" style="--mdc-icon-size:20px;color:${statusColor}"></ha-icon>
+                        <span class="charger-name">${name}</span>
+                        <span class="charger-status" style="color:${statusColor}">${statusText}</span>
+                    </div>
+                    <div class="charger-metrics">
+                        <div class="metric">
+                            <span class="metric-value">${power.toFixed(0)}</span>
+                            <span class="metric-unit">W</span>
+                            <span class="metric-label">${this._t('power')}</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">${session.toFixed(1)}</span>
+                            <span class="metric-unit">kWh</span>
+                            <span class="metric-label">${this._t('session')}</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value">${solar.toFixed(0)}</span>
+                            <span class="metric-unit">%</span>
+                            <span class="metric-label">${this._t('solar')}</span>
+                        </div>
+                        <div class="metric">
+                            <span class="metric-value taper-${taper}">${taper}</span>
+                            <span class="metric-label">${this._t('taper')}</span>
+                        </div>
+                    </div>
+                </div>
+            `;
+        }).join('');
+
+        // Update subtitle with charger count
+        const subtitle = this.shadowRoot.querySelector('.card-subtitle');
+        if (subtitle) {
+            subtitle.textContent = `${this._chargers.length} ${this._t('chargers_configured')}`;
+        }
+    }
+
+    _renderSkeleton() {
+        const T = (typeof semTheme === 'function') ? semTheme() : {};
+        const textCol = T.text || '#e0e0e0';
+        const textSecCol = T.textSec || '#999';
+        const surfaceCol = T.surface || 'rgba(255,255,255,0.06)';
+        const surfBorder = T.surfaceBorder || 'rgba(255,255,255,0.12)';
+
+        this.shadowRoot.innerHTML = `
+            <style>
+                :host { display: block; }
+                .card-wrap {
+                    padding: 16px;
+                    position: relative;
+                }
+                .card-title {
+                    font-size: 1.1em;
+                    font-weight: 500;
+                    color: ${textCol};
+                    margin-bottom: 4px;
+                }
+                .card-subtitle {
+                    font-size: 0.85em;
+                    color: ${textSecCol};
+                    margin-bottom: 16px;
+                }
+                .charger-grid {
+                    display: grid;
+                    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+                    gap: 12px;
+                }
+                .charger-tile {
+                    position: relative;
+                    background: ${surfaceCol};
+                    border: 1px solid ${surfBorder};
+                    border-radius: 12px;
+                    padding: 14px;
+                    overflow: hidden;
+                }
+                .charger-glow {
+                    position: absolute;
+                    top: -20px; right: -20px;
+                    width: 80px; height: 80px;
+                    border-radius: 50%;
+                    background: radial-gradient(circle, rgba(141,200,146,0.4), transparent 70%);
+                    pointer-events: none;
+                    transition: opacity 0.5s ease;
+                }
+                .charger-header {
+                    display: flex;
+                    align-items: center;
+                    gap: 8px;
+                    margin-bottom: 12px;
+                }
+                .charger-name {
+                    flex: 1;
+                    font-weight: 500;
+                    color: ${textCol};
+                    font-size: 0.95em;
+                }
+                .charger-status {
+                    font-size: 0.8em;
+                    font-weight: 500;
+                    text-transform: uppercase;
+                    letter-spacing: 0.05em;
+                }
+                .charger-metrics {
+                    display: grid;
+                    grid-template-columns: repeat(4, 1fr);
+                    gap: 8px;
+                    text-align: center;
+                }
+                .metric-value {
+                    display: block;
+                    font-size: 1.15em;
+                    font-weight: 600;
+                    color: ${textCol};
+                }
+                .metric-unit {
+                    font-size: 0.75em;
+                    color: ${textSecCol};
+                    margin-left: 1px;
+                }
+                .metric-label {
+                    display: block;
+                    font-size: 0.7em;
+                    color: ${textSecCol};
+                    margin-top: 2px;
+                    text-transform: uppercase;
+                    letter-spacing: 0.03em;
+                }
+                .taper-rising { color: #f06292; }
+                .taper-falling { color: #8DC892; }
+                .taper-stable { color: ${textSecCol}; }
+            </style>
+            <div class="card-wrap">
+                <div class="card-title">${this._t('Charger Status')}</div>
+                <div class="card-subtitle"></div>
+                <div class="charger-grid"></div>
+            </div>
+        `;
+    }
+
+    getCardSize() {
+        return Math.max(2, this._chargers.length);
+    }
+
+    static getStubConfig() {
+        return {};
+    }
+}
+
+customElements.define('sem-charger-status-card', SEMChargerStatusCard);
+
+window.customCards = window.customCards || [];
+window.customCards.push({
+    type: 'sem-charger-status-card',
+    name: 'SEM Charger Status',
+    description: 'Multi-charger status display with per-charger tiles',
+});

--- a/dashboard/card/sem-localize.js
+++ b/dashboard/card/sem-localize.js
@@ -487,7 +487,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "de": {
         "charging": "Laden",
@@ -977,7 +979,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Karten aktualisieren",
         "Sync Priorities": "Prioritäten synchronisieren",
         "no_devices_yet": "Noch keine steuerbaren Geräte erkannt.",
-        "devices_auto_discovered": "Geräte werden automatisch vom HA Energie-Dashboard erkannt.<br>Einstellungen → Dashboards → Energie → Einzelne Geräte"
+        "devices_auto_discovered": "Geräte werden automatisch vom HA Energie-Dashboard erkannt.<br>Einstellungen → Dashboards → Energie → Einzelne Geräte",
+        "taper": "Taper",
+        "chargers_configured": "Ladegeräte konfiguriert"
     },
     "fr": {
         "charging": "En charge",
@@ -1467,7 +1471,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Rafraîchir les cartes",
         "Sync Priorities": "Synchroniser priorités",
         "no_devices_yet": "Aucun appareil contrôlable découvert.",
-        "devices_auto_discovered": "Les appareils sont auto-découverts depuis le tableau de bord énergie HA.<br>Paramètres → Tableaux de bord → Énergie → Appareils individuels"
+        "devices_auto_discovered": "Les appareils sont auto-découverts depuis le tableau de bord énergie HA.<br>Paramètres → Tableaux de bord → Énergie → Appareils individuels",
+        "taper": "Taper",
+        "chargers_configured": "chargeurs configurés"
     },
     "es": {
         "charging": "Cargando",
@@ -1957,7 +1963,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Actualizar tarjetas",
         "Sync Priorities": "Sincronizar prioridades",
         "no_devices_yet": "No se han descubierto dispositivos controlables.",
-        "devices_auto_discovered": "Los dispositivos se descubren automáticamente del panel de energía HA.<br>Ajustes → Paneles → Energía → Dispositivos individuales"
+        "devices_auto_discovered": "Los dispositivos se descubren automáticamente del panel de energía HA.<br>Ajustes → Paneles → Energía → Dispositivos individuales",
+        "taper": "Taper",
+        "chargers_configured": "cargadores configurados"
     },
     "it": {
         "charging": "In carica",
@@ -2447,7 +2455,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Aggiorna schede",
         "Sync Priorities": "Sincronizza priorità",
         "no_devices_yet": "Nessun dispositivo controllabile scoperto.",
-        "devices_auto_discovered": "I dispositivi vengono scoperti automaticamente dalla dashboard energia HA.<br>Impostazioni → Dashboard → Energia → Dispositivi individuali"
+        "devices_auto_discovered": "I dispositivi vengono scoperti automaticamente dalla dashboard energia HA.<br>Impostazioni → Dashboard → Energia → Dispositivi individuali",
+        "taper": "Taper",
+        "chargers_configured": "caricatori configurati"
     },
     "nl": {
         "charging": "Laden",
@@ -2937,7 +2947,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Kaarten vernieuwen",
         "Sync Priorities": "Prioriteiten synchroniseren",
         "no_devices_yet": "Nog geen bestuurbare apparaten ontdekt.",
-        "devices_auto_discovered": "Apparaten worden automatisch ontdekt vanuit het HA Energie Dashboard.<br>Instellingen → Dashboards → Energie → Individuele apparaten"
+        "devices_auto_discovered": "Apparaten worden automatisch ontdekt vanuit het HA Energie Dashboard.<br>Instellingen → Dashboards → Energie → Individuele apparaten",
+        "taper": "Taper",
+        "chargers_configured": "laders geconfigureerd"
     },
     "cs": {
         "charging": "Nabíjení",
@@ -3427,7 +3439,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "da": {
         "charging": "Oplader",
@@ -3917,7 +3931,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "fi": {
         "charging": "Lataus",
@@ -4407,7 +4423,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "hu": {
         "charging": "Töltés",
@@ -4897,7 +4915,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "no": {
         "charging": "Lader",
@@ -5387,7 +5407,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "pl": {
         "charging": "Ładowanie",
@@ -5877,7 +5899,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "pt": {
         "charging": "A carregar",
@@ -6367,7 +6391,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "ro": {
         "charging": "Încărcare",
@@ -6857,7 +6883,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "sv": {
         "charging": "Laddar",
@@ -7347,7 +7375,9 @@ const SEM_TRANSLATIONS = {
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     }
 };
 function semLocalize(key, lang) {

--- a/dashboard/sem_dashboard_template.yaml
+++ b/dashboard/sem_dashboard_template.yaml
@@ -1289,25 +1289,9 @@ views:
                 entity: sensor.sem_ev_charger_count
                 above: 1
             card:
-              type: vertical-stack
-              cards:
-                - type: custom:mushroom-title-card
-                  card_mod:
-                    style: *lumina_title
-                  title: Charger Status
-                  subtitle: >-
-                    {{ states('sensor.sem_ev_charger_count') }} chargers configured
-                - type: markdown
-                  content: >-
-                    | Charger | Power | Session | Solar | Taper |
-                    |---------|-------|---------|-------|-------|
-                    {% for eid in states.sensor | selectattr('entity_id', 'match', 'sensor.sem_charger_.*_power') | map(attribute='entity_id') | list %}
-                    {% set base = eid | replace('_power', '') %}
-                    {% set name = state_attr(eid, 'friendly_name') | replace(' Power', '') | replace('SEM ', '') %}
-                    | {{ name }} | {{ states(eid) | float(0) | round(0) }}W | {{ states(base ~ '_session_energy') | float(0) | round(1) }}kWh | {{ states(base ~ '_session_solar_share') | float(0) | round(0) }}% | {{ states(base ~ '_taper_trend') or 'idle' }} |
-                    {% endfor %}
-                  card_mod:
-                    style: *glass_card
+              type: custom:sem-charger-status-card
+              card_mod:
+                style: *glass_card
 
           # ── Charging Controls ──
           - type: custom:mushroom-title-card

--- a/dashboard/translations.json
+++ b/dashboard/translations.json
@@ -487,7 +487,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "de": {
         "charging": "Laden",
@@ -977,7 +979,9 @@
         "Refresh Cards": "Karten aktualisieren",
         "Sync Priorities": "Prioritäten synchronisieren",
         "no_devices_yet": "Noch keine steuerbaren Geräte erkannt.",
-        "devices_auto_discovered": "Geräte werden automatisch vom HA Energie-Dashboard erkannt.<br>Einstellungen → Dashboards → Energie → Einzelne Geräte"
+        "devices_auto_discovered": "Geräte werden automatisch vom HA Energie-Dashboard erkannt.<br>Einstellungen → Dashboards → Energie → Einzelne Geräte",
+        "taper": "Taper",
+        "chargers_configured": "Ladegeräte konfiguriert"
     },
     "fr": {
         "charging": "En charge",
@@ -1467,7 +1471,9 @@
         "Refresh Cards": "Rafraîchir les cartes",
         "Sync Priorities": "Synchroniser priorités",
         "no_devices_yet": "Aucun appareil contrôlable découvert.",
-        "devices_auto_discovered": "Les appareils sont auto-découverts depuis le tableau de bord énergie HA.<br>Paramètres → Tableaux de bord → Énergie → Appareils individuels"
+        "devices_auto_discovered": "Les appareils sont auto-découverts depuis le tableau de bord énergie HA.<br>Paramètres → Tableaux de bord → Énergie → Appareils individuels",
+        "taper": "Taper",
+        "chargers_configured": "chargeurs configurés"
     },
     "es": {
         "charging": "Cargando",
@@ -1957,7 +1963,9 @@
         "Refresh Cards": "Actualizar tarjetas",
         "Sync Priorities": "Sincronizar prioridades",
         "no_devices_yet": "No se han descubierto dispositivos controlables.",
-        "devices_auto_discovered": "Los dispositivos se descubren automáticamente del panel de energía HA.<br>Ajustes → Paneles → Energía → Dispositivos individuales"
+        "devices_auto_discovered": "Los dispositivos se descubren automáticamente del panel de energía HA.<br>Ajustes → Paneles → Energía → Dispositivos individuales",
+        "taper": "Taper",
+        "chargers_configured": "cargadores configurados"
     },
     "it": {
         "charging": "In carica",
@@ -2447,7 +2455,9 @@
         "Refresh Cards": "Aggiorna schede",
         "Sync Priorities": "Sincronizza priorità",
         "no_devices_yet": "Nessun dispositivo controllabile scoperto.",
-        "devices_auto_discovered": "I dispositivi vengono scoperti automaticamente dalla dashboard energia HA.<br>Impostazioni → Dashboard → Energia → Dispositivi individuali"
+        "devices_auto_discovered": "I dispositivi vengono scoperti automaticamente dalla dashboard energia HA.<br>Impostazioni → Dashboard → Energia → Dispositivi individuali",
+        "taper": "Taper",
+        "chargers_configured": "caricatori configurati"
     },
     "nl": {
         "charging": "Laden",
@@ -2937,7 +2947,9 @@
         "Refresh Cards": "Kaarten vernieuwen",
         "Sync Priorities": "Prioriteiten synchroniseren",
         "no_devices_yet": "Nog geen bestuurbare apparaten ontdekt.",
-        "devices_auto_discovered": "Apparaten worden automatisch ontdekt vanuit het HA Energie Dashboard.<br>Instellingen → Dashboards → Energie → Individuele apparaten"
+        "devices_auto_discovered": "Apparaten worden automatisch ontdekt vanuit het HA Energie Dashboard.<br>Instellingen → Dashboards → Energie → Individuele apparaten",
+        "taper": "Taper",
+        "chargers_configured": "laders geconfigureerd"
     },
     "cs": {
         "charging": "Nabíjení",
@@ -3427,7 +3439,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "da": {
         "charging": "Oplader",
@@ -3917,7 +3931,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "fi": {
         "charging": "Lataus",
@@ -4407,7 +4423,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "hu": {
         "charging": "Töltés",
@@ -4897,7 +4915,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "no": {
         "charging": "Lader",
@@ -5387,7 +5407,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "pl": {
         "charging": "Ładowanie",
@@ -5877,7 +5899,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "pt": {
         "charging": "A carregar",
@@ -6367,7 +6391,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "ro": {
         "charging": "Încărcare",
@@ -6857,7 +6883,9 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     },
     "sv": {
         "charging": "Laddar",
@@ -7347,6 +7375,8 @@
         "Refresh Cards": "Refresh Cards",
         "Sync Priorities": "Sync Priorities",
         "no_devices_yet": "No controllable devices discovered yet.",
-        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices"
+        "devices_auto_discovered": "Devices are auto-discovered from the HA Energy Dashboard.<br>Settings → Dashboards → Energy → Individual devices",
+        "taper": "Taper",
+        "chargers_configured": "chargers configured"
     }
 }


### PR DESCRIPTION
## Summary
- New `sem-charger-status-card.js` — dynamically discovers all charger entities and renders per-charger tiles
- Replaces Jinja horizontal-stack + markdown table that caused "Configuratiefout" on multi-charger installs
- Fully translatable (15 languages)
- Registered as Lovelace resource
- Fix CI: mock `hour`/`minute` in forecast tracker, mock `dampening_factor` in zone strategy

## Test plan
- [x] Card JS passes `node --check`
- [x] Translation keys added for all 15 languages
- [ ] CI green
- [ ] Deploy to HA-TEST and verify card renders

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)