### PR TITLE
Fix EV intelligence SOC decay on restart

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -211,7 +211,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Hourly activity tracker for schedule card (#63)
         self._today_surplus_hours: list = [False] * 24
         self._today_ev_hours: list = [False] * 24
-        self._tracker_date = None
+        # Initialize to today so restarts don't re-apply daily decay
+        self._tracker_date = dt_util.now().date()
 
         # Per-cycle caches (initialized here, populated in _async_update_data)
         self._cycle_forecast = None

--- a/coordinator/ev_taper_detector.py
+++ b/coordinator/ev_taper_detector.py
@@ -261,17 +261,22 @@ class EVTaperDetector:
                         extra, hw_total_energy_kwh,
                     )
             return
-            if self._hw_total_at_full is not None:
-                # Calculate energy since full from hardware delta
-                hw_energy = hw_total_energy_kwh - self._hw_total_at_full
-                if 0 <= hw_energy <= capacity:
-                    if abs(hw_energy - self._energy_since_full) > 0.5:
-                        _LOGGER.debug(
-                            "SOC reconciled from hardware: %.1f kWh (was %.1f from integration)",
-                            hw_energy, self._energy_since_full,
-                        )
-                    self._energy_since_full = hw_energy
-                    return
+
+        # Reconcile energy_since_full from hardware total energy counter
+        # This corrects drift from the daily decay prediction (#174)
+        if self._hw_total_at_full is not None and hw_total_energy_kwh is not None:
+            hw_energy = hw_total_energy_kwh - self._hw_total_at_full
+            if 0 <= hw_energy <= capacity:
+                if abs(hw_energy - self._energy_since_full) > 0.5:
+                    _LOGGER.info(
+                        "SOC reconciled from hardware: %.1f kWh (was %.1f from decay)",
+                        hw_energy, self._energy_since_full,
+                    )
+                self._energy_since_full = hw_energy
+                self._estimated_soc = max(
+                    0.0, 100.0 - (self._energy_since_full / capacity * 100.0)
+                )
+                return
 
         # Fallback: power integration
         if ev_energy_increment_kwh > 0:


### PR DESCRIPTION
## Summary
- Fix daily SOC decay re-applied on every HA restart (caused estimated_soc to drop to 0%)
- Fix unreachable hardware reconciliation code in ev_taper_detector

## Test plan
- [x] 1552 tests passing
- [x] Deployed to HA-PROD — ev_estimated_soc back to 99.1%
- [x] Verified no double-decay on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)