### PR TITLE
Fix charger status card crash (#190)

### DIFF
--- a/dashboard/card/sem-charger-status-card.js
+++ b/dashboard/card/sem-charger-status-card.js
@@ -44,7 +44,7 @@ class SEMChargerStatusCard extends SEMBaseCard {
         }
 
         // Build reactivity key
-        const key = chargers.map(id => [
+        const key = this._chargers.map(id => [
             `charger_${id}_power`, `charger_${id}_session_energy`,
             `charger_${id}_session_solar_share`, `charger_${id}_taper_trend`,
         ].map(s => hass.states[`${this._prefix}${s}`]?.state || '').join(':')).join('|');

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }


### PR DESCRIPTION
## Summary
- Fix `ReferenceError` in `sem-charger-status-card.js` where block-scoped `chargers` was used instead of `this._chargers` after the race condition fix in aa323d7
- Bump version to 1.5.1

Fixes #190

## Verified
- [x] Bug confirmed on HA-TEST and HA-PROD (line 47 referenced undefined `chargers`)
- [x] Fix deployed and verified on HA-TEST
- [x] Fix deployed and verified on HA-PROD