### PR TITLE
Release v1.5.3-beta.7

### DIFF
--- a/binary_sensor.py
+++ b/binary_sensor.py
@@ -82,6 +82,16 @@ async def async_setup_entry(
         for description in BINARY_SENSOR_TYPES
     ]
 
+    # Per-charger binary sensors (#193)
+    full_config = {**entry.data, **entry.options}
+    ev_chargers = full_config.get("ev_chargers", [])
+    for charger_cfg in ev_chargers:
+        cid = charger_cfg.get("id", "ev_charger")
+        entities.append(SEMSolarBinarySensor(coordinator, BinarySensorEntityDescription(
+            key=f"charger_{cid}_connected",
+            device_class=BinarySensorDeviceClass.PLUG,
+        ), entry))
+
     async_add_entities(entities)
 
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -977,6 +977,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         unit_of_measurement="A", mode="slider",
                     )
                 ),
+                # Per-charger vehicle SOC entity (#193)
+                vol.Optional(
+                    "vehicle_soc_entity",
+                    description={"suggested_value": suggestions.get("vehicle_soc_entity")},
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
+                ),
             }),
             errors=errors,
         )
@@ -1076,6 +1083,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         min=6, max=16, step=1,
                         unit_of_measurement="A", mode="slider",
                     )
+                ),
+                # Per-charger vehicle SOC entity (#193)
+                vol.Optional(
+                    "vehicle_soc_entity",
+                    description={"suggested_value": charger.get("vehicle_soc_entity")},
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="sensor")
                 ),
             }),
             errors=errors,

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -549,6 +549,18 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     saved_dev, saved_sess, saved_conn = (
                         self._ev_device, self._session_data, self._last_ev_connected
                     )
+                    # Per-charger vehicle SOC override (#193)
+                    saved_vehicle_soc = self._cycle_vehicle_soc
+                    ev_chargers_cfg = self.config.get("ev_chargers", [])
+                    charger_cfg = next((c for c in ev_chargers_cfg if c.get("id") == cid), {})
+                    per_charger_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
+                    if per_charger_soc_entity:
+                        soc_state = self.hass.states.get(per_charger_soc_entity)
+                        if soc_state and soc_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                            try:
+                                self._cycle_vehicle_soc = float(soc_state.state)
+                            except (ValueError, TypeError):
+                                pass
                     self._ev_device = ev_dev
                     self._session_data = self._session_data_per_charger[cid]
                     self._last_ev_connected = self._last_ev_connected_per_charger[cid]
@@ -560,6 +572,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     self._ev_device, self._session_data, self._last_ev_connected = (
                         saved_dev, saved_sess, saved_conn
                     )
+                    self._cycle_vehicle_soc = saved_vehicle_soc
                 # Primary charger session = first charger's session
                 primary_id = next(iter(self._ev_devices))
                 self._session_data = self._session_data_per_charger.get(
@@ -856,6 +869,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             pass
                 result[f"charger_{cid}_power"] = round(charger_power, 0)
                 result[f"charger_{cid}_name"] = ev_dev.name
+                result[f"charger_{cid}_connected"] = self._last_ev_connected_per_charger.get(cid, False)
                 # Per-charger session data
                 session = self._session_data_per_charger.get(cid)
                 if session:
@@ -871,6 +885,17 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     result[f"charger_{cid}_taper_ratio"] = round(
                         (charger_power / taper_det._session_peak_w * 100) if taper_det._session_peak_w > 0 else 0, 1
                     )
+                # Per-charger vehicle SOC (#193)
+                ev_chargers_cfg = self.config.get("ev_chargers", [])
+                charger_cfg = next((c for c in ev_chargers_cfg if c.get("id") == cid), {})
+                charger_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
+                if charger_soc_entity:
+                    soc_state = self.hass.states.get(charger_soc_entity)
+                    if soc_state and soc_state.state not in ("unknown", "unavailable"):
+                        try:
+                            result[f"charger_{cid}_vehicle_soc"] = float(soc_state.state)
+                        except (ValueError, TypeError):
+                            pass
 
             # Add forecast tracker data (accuracy, correction factor)
             if tracker_data:
@@ -1329,35 +1354,35 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 await self._notification_manager.notify_forecast_alert(
                     forecast_data.forecast_tomorrow_kwh
                 )
-            # EV Intelligence notifications (#106)
-            ev_intel = getattr(self, '_last_ev_intelligence', None)
-            if ev_intel:
+            # EV Intelligence notifications — per-charger (#106, #193)
+            per_charger_intel = self._build_per_charger_intelligence()
+            is_night = self.time_manager.is_night_mode()
+            for cid, intel in per_charger_intel.items():
+                charger_name = self._ev_devices[cid].name if cid in self._ev_devices else cid
+                charger_connected = self._last_ev_connected_per_charger.get(cid, False)
+                mins_to_full = intel.get("minutes_to_full", 0)
+                est_soc = intel.get("estimated_soc", 0)
+                charge_needed = intel.get("charge_needed", False)
+                nights = intel.get("nights_until_charge", 0)
+
                 # 1. Nearly full: taper detector shows < 5 minutes remaining
-                if (ev_intel.taper.minutes_to_full > 0
-                        and ev_intel.taper.minutes_to_full < 5
-                        and power.ev_charging):
+                if mins_to_full > 0 and mins_to_full < 5 and power.ev_charging:
                     await self._notification_manager.notify_ev_nearly_full(
-                        ev_intel.taper.minutes_to_full
+                        mins_to_full, charger_name=charger_name
                     )
 
                 # 2. Night charge skipped: night mode, EV connected, skip decided
-                if (self.time_manager.is_night_mode()
-                        and power.ev_connected
-                        and not ev_intel.charge_needed
-                        and ev_intel.estimated_soc_pct > 0):
+                if (is_night and charger_connected
+                        and not charge_needed and est_soc > 0):
                     await self._notification_manager.notify_ev_charge_skip(
-                        ev_intel.estimated_soc_pct,
-                        ev_intel.nights_until_charge,
+                        est_soc, nights, charger_name=charger_name
                     )
 
                 # 3. Charge recommended: night mode, SOC low, charge needed
-                if (self.time_manager.is_night_mode()
-                        and power.ev_connected
-                        and ev_intel.charge_needed
-                        and ev_intel.estimated_soc_pct < 30
-                        and ev_intel.estimated_soc_pct > 0):
+                if (is_night and charger_connected
+                        and charge_needed and 0 < est_soc < 30):
                     await self._notification_manager.notify_ev_charge_recommended(
-                        ev_intel.estimated_soc_pct
+                        est_soc, charger_name=charger_name
                     )
 
         except (ValueError, TypeError) as e:

--- a/coordinator/notifications.py
+++ b/coordinator/notifications.py
@@ -478,68 +478,82 @@ class NotificationManager:
             group="sem_alerts",
         )
 
-    async def notify_ev_nearly_full(self, minutes_remaining: float) -> None:
-        """Notify user that EV is nearly full based on taper detection (#106)."""
+    async def notify_ev_nearly_full(
+        self, minutes_remaining: float, *, charger_name: str | None = None,
+    ) -> None:
+        """Notify user that EV is nearly full based on taper detection (#106, #193)."""
+        flag = f"ev_nearly_full_{charger_name}" if charger_name else "ev_nearly_full"
         if minutes_remaining > 10:
-            self._notified_flags.discard("ev_nearly_full")
+            self._notified_flags.discard(flag)
             return
-        if "ev_nearly_full" in self._notified_flags:
+        if flag in self._notified_flags:
             return
-        self._notified_flags.add("ev_nearly_full")
+        self._notified_flags.add(flag)
 
+        label = charger_name or "EV"
         self.hass.bus.async_fire(f"{DOMAIN}_notification", {
             "category": "charging",
             "event": "ev_nearly_full",
+            "charger_name": label,
             "minutes_remaining": round(minutes_remaining, 0),
         })
         from ..utils.translate import get_text
         await self._send_mobile_notification(
             get_text(self.hass, "notif_ev_nearly_full",
-                "EV nearly full — ~{minutes:.0f} min remaining",
-                minutes=minutes_remaining),
+                "{name} nearly full — ~{minutes:.0f} min remaining",
+                name=label, minutes=minutes_remaining),
             channel=_CHANNEL_CHARGING,
             group="sem_charging",
         )
 
     async def notify_ev_charge_skip(
         self, estimated_soc: float, nights: int,
+        *, charger_name: str | None = None,
     ) -> None:
-        """Notify user that night charge was skipped (#106)."""
-        if "ev_charge_skip" in self._notified_flags:
+        """Notify user that night charge was skipped (#106, #193)."""
+        flag = f"ev_charge_skip_{charger_name}" if charger_name else "ev_charge_skip"
+        if flag in self._notified_flags:
             return
-        self._notified_flags.add("ev_charge_skip")
+        self._notified_flags.add(flag)
 
+        label = charger_name or "EV"
         self.hass.bus.async_fire(f"{DOMAIN}_notification", {
             "category": "charging",
             "event": "ev_charge_skip",
+            "charger_name": label,
             "estimated_soc": round(estimated_soc, 0),
             "nights_remaining": nights,
         })
         from ..utils.translate import get_text
         await self._send_mobile_notification(
             get_text(self.hass, "notif_ev_charge_skip",
-                "Night charge skipped — EV SOC {soc:.0f}%, {nights} night(s) range remaining",
-                soc=estimated_soc, nights=nights),
+                "Night charge skipped for {name} — SOC {soc:.0f}%, {nights} night(s) range remaining",
+                name=label, soc=estimated_soc, nights=nights),
             channel=_CHANNEL_CHARGING,
             group="sem_charging",
         )
 
-    async def notify_ev_charge_recommended(self, estimated_soc: float) -> None:
-        """Notify user that EV charging is recommended (#106)."""
-        if "ev_charge_recommended" in self._notified_flags:
+    async def notify_ev_charge_recommended(
+        self, estimated_soc: float, *, charger_name: str | None = None,
+    ) -> None:
+        """Notify user that EV charging is recommended (#106, #193)."""
+        flag = f"ev_charge_recommended_{charger_name}" if charger_name else "ev_charge_recommended"
+        if flag in self._notified_flags:
             return
-        self._notified_flags.add("ev_charge_recommended")
+        self._notified_flags.add(flag)
 
+        label = charger_name or "EV"
         self.hass.bus.async_fire(f"{DOMAIN}_notification", {
             "category": "charging",
             "event": "ev_charge_recommended",
+            "charger_name": label,
             "estimated_soc": round(estimated_soc, 0),
         })
         from ..utils.translate import get_text
         await self._send_mobile_notification(
             get_text(self.hass, "notif_ev_charge_recommended",
-                "EV charge recommended tonight — estimated SOC {soc:.0f}%",
-                soc=estimated_soc),
+                "{name} charge recommended tonight — estimated SOC {soc:.0f}%",
+                name=label, soc=estimated_soc),
             channel=_CHANNEL_CHARGING,
             group="sem_charging",
         )

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -402,13 +402,27 @@ class SensorReader:
         elif self.config.ev_power_sensor:
             readings.ev_power = self._read_sensor(self.config.ev_power_sensor, "ev")
 
-        # EV connection status (from legacy config, not Energy Dashboard)
-        readings.ev_connected = self._read_binary_sensor(
-            self.config.ev_plug_sensor, "ev_plug"
-        )
-        readings.ev_charging = self._read_binary_sensor(
-            self.config.ev_charging_sensor, "ev_charging"
-        )
+        # EV connection status — per-charger OR'd for global (#193)
+        ev_chargers = self._raw_config.get("ev_chargers", [])
+        if len(ev_chargers) > 1:
+            any_connected = False
+            any_charging = False
+            for charger_cfg in ev_chargers:
+                conn_sensor = charger_cfg.get("ev_connected_sensor")
+                chrg_sensor = charger_cfg.get("ev_charging_sensor")
+                if conn_sensor and self._read_binary_sensor(conn_sensor, "ev_plug"):
+                    any_connected = True
+                if chrg_sensor and self._read_binary_sensor(chrg_sensor, "ev_charging"):
+                    any_charging = True
+            readings.ev_connected = any_connected
+            readings.ev_charging = any_charging
+        else:
+            readings.ev_connected = self._read_binary_sensor(
+                self.config.ev_plug_sensor, "ev_plug"
+            )
+            readings.ev_charging = self._read_binary_sensor(
+                self.config.ev_charging_sensor, "ev_charging"
+            )
 
         # Battery temperature (from legacy config if available)
         if self.config.battery_temperature_sensor:
@@ -587,13 +601,27 @@ class SensorReader:
                 self.config.ev_power_sensor, "ev"
             )
 
-        # EV connection status
-        readings.ev_connected = self._read_binary_sensor(
-            self.config.ev_plug_sensor, "ev_plug"
-        )
-        readings.ev_charging = self._read_binary_sensor(
-            self.config.ev_charging_sensor, "ev_charging"
-        )
+        # EV connection status — per-charger OR'd for global (#193)
+        ev_chargers_leg = self._raw_config.get("ev_chargers", [])
+        if len(ev_chargers_leg) > 1:
+            any_connected = False
+            any_charging = False
+            for charger_cfg in ev_chargers_leg:
+                conn_sensor = charger_cfg.get("ev_connected_sensor")
+                chrg_sensor = charger_cfg.get("ev_charging_sensor")
+                if conn_sensor and self._read_binary_sensor(conn_sensor, "ev_plug"):
+                    any_connected = True
+                if chrg_sensor and self._read_binary_sensor(chrg_sensor, "ev_charging"):
+                    any_charging = True
+            readings.ev_connected = any_connected
+            readings.ev_charging = any_charging
+        else:
+            readings.ev_connected = self._read_binary_sensor(
+                self.config.ev_plug_sensor, "ev_plug"
+            )
+            readings.ev_charging = self._read_binary_sensor(
+                self.config.ev_charging_sensor, "ev_charging"
+            )
 
         return readings
 

--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -2501,24 +2501,24 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     ${null!=t?Math.round(t)+"%":"—"}
                 </text>
             </svg>
-        `}_renderChargerSection(t,e){const i=Qt[e%Qt.length],s=this._val(`charger_${t}_power`,0),r=this._val(`charger_${t}_session_energy`,0),a=this._val(`charger_${t}_daily_energy`,0),o=this._val(`charger_${t}_session_solar_share`,0),n=this._val(`charger_${t}_estimated_soc`,null),l=this._entityVal(`number.sem_charger_${t}_nights_until_charge`,null),c=this._valStr(`charger_${t}_charge_needed`),d=this._chargerName(t),h=s>50,p=h?this._t("charging"):this._t("idle"),g=this._hass?.states[`switch.sem_charger_${t}_night_charging`],_="on"===g?.state,u=this._entityVal(`number.sem_charger_${t}_daily_ev_target`,10),f=this._entityVal(`number.sem_charger_${t}_night_initial_current`,10),m=this._entityVal(`number.sem_charger_${t}_minimum_current`,6),v="True"===c||"true"===c,y=v?"mdi:battery-alert":"mdi:battery-check",x=v?"#f06292":"#8DC892",b=v?this._t("yes"):this._t("no"),$=`switch.sem_charger_${t}_night_charging`;return H`
+        `}_renderChargerSection(t,e){const i=Qt[e%Qt.length],s=this._val(`charger_${t}_power`,0),r=this._val(`charger_${t}_session_energy`,0),a=this._val(`charger_${t}_daily_energy`,0),o=this._val(`charger_${t}_session_solar_share`,0),n=this._val(`charger_${t}_vehicle_soc`,null),l=this._val(`charger_${t}_estimated_soc`,null),c=null!=n?n:l,d=this._entityVal(`number.sem_charger_${t}_nights_until_charge`,null),h=this._valStr(`charger_${t}_charge_needed`),p=this._chargerName(t),g=this._hass?.states[`binary_sensor.sem_charger_${t}_connected`],_="on"===g?.state,u=s>50,f=u?this._t("charging"):_?this._t("connected"):this._t("idle"),m=this._hass?.states[`switch.sem_charger_${t}_night_charging`],v="on"===m?.state,y=this._entityVal(`number.sem_charger_${t}_daily_ev_target`,10),x=this._entityVal(`number.sem_charger_${t}_night_initial_current`,10),b=this._entityVal(`number.sem_charger_${t}_minimum_current`,6),$="True"===h||"true"===h,w=$?"mdi:battery-alert":"mdi:battery-check",k=$?"#f06292":"#8DC892",S=$?this._t("yes"):this._t("no"),C=`switch.sem_charger_${t}_night_charging`;return H`
             <div class="charger-section">
                 <div class="charger-header">
                     <div class="charger-dot" style="background:${i}"></div>
-                    <span class="charger-name">${d}</span>
-                    <span class="charger-status" style="color:${h?i:""}">${p}</span>
+                    <span class="charger-name">${p}</span>
+                    <span class="charger-status" style="color:${u?i:""}">${f}</span>
                 </div>
 
                 <div class="charger-body">
                     <div class="charger-soc">
-                        ${this._renderSocGauge(n)}
+                        ${this._renderSocGauge(c)}
                         <span class="soc-label">SOC</span>
                     </div>
 
                     <div class="charger-metrics">
                         <div class="cm-row">
                             <span class="cm-label">${this._t("power")}</span>
-                            <span class="cm-value" style="color:${h?i:""}">${pt(s)}</span>
+                            <span class="cm-value" style="color:${u?i:""}">${pt(s)}</span>
                         </div>
                         <div class="cm-row">
                             <span class="cm-label">${this._t("today")}</span>
@@ -2534,15 +2534,15 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                         </div>
                         <div class="cm-row">
                             <span class="cm-label">${this._t("charge_tonight")}</span>
-                            <span class="cm-value" style="color:${x}">
-                                <ha-icon icon="${y}" style="--mdc-icon-size:14px;vertical-align:middle;color:${x}"></ha-icon>
-                                ${b}
+                            <span class="cm-value" style="color:${k}">
+                                <ha-icon icon="${w}" style="--mdc-icon-size:14px;vertical-align:middle;color:${k}"></ha-icon>
+                                ${S}
                             </span>
                         </div>
-                        ${null!=l?H`
+                        ${null!=d?H`
                             <div class="cm-row">
                                 <span class="cm-label">${this._t("nights_until_charge")}</span>
-                                <span class="cm-value">${Math.round(l)}</span>
+                                <span class="cm-value">${Math.round(d)}</span>
                             </div>
                         `:K}
                     </div>
@@ -2550,12 +2550,12 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
 
                 <div class="charger-settings">
                     <div class="setting-item">
-                        <ha-icon icon="mdi:weather-night" style="--mdc-icon-size:16px;color:${_?"#7986CB":"#666"}"></ha-icon>
+                        <ha-icon icon="mdi:weather-night" style="--mdc-icon-size:16px;color:${v?"#7986CB":"#666"}"></ha-icon>
                         <span class="setting-label">${this._t("night")}</span>
                         <span
-                            class="setting-toggle ${_?"on":"off"}"
-                            @click=${t=>{t.stopPropagation(),this._toggleSwitch($)}}
-                        >${_?"ON":"OFF"}</span>
+                            class="setting-toggle ${v?"on":"off"}"
+                            @click=${t=>{t.stopPropagation(),this._toggleSwitch(C)}}
+                        >${v?"ON":"OFF"}</span>
                     </div>
                     <div
                         class="setting-item clickable"
@@ -2563,21 +2563,21 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     >
                         <ha-icon icon="mdi:bullseye-arrow" style="--mdc-icon-size:16px;color:#8DC892"></ha-icon>
                         <span class="setting-label">${this._t("night_target")}</span>
-                        <span class="setting-value">${this._fmt(u,1)} kWh</span>
+                        <span class="setting-value">${this._fmt(y,1)} kWh</span>
                     </div>
                     <div
                         class="setting-item clickable"
                         @click=${()=>{const e=new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:`number.sem_charger_${t}_night_initial_current`}});this.dispatchEvent(e)}}
                     >
                         <ha-icon icon="mdi:current-ac" style="--mdc-icon-size:16px;color:#64B5F6"></ha-icon>
-                        <span class="setting-value">${this._fmt(f,0)}A</span>
+                        <span class="setting-value">${this._fmt(x,0)}A</span>
                     </div>
                     <div
                         class="setting-item clickable"
                         @click=${()=>{const e=new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:`number.sem_charger_${t}_minimum_current`}});this.dispatchEvent(e)}}
                     >
                         <ha-icon icon="mdi:speedometer-slow" style="--mdc-icon-size:16px;color:#ff9800"></ha-icon>
-                        <span class="setting-value">${this._fmt(m,0)}A</span>
+                        <span class="setting-value">${this._fmt(b,0)}A</span>
                     </div>
                 </div>
             </div>

--- a/dashboard/card/src/cards/sem-ev-status-card.js
+++ b/dashboard/card/src/cards/sem-ev-status-card.js
@@ -170,13 +170,19 @@ class SEMEVStatusCard extends SEMLitBase {
         const session = this._val(`charger_${id}_session_energy`, 0);
         const dailyEnergy = this._val(`charger_${id}_daily_energy`, 0);
         const solar = this._val(`charger_${id}_session_solar_share`, 0);
-        const soc = this._val(`charger_${id}_estimated_soc`, null);
+        // Prefer real vehicle SOC over estimated (#193)
+        const vehicleSoc = this._val(`charger_${id}_vehicle_soc`, null);
+        const estimatedSoc = this._val(`charger_${id}_estimated_soc`, null);
+        const soc = vehicleSoc != null ? vehicleSoc : estimatedSoc;
         const nights = this._entityVal(`number.sem_charger_${id}_nights_until_charge`, null);
         const chargeNeeded = this._valStr(`charger_${id}_charge_needed`);
         const name = this._chargerName(id);
 
+        // Per-charger connected status (#193)
+        const perChargerConnected = this._hass?.states[`binary_sensor.sem_charger_${id}_connected`];
+        const isConnected = perChargerConnected?.state === 'on';
         const isCharging = power > 50;
-        const statusText = isCharging ? this._t('charging') : this._t('idle');
+        const statusText = isCharging ? this._t('charging') : isConnected ? this._t('connected') : this._t('idle');
 
         const nightSwitch = this._hass?.states[`switch.sem_charger_${id}_night_charging`];
         const nightOn = nightSwitch?.state === 'on';

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.3-beta.6"
+  "version": "1.5.3-beta.7"
 }

--- a/tests/test_per_charger_entities.py
+++ b/tests/test_per_charger_entities.py
@@ -399,6 +399,110 @@ class TestPerChargerAggregation:
         unique_ids = {s._attr_unique_id for s in switches}
         assert len(unique_ids) == 4
 
+    def test_ev_connected_or_multi_charger(self):
+        """Global ev_connected should be True if ANY charger is connected (#193)."""
+        from custom_components.solar_energy_management.coordinator.sensor_reader import SensorReader
+
+        chargers = [
+            {"id": "c1", "name": "C1", "ev_charging_power_sensor": "sensor.c1_power",
+             "ev_connected_sensor": "binary_sensor.c1_plug", "ev_charging_sensor": "binary_sensor.c1_charging"},
+            {"id": "c2", "name": "C2", "ev_charging_power_sensor": "sensor.c2_power",
+             "ev_connected_sensor": "binary_sensor.c2_plug", "ev_charging_sensor": "binary_sensor.c2_charging"},
+        ]
+        hass = MagicMock()
+        config = {
+            "solar_production_sensor": "sensor.solar",
+            "grid_power_sensor": "sensor.grid",
+            "battery_power_sensor": "sensor.battery",
+            "ev_charging_power_sensor": "sensor.c1_power",
+            "ev_connected_sensor": "binary_sensor.c1_plug",
+            "ev_charging_sensor": "binary_sensor.c1_charging",
+            "ev_chargers": chargers,
+        }
+        reader = SensorReader(hass, config)
+
+        # Only charger 2 connected, charger 1 disconnected
+        def mock_get(entity_id):
+            states = {
+                "sensor.c1_power": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "sensor.c2_power": MagicMock(state="3000", attributes={"unit_of_measurement": "W"}),
+                "sensor.solar": MagicMock(state="5000", attributes={"unit_of_measurement": "W"}),
+                "sensor.grid": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "sensor.battery": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "binary_sensor.c1_plug": MagicMock(state="off"),
+                "binary_sensor.c2_plug": MagicMock(state="on"),
+                "binary_sensor.c1_charging": MagicMock(state="off"),
+                "binary_sensor.c2_charging": MagicMock(state="on"),
+            }
+            return states.get(entity_id)
+        hass.states.get = mock_get
+
+        readings = reader.read_power()
+        assert readings.ev_connected is True  # OR'd: c2 is connected
+        assert readings.ev_charging is True  # OR'd: c2 is charging
+
+    def test_ev_connected_none_multi_charger(self):
+        """Global ev_connected should be False if NO charger is connected."""
+        from custom_components.solar_energy_management.coordinator.sensor_reader import SensorReader
+
+        chargers = [
+            {"id": "c1", "name": "C1", "ev_charging_power_sensor": "sensor.c1_power",
+             "ev_connected_sensor": "binary_sensor.c1_plug", "ev_charging_sensor": "binary_sensor.c1_charging"},
+            {"id": "c2", "name": "C2", "ev_charging_power_sensor": "sensor.c2_power",
+             "ev_connected_sensor": "binary_sensor.c2_plug", "ev_charging_sensor": "binary_sensor.c2_charging"},
+        ]
+        hass = MagicMock()
+        config = {
+            "solar_production_sensor": "sensor.solar",
+            "grid_power_sensor": "sensor.grid",
+            "battery_power_sensor": "sensor.battery",
+            "ev_charging_power_sensor": "sensor.c1_power",
+            "ev_connected_sensor": "binary_sensor.c1_plug",
+            "ev_charging_sensor": "binary_sensor.c1_charging",
+            "ev_chargers": chargers,
+        }
+        reader = SensorReader(hass, config)
+
+        def mock_get(entity_id):
+            states = {
+                "sensor.c1_power": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "sensor.c2_power": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "sensor.solar": MagicMock(state="5000", attributes={"unit_of_measurement": "W"}),
+                "sensor.grid": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "sensor.battery": MagicMock(state="0", attributes={"unit_of_measurement": "W"}),
+                "binary_sensor.c1_plug": MagicMock(state="off"),
+                "binary_sensor.c2_plug": MagicMock(state="off"),
+                "binary_sensor.c1_charging": MagicMock(state="off"),
+                "binary_sensor.c2_charging": MagicMock(state="off"),
+            }
+            return states.get(entity_id)
+        hass.states.get = mock_get
+
+        readings = reader.read_power()
+        assert readings.ev_connected is False
+        assert readings.ev_charging is False
+
+    @pytest.mark.asyncio
+    async def test_per_charger_connected_binary_sensor(self):
+        """Per-charger connected binary sensor should be created for each charger."""
+        from custom_components.solar_energy_management.binary_sensor import (
+            async_setup_entry, BinarySensorEntityDescription,
+        )
+        coord = _mock_coordinator(TWO_CHARGERS)
+        entry = _mock_entry(TWO_CHARGERS)
+        entry.runtime_data = coord
+
+        entities = []
+        def mock_add(ents):
+            entities.extend(ents)
+
+        await async_setup_entry(coord.hass, entry, mock_add)
+
+        # Should have per-charger connected binary sensors
+        keys = [e.entity_description.key for e in entities]
+        assert "charger_ev_charger_connected" in keys
+        assert "charger_ev_charger_1_connected" in keys
+
     def test_ev_power_single_charger_unchanged(self):
         """Single charger should read from primary sensor only."""
         from custom_components.solar_energy_management.coordinator.sensor_reader import SensorReader


### PR DESCRIPTION
## Summary

- **Per-charger connected binary sensor** — `binary_sensor.sem_charger_{id}_connected` per charger (#193)
- **Vehicle SOC per charger** — `vehicle_soc_entity` configurable per charger in config flow
- **Per-charger EV notifications** — nearly full, charge skip, charge recommended fire per-charger with charger name
- **Multi-charger EV connection OR** — global `ev_connected`/`ev_charging` OR'd from per-charger sensors
- **EV status card** — shows per-charger connected status, prefers real vehicle SOC over estimated

## Test plan
- [x] 1606 tests pass (0 failures)
- [x] CI green (Tests 3.12 + 3.13, Validate)
- [x] HA-TEST: 255 entities, zero errors/warnings in logs
- [x] HA-PROD: deployed, dashboard regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)