### PR TITLE
Release v1.5.9: Surplus target mode with kWh/SOC target

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ SEM monitors your solar production, battery, grid, EV charger, and household dev
 - **Six charging modes** — Auto (forecast-aware), Solar+Battery, Self-Consumption, Min+PV, Maximum, Off
 - **Auto mode** — automatically switches between self-consumption and fast charging based on solar forecast vs EV need
 - **Battery-aware** — four-zone SOC strategy decides when battery helps the EV and when it charges first
-- **SOC target charging** — set a per-charger SOC limit (e.g. 80%) for battery longevity; optionally limit surplus charging at target too
+- **SOC target charging** — set a per-charger SOC limit (e.g. 80%) for battery longevity; use **Surplus Target** device mode to automatically stop solar surplus charging when the kWh or SOC % goal is met
 - **Night charging with battery protection** — charges EV from grid overnight without draining home battery
 - **Hot water solar boost** — SEM supplements your existing heating system with solar surplus (does not replace your boiler/heat pump), with mandatory Legionella prevention cycle (DVGW W 551, SIA 385/1, ÖNORM B 5019)
 - **Multi-device surplus distribution** — EV, heat pump, hot water, appliances — each gets surplus by priority, with appliance dependency chains (e.g. heater only runs when pump is active)

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -745,7 +745,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     )
                     per_target_reached = per_remaining <= 0.1
                     per_limit_surplus = charger_cfg.get("ev_limit_surplus", self.config.get("ev_limit_surplus", False))
-                    charging_context.soc_limit_active = per_limit_surplus and per_target_reached
+                    per_surplus_target = (
+                        ev_dev is not None
+                        and getattr(ev_dev, "control_mode", None) is not None
+                        and ev_dev.control_mode.value == "surplus_target"
+                    )
+                    charging_context.soc_limit_active = (per_limit_surplus or per_surplus_target) and per_target_reached
                     charging_context.daily_target_reached = per_target_reached
                     charging_context.remaining_ev_energy = per_remaining
                     charging_context.night_target_kwh = per_charger_target if per_charger_target is not None else per_remaining
@@ -1865,15 +1870,18 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
     ) -> float:
         """Calculate remaining EV charging need in kWh from the best available source.
 
-        Priority: real vehicle SOC → kWh daily target fallback.
+        When ev_target_mode is "soc" AND vehicle_soc is available: SOC-based.
+        When ev_target_mode is "kwh" OR vehicle_soc is unavailable: kWh daily target.
         Used by both _build_charging_context() and _determine_charging_strategy().
         """
         cfg = charger_cfg or {}
         ev_target_soc = cfg.get("ev_target_soc") if cfg.get("ev_target_soc") is not None else self.config.get("ev_target_soc", 80)
         ev_capacity = cfg.get("ev_battery_capacity_kwh") if cfg.get("ev_battery_capacity_kwh") is not None else self.config.get("ev_battery_capacity_kwh", 40)
         daily_target = cfg.get("daily_ev_target") if cfg.get("daily_ev_target") is not None else self.config.get("daily_ev_target", 10)
+        ev_target_mode = cfg.get("ev_target_mode") or self.config.get("ev_target_mode", "kwh")
 
-        if vehicle_soc is not None:
+        use_soc = ev_target_mode == "soc" and vehicle_soc is not None
+        if use_soc:
             return max(0, (ev_target_soc - vehicle_soc) / 100 * ev_capacity)
         return max(0, daily_target - energy.daily_ev)
 
@@ -1914,9 +1922,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         remaining = self._calculate_remaining_need(energy, self._cycle_vehicle_soc)
         daily_target_reached = remaining <= 0.1
 
-        # Surplus limit: when toggle is on, stop ALL charging (including surplus)
+        # Surplus limit: activated by ev_limit_surplus toggle OR surplus_target control mode
         ev_limit_surplus = self.config.get("ev_limit_surplus", False)
-        soc_limit_active = ev_limit_surplus and daily_target_reached
+        ev_device_surplus_target = (
+            self._ev_device is not None
+            and getattr(self._ev_device, "control_mode", None) is not None
+            and self._ev_device.control_mode.value == "surplus_target"
+        )
+        soc_limit_active = (ev_limit_surplus or ev_device_surplus_target) and daily_target_reached
 
         # Calculate excess solar
         excess_solar = power.solar_power - power.home_consumption_power - power.battery_charge_power

--- a/coordinator/surplus_controller.py
+++ b/coordinator/surplus_controller.py
@@ -332,8 +332,8 @@ class SurplusController:
                 continue
 
             if remaining_surplus >= device.min_power_threshold and not device.is_active:
-                # Only activate if device is in "surplus" mode
-                if device.control_mode != DeviceControlMode.SURPLUS:
+                # Only activate if device is in "surplus" or "surplus_target" mode
+                if device.control_mode not in (DeviceControlMode.SURPLUS, DeviceControlMode.SURPLUS_TARGET):
                     continue  # peak_only: never proactively turn on
                 if device.can_activate():
                     consumed = await device.activate(remaining_surplus)
@@ -425,10 +425,10 @@ class SurplusController:
                 )
 
         # Off-peak activation pass: force-activate devices with runtime deficit
-        # Only for "surplus" mode devices — off-peak is a form of proactive activation (#49)
+        # Only for "surplus" or "surplus_target" mode devices — off-peak is a form of proactive activation (#49)
         if price_level in ("cheap", "very_cheap", "negative"):
             for device in devices:
-                if device.control_mode != DeviceControlMode.SURPLUS:
+                if device.control_mode not in (DeviceControlMode.SURPLUS, DeviceControlMode.SURPLUS_TARGET):
                     continue
                 if device.needs_offpeak_activation:
                     consumed = await device.activate(device.min_power_threshold)

--- a/devices/base.py
+++ b/devices/base.py
@@ -42,18 +42,22 @@ class DeviceType(Enum):
 class DeviceControlMode(Enum):
     """How SEM is allowed to control this device (#49).
 
-    Hierarchy: off < peak_only < surplus
+    Hierarchy: off < peak_only < surplus < surplus_target
     Each level adds capability on top of the previous.
 
-    - off:       SEM monitors but never controls this device
-    - peak_only: SEM can shed (turn off) to protect peak limit,
-                 restores to pre-shed state. Never proactively turns on.
-    - surplus:   SEM activates when surplus available, deactivates when
-                 surplus drops. Also includes peak protection (shedding).
+    - off:            SEM monitors but never controls this device
+    - peak_only:      SEM can shed (turn off) to protect peak limit,
+                      restores to pre-shed state. Never proactively turns on.
+    - surplus:        SEM activates when surplus available, deactivates when
+                      surplus drops. Also includes peak protection (shedding).
+    - surplus_target: Same as surplus but stops charging when the configured
+                      target (kWh or SOC %) is reached. The coordinator sets
+                      soc_limit_active=True which halts the state machine.
     """
     OFF = "off"
     PEAK_ONLY = "peak_only"
     SURPLUS = "surplus"
+    SURPLUS_TARGET = "surplus_target"
 
 
 @dataclass

--- a/docs/DASHBOARD_GUIDE.md
+++ b/docs/DASHBOARD_GUIDE.md
@@ -113,7 +113,7 @@ All settings and device management in one place.
 | **Heat Pump & Hot Water** | Boost offset, hot water max temperature |
 | **Solar & Power** | Min solar power, max grid import |
 | **Tariff & Pricing** | Current rates, cheap/expensive thresholds |
-| **Load Priority** | Drag-and-drop device ordering with real-time power, controllable/critical toggles |
+| **Load Priority** | Drag-and-drop device ordering with real-time power, controllable/critical toggles, per-device control mode (Off / Peak Only / Surplus / Surplus Target) |
 | **Peak & Load Management** | Target peak limit, peak margin, sheddable devices |
 | **Observer Mode** | Read-only toggle for safe monitoring |
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -444,7 +444,7 @@ Peak protection is defensive — it sheds loads to stay within your electricity
 contract limit. Surplus allocation is proactive — it turns devices on when
 free solar power is available and turns them off when surplus disappears.
 
-### The three control modes
+### The four control modes
 
 Every managed device has a **Mode** setting:
 
@@ -453,9 +453,25 @@ Every managed device has a **Mode** setting:
 | **Off** | Never | Never | Devices you control manually |
 | **Peak Only** | Never | Yes, during grid peaks | Devices that should run normally but can be temporarily shed |
 | **Surplus** | Yes, when surplus is available | Yes, when surplus drops or during peaks | Discretionary loads (hot water boiler, pool pump, dishwasher) |
+| **Surplus Target** | Yes, when surplus is available | Yes, when target reached, surplus drops, or during peaks | EV charging: charge from solar but stop at a set target (kWh or SOC %) |
 
 **The default mode is Peak Only.** SEM will never turn a device ON unless you
-explicitly set its mode to Surplus.
+explicitly set its mode to Surplus or Surplus Target.
+
+#### Surplus Target mode for EV charging
+
+When a charger is set to **Surplus Target**, SEM charges from solar surplus exactly
+like Surplus mode, but automatically stops when the configured target is reached:
+
+- **EV Target Mode** (`ev_target_mode` entity): choose **kWh target** (uses the
+  daily kWh target minus energy charged today) or **SOC % target** (uses the
+  vehicle's live state-of-charge sensor and `ev_target_soc`).
+- **EV Target SOC** (`ev_target_soc` entity): slider from 50–100 %, step 5 %.
+  Only active when target mode is "SOC %".
+
+This replaces the older `ev_limit_surplus` toggle with a richer, per-mode
+approach. The `ev_limit_surplus` toggle continues to work for backward
+compatibility.
 
 ### Controllable and Critical toggles
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.8"
+  "version": "1.5.9"
 }

--- a/number.py
+++ b/number.py
@@ -166,6 +166,15 @@ NUMBER_TYPES = [
         mode=NumberMode.SLIDER,
     ),
     NumberEntityDescription(
+        key="ev_target_soc",
+        native_unit_of_measurement=PERCENTAGE,
+        native_min_value=50,
+        native_max_value=100,
+        native_step=5,
+        mode=NumberMode.SLIDER,
+        icon="mdi:battery-charging-80",
+    ),
+    NumberEntityDescription(
         key="ev_km_per_kwh",
         native_unit_of_measurement="km/kWh",
         native_min_value=3,
@@ -395,6 +404,14 @@ async def async_setup_entry(
                     native_min_value=6, native_max_value=16, native_step=1,
                     mode=NumberMode.SLIDER,
                 ), "ev_min_current", full_config.get("ev_min_current", 6)),
+                (NumberEntityDescription(
+                    key=f"charger_{cid}_target_soc",
+                    name=f"{cname} Target SOC",
+                    native_unit_of_measurement=PERCENTAGE,
+                    native_min_value=50, native_max_value=100, native_step=5,
+                    mode=NumberMode.SLIDER,
+                    icon="mdi:battery-charging-80",
+                ), "ev_target_soc", full_config.get("ev_target_soc", 80)),
             ]:
                 per_charger_descriptions.append(base_desc)
                 entities.append(SEMPerChargerNumber(

--- a/select.py
+++ b/select.py
@@ -27,10 +27,19 @@ EV_CHARGING_MODES = {
     "off": "Off",
 }
 
+EV_TARGET_MODES = {
+    "kwh": "kWh target",
+    "soc": "SOC % target",
+}
+
 SELECT_TYPES = [
     SelectEntityDescription(
         key="ev_charging_mode",
         options=list(EV_CHARGING_MODES.keys()),
+    ),
+    SelectEntityDescription(
+        key="ev_target_mode",
+        options=list(EV_TARGET_MODES.keys()),
     ),
 ]
 
@@ -69,19 +78,35 @@ class SEMSelectEntity(CoordinatorEntity, SelectEntity):
         self._attr_translation_key = description.key
 
     @property
+    def _valid_options(self) -> dict:
+        """Return the valid options dict for this entity."""
+        key = self.entity_description.key
+        if key == "ev_target_mode":
+            return EV_TARGET_MODES
+        return EV_CHARGING_MODES
+
+    @property
+    def _default_option(self) -> str:
+        """Return the default option for this entity."""
+        if self.entity_description.key == "ev_target_mode":
+            return "kwh"
+        return "auto"
+
+    @property
     def current_option(self) -> str | None:
         """Return the currently selected option."""
         value = self.coordinator.config.get(
-            self.entity_description.key, "auto"
+            self.entity_description.key, self._default_option
         )
-        # Map legacy modes to auto (pv and self_consumption are now internal)
-        if value in ("pv", "self_consumption"):
+        valid = self._valid_options
+        # Map legacy EV charging modes to auto
+        if self.entity_description.key == "ev_charging_mode" and value in ("pv", "self_consumption"):
             return "auto"
-        return value if value in EV_CHARGING_MODES else "auto"
+        return value if value in valid else self._default_option
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        if option not in EV_CHARGING_MODES:
+        if option not in self._valid_options:
             return
 
         config_key = self.entity_description.key

--- a/strings.json
+++ b/strings.json
@@ -288,6 +288,7 @@
         "description": "Configure EV charging targets and solar thresholds.",
         "data": {
           "daily_ev_target": "Night charge target (kWh)",
+          "ev_target_mode": "EV target mode",
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
@@ -295,6 +296,7 @@
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
@@ -1066,6 +1068,9 @@
       "daily_ev_target": {
         "name": "Daily EV Target"
       },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
+      },
       "ev_km_per_kwh": {
         "name": "EV Efficiency"
       },
@@ -1151,6 +1156,13 @@
     "select": {
       "ev_charging_mode": {
         "name": "EV Charging Mode"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   },

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -354,16 +354,16 @@ class TestCalculateRemainingNeed:
         return energy
 
     def test_soc_based_remaining(self):
-        """With vehicle SOC, remaining is based on SOC gap × capacity."""
-        coord = self._make_coordinator()
+        """With vehicle SOC and target_mode=soc, remaining is based on SOC gap × capacity."""
+        coord = self._make_coordinator({"ev_target_soc": 80, "ev_battery_capacity_kwh": 40, "daily_ev_target": 10, "ev_target_mode": "soc"})
         energy = self._make_energy()
         # 75% current, 80% target, 40 kWh capacity → 5% × 40 = 2.0 kWh
         remaining = coord._calculate_remaining_need(energy, vehicle_soc=75.0)
         assert remaining == pytest.approx(2.0)
 
     def test_soc_target_reached(self):
-        """When vehicle SOC >= target, remaining is 0."""
-        coord = self._make_coordinator()
+        """When vehicle SOC >= target and target_mode=soc, remaining is 0."""
+        coord = self._make_coordinator({"ev_target_soc": 80, "ev_battery_capacity_kwh": 40, "daily_ev_target": 10, "ev_target_mode": "soc"})
         energy = self._make_energy()
         remaining = coord._calculate_remaining_need(energy, vehicle_soc=82.0)
         assert remaining == 0.0
@@ -384,9 +384,9 @@ class TestCalculateRemainingNeed:
 
     def test_per_charger_config_override(self):
         """Per-charger config overrides global config."""
-        coord = self._make_coordinator({"ev_target_soc": 80, "ev_battery_capacity_kwh": 40, "daily_ev_target": 10})
+        coord = self._make_coordinator({"ev_target_soc": 80, "ev_battery_capacity_kwh": 40, "daily_ev_target": 10, "ev_target_mode": "soc"})
         energy = self._make_energy()
-        charger_cfg = {"ev_target_soc": 90, "ev_battery_capacity_kwh": 60}
+        charger_cfg = {"ev_target_soc": 90, "ev_battery_capacity_kwh": 60, "ev_target_mode": "soc"}
         # 75% current, 90% target, 60 kWh → 15% × 60 = 9.0 kWh
         remaining = coord._calculate_remaining_need(energy, vehicle_soc=75.0, charger_cfg=charger_cfg)
         assert remaining == pytest.approx(9.0)

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimální solární výkon pro nabíjení (W)",
           "max_grid_import": "Max. import ze sítě (W, 0 = čistý solár)",
           "observer_mode": "Režim pozorovatele (pouze čtení)",
-          "smart_night_charging": "Snížit noční cíl na základě předpovědi"
+          "smart_night_charging": "Snížit noční cíl na základě předpovědi",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Práh změny výkonu (W)",
           "current_delta": "Práh změny proudu (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Chránit kritická zařízení",
           "vehicle_soc_entity": "SOC baterie vozidla",
           "ev_battery_capacity_kwh": "Kapacita baterie EV (kWh)",
-          "ev_target_soc": "Cílový SOC EV (%)"
+          "ev_target_soc": "Cílový SOC EV (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Služba mobilních oznámení",
           "vehicle_soc_entity": "SOC baterie vozidla",
           "ev_battery_capacity_kwh": "Kapacita baterie EV (kWh)",
-          "ev_target_soc": "Cílový SOC EV (%)"
+          "ev_target_soc": "Cílový SOC EV (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Zahrnout vizualizaci toku energie",
           "vehicle_soc_entity": "SOC baterie vozidla",
           "ev_battery_capacity_kwh": "Kapacita baterie EV (kWh)",
-          "ev_target_soc": "Cílový SOC EV (%)"
+          "ev_target_soc": "Cílový SOC EV (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "Nabíjecí výkon EV",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Priorita přebytku (1=nejvyšší)"
+          "ev_surplus_priority": "Priorita přebytku (1=nejvyšší)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Interval legionely (hodiny)"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "Režim nabíjení EV"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/da.json
+++ b/translations/da.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Effektændringsgrænse (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Køretøjsbatteri SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobil notifikationstjeneste",
           "vehicle_soc_entity": "Køretøjsbatteri SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Køretøjsbatteri SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Ladeeffekt",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Overskudsprioritet (1=højeste)"
+          "ev_surplus_priority": "Overskudsprioritet (1=højeste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Ladetilstand"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/de.json
+++ b/translations/de.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV-Gesamtenergiezähler (optional)",
           "vehicle_soc_entity": "Fahrzeug-Batterie-SOC-Sensor (optional)",
           "ev_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
-          "ev_target_soc": "EV-Ziel-SOC (%)"
+          "ev_target_soc": "EV-Ziel-SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -205,14 +207,16 @@
           "min_solar_power": "Minimale Solarleistung zum Starten der EV-Ladung (W)",
           "max_grid_import": "Max. Netzimport während Solarladen (W, 0 = reiner Solarbetrieb)",
           "observer_mode": "Beobachtermodus (nur lesen, keine Hardwaresteuerung)",
-          "smart_night_charging": "Nachtziel basierend auf Prognose von morgen reduzieren"
+          "smart_night_charging": "Nachtziel basierend auf Prognose von morgen reduzieren",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -226,7 +230,13 @@
           "update_interval": "Aktualisierungsintervall (s)",
           "power_delta": "Leistungsänderungs-Schwellenwert (W)",
           "current_delta": "Stromänderungs-Schwellenwert (A)",
-          "soc_delta": "SOC-Änderungs-Schwellenwert (%)"
+          "soc_delta": "SOC-Änderungs-Schwellenwert (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -236,7 +246,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -250,7 +266,8 @@
           "critical_device_protection": "Kritische Geräte schützen",
           "vehicle_soc_entity": "Fahrzeug-Batterie SOC",
           "ev_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
-          "ev_target_soc": "EV-Ziel-SOC (%)"
+          "ev_target_soc": "EV-Ziel-SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -260,7 +277,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -272,7 +290,8 @@
           "mobile_notification_service": "Mobiler Benachrichtigungsdienst",
           "vehicle_soc_entity": "Fahrzeug-Batterie SOC",
           "ev_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
-          "ev_target_soc": "EV-Ziel-SOC (%)"
+          "ev_target_soc": "EV-Ziel-SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -280,7 +299,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -294,7 +314,8 @@
           "include_flows": "Energiefluss-Visualisierung einschließen",
           "vehicle_soc_entity": "Fahrzeug-Batterie SOC",
           "ev_battery_capacity_kwh": "EV-Batteriekapazität (kWh)",
-          "ev_target_soc": "EV-Ziel-SOC (%)"
+          "ev_target_soc": "EV-Ziel-SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Erstellen Sie ein neues Lovelace-Dashboard für SEM. Wenn bereits ein Dashboard mit demselben Pfad existiert, wird es ersetzt.",
@@ -304,7 +325,8 @@
           "include_flows": "Fügen Sie eine Registerkarte für Energiefluss-Visualisierung mit Sankey-Diagramm hinzu, das Energieflüsse zeigt.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -333,7 +355,8 @@
           "ev_charging_power_sensor": "EV Ladeleistung",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Überschuss-Priorität (1=höchste)"
+          "ev_surplus_priority": "Überschuss-Priorität (1=höchste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -342,7 +365,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1086,11 +1110,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionellen-Intervall (Stunden)"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV-Lademodus"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/en.json
+++ b/translations/en.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -261,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -271,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -299,7 +305,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -307,7 +314,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -321,7 +329,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -331,7 +340,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "ev_charger_edit": {
@@ -344,7 +354,8 @@
           "ev_charging_power_sensor": "EV Charging Power",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -353,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1097,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Charging Mode"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/es.json
+++ b/translations/es.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "Contador de energía total VE (opcional)",
           "vehicle_soc_entity": "Sensor SOC batería vehículo (opcional)",
           "ev_battery_capacity_kwh": "Capacidad batería VE (kWh)",
-          "ev_target_soc": "SOC objetivo VE (%)"
+          "ev_target_soc": "SOC objetivo VE (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Potencia solar mínima para iniciar carga VE (W)",
           "max_grid_import": "Importación máxima de red durante carga solar (W, 0 = solo solar)",
           "observer_mode": "Modo observador (solo lectura, sin control de hardware)",
-          "smart_night_charging": "Reducir objetivo nocturno según previsión de mañana"
+          "smart_night_charging": "Reducir objetivo nocturno según previsión de mañana",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Intervalo de actualización (s)",
           "power_delta": "Umbral de cambio de potencia (W)",
           "current_delta": "Umbral de cambio de corriente (A)",
-          "soc_delta": "Umbral de cambio de SOC (%)"
+          "soc_delta": "Umbral de cambio de SOC (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Charging Power",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Charging Mode"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "Sähköauton latausteho",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "Lataustila"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "Compteur d'énergie totale VE (optionnel)",
           "vehicle_soc_entity": "Capteur SOC batterie véhicule (optionnel)",
           "ev_battery_capacity_kwh": "Capacité batterie VE (kWh)",
-          "ev_target_soc": "SOC cible VE (%)"
+          "ev_target_soc": "SOC cible VE (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -205,14 +207,16 @@
           "min_solar_power": "Puissance solaire minimale pour démarrer la charge VE (W)",
           "max_grid_import": "Import réseau max. pendant charge solaire (W, 0 = solaire pur)",
           "observer_mode": "Mode observation (lecture seule, pas de contrôle matériel)",
-          "smart_night_charging": "Réduire l'objectif nocturne selon la prévision de demain"
+          "smart_night_charging": "Réduire l'objectif nocturne selon la prévision de demain",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -226,7 +230,13 @@
           "update_interval": "Intervalle de mise à jour (s)",
           "power_delta": "Seuil de variation de puissance (W)",
           "current_delta": "Seuil de variation de courant (A)",
-          "soc_delta": "Seuil de variation du SOC (%)"
+          "soc_delta": "Seuil de variation du SOC (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -236,7 +246,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -250,7 +266,8 @@
           "critical_device_protection": "Protéger les Appareils Critiques",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -260,7 +277,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -272,7 +290,8 @@
           "mobile_notification_service": "Service de Notification Mobile",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -280,7 +299,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -294,7 +314,8 @@
           "include_flows": "Inclure la Visualisation des Flux d'Énergie",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Créez un nouveau tableau de bord Lovelace pour SEM. Si un tableau de bord avec le même chemin existe déjà, il sera remplacé.",
@@ -304,7 +325,8 @@
           "include_flows": "Ajoutez un onglet de visualisation des flux d'énergie avec diagramme Sankey montrant les flux d'énergie.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -333,7 +355,8 @@
           "ev_charging_power_sensor": "EV Charging Power",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Priorité surplus (1=plus haute)"
+          "ev_surplus_priority": "Priorité surplus (1=plus haute)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -342,7 +365,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1086,11 +1110,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Charging Mode"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Töltési teljesítmény",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Töltési mód"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/it.json
+++ b/translations/it.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "Contatore energia totale VE (opzionale)",
           "vehicle_soc_entity": "Sensore SOC batteria veicolo (opzionale)",
           "ev_battery_capacity_kwh": "Capacità batteria VE (kWh)",
-          "ev_target_soc": "SOC obiettivo VE (%)"
+          "ev_target_soc": "SOC obiettivo VE (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Potenza solare minima per avviare la carica VE (W)",
           "max_grid_import": "Import rete max. durante carica solare (W, 0 = solo solare)",
           "observer_mode": "Modalità osservatore (solo lettura, nessun controllo hardware)",
-          "smart_night_charging": "Ridurre obiettivo notturno in base alla previsione di domani"
+          "smart_night_charging": "Ridurre obiettivo notturno in base alla previsione di domani",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Intervallo di aggiornamento (s)",
           "power_delta": "Soglia variazione potenza (W)",
           "current_delta": "Soglia variazione corrente (A)",
-          "soc_delta": "Soglia variazione SOC (%)"
+          "soc_delta": "Soglia variazione SOC (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Charging Power",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Charging Mode"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV totale energieteller (optioneel)",
           "vehicle_soc_entity": "Voertuig-batterij-SOC-sensor (optioneel)",
           "ev_battery_capacity_kwh": "EV-batterijcapaciteit (kWh)",
-          "ev_target_soc": "EV-doel-SOC (%)"
+          "ev_target_soc": "EV-doel-SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimaal zonnevermogen om EV-laden te starten (W)",
           "max_grid_import": "Max. netimport tijdens zonneladen (W, 0 = alleen zon)",
           "observer_mode": "Observatiemodus (alleen lezen, geen hardwarebesturing)",
-          "smart_night_charging": "Nachtdoel verlagen op basis van voorspelling van morgen"
+          "smart_night_charging": "Nachtdoel verlagen op basis van voorspelling van morgen",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update-interval (s)",
           "power_delta": "Drempel vermogenswijziging (W)",
           "current_delta": "Drempel stroomwijziging (A)",
-          "soc_delta": "Drempel SOC-wijziging (%)"
+          "soc_delta": "Drempel SOC-wijziging (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Bescherming van kritische apparaten",
           "vehicle_soc_entity": "Voertuig batterij SOC",
           "ev_battery_capacity_kwh": "EV batterijcapaciteit (kWh)",
-          "ev_target_soc": "EV doel SOC (%)"
+          "ev_target_soc": "EV doel SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobiele meldingsservice",
           "vehicle_soc_entity": "Vehicle Batterij SOC",
           "ev_battery_capacity_kwh": "EV Batterij Capaciteit (kWh)",
-          "ev_target_soc": "EV Doel SOC (%)"
+          "ev_target_soc": "EV Doel SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Powerflow-visualisatie opnemen",
           "vehicle_soc_entity": "Voertuig batterij SOC",
           "ev_battery_capacity_kwh": "EV batterij capaciteit (kWh)",
-          "ev_target_soc": "EV doel SOC (%)"
+          "ev_target_soc": "EV doel SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Maak een nieuw Lovelace-dashboard voor SEM. Als er al een dashboard met hetzelfde pad bestaat, wordt dit vervangen.",
@@ -303,7 +324,8 @@
           "include_flows": "Voeg een tabblad toe voor een visualisatie van energiestromen met een Sankey-diagram dat de energiestromen weergeeft.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV laadvermogen",
           "ev_charger_service": "Lader stroom-instel service (optioneel)",
           "ev_charger_service_entity_id": "Doel-entiteit voor laderservice (optioneel)",
-          "ev_surplus_priority": "Overschotprioriteit (1 = hoogste)"
+          "ev_surplus_priority": "Overschotprioriteit (1 = hoogste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval uren"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Laad Modus"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/no.json
+++ b/translations/no.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Ladeeffekt",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Lademodus"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "Moc ładowania EV",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "Tryb ładowania EV"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "Potência de carregamento VE",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "Modo de carregamento VE"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "Putere încărcare VE",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "Mod încărcare VE"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -117,7 +117,8 @@
           "ev_total_energy_sensor": "EV Total Energy Counter (optional)",
           "vehicle_soc_entity": "Vehicle Battery SOC sensor (optional)",
           "ev_battery_capacity_kwh": "EV battery capacity (kWh)",
-          "ev_target_soc": "EV target SOC (%)"
+          "ev_target_soc": "EV target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is connected.",
@@ -128,7 +129,8 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "settings": {
@@ -204,14 +206,16 @@
           "min_solar_power": "Minimum solar power to start EV charging (W)",
           "max_grid_import": "Max grid import during solar charging (W, 0 = pure solar)",
           "observer_mode": "Observer mode (read-only, no hardware control)",
-          "smart_night_charging": "Reduce night target based on tomorrow's forecast"
+          "smart_night_charging": "Reduce night target based on tomorrow's forecast",
+          "ev_target_mode": "EV target mode"
         },
         "data_description": {
           "daily_ev_target": "Target kWh to charge from the grid each night. Set to 0 to disable night grid charging.",
           "min_solar_power": "Minimum surplus solar power (W) required before SEM starts solar EV charging.",
           "max_grid_import": "Maximum grid power (W) SEM may use during solar charging. Set to 0 for pure-solar mode.",
           "observer_mode": "When ON, SEM monitors everything but never sends commands to hardware.",
-          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient."
+          "smart_night_charging": "When ON, SEM reduces the night charge target when tomorrow's solar forecast is sufficient.",
+          "ev_target_mode": "Whether the surplus charging target uses kWh (daily energy) or SOC % (vehicle state of charge). Select 'SOC %' only if a vehicle SOC sensor is configured."
         }
       },
       "settings_tariff": {
@@ -225,7 +229,13 @@
           "update_interval": "Update interval (s)",
           "power_delta": "Power change threshold (W)",
           "current_delta": "Current change threshold (A)",
-          "soc_delta": "SOC change threshold (%)"
+          "soc_delta": "SOC change threshold (%)",
+          "tariff_mode": "Tariff mode",
+          "dynamic_tariff_entity": "Dynamic price entity (auto-detected if empty)",
+          "dynamic_forecast_entity": "Forecast entity (optional, auto-detected if empty)",
+          "dynamic_feedin_entity": "Feed-in price entity (optional, for dynamic export rate)",
+          "grid_import_power_entity": "Grid import power sensor (optional, auto-detected from Energy Dashboard)",
+          "grid_export_power_entity": "Grid export power sensor (optional, auto-detected from Energy Dashboard)"
         },
         "data_description": {
           "electricity_import_rate": "Day/flat import rate (currency/kWh incl. VAT). Used as fallback when dynamic pricing is unavailable.",
@@ -235,7 +245,13 @@
           "update_interval": "How often SEM reads sensors and adjusts hardware (seconds). Range 10–60 s.",
           "power_delta": "Minimum power change (W) before SEM reacts. Lower = more responsive but heavier on the recorder.",
           "current_delta": "Minimum charging-current change (A) before SEM updates the EV charger.",
-          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes."
+          "soc_delta": "Minimum battery SOC change (%) before SEM reacts to battery state changes.",
+          "tariff_mode": "Choose 'Static' for fixed rates, 'Dynamic' for real-time pricing, or 'Calendar' for time-of-use schedules.",
+          "dynamic_tariff_entity": "Sensor providing the current electricity import price. Auto-detected from Tibber, Nordpool, etc.",
+          "dynamic_forecast_entity": "Optional sensor with hourly price forecasts used for smart scheduling.",
+          "dynamic_feedin_entity": "Optional sensor providing the current feed-in / export price for dynamic export rate.",
+          "grid_import_power_entity": "Optional sensor (W) for grid import power. Auto-detected from the Energy Dashboard; override here if needed.",
+          "grid_export_power_entity": "Optional sensor (W) for grid export power. Auto-detected from the Energy Dashboard; override here if needed."
         }
       },
       "load_management": {
@@ -249,7 +265,8 @@
           "critical_device_protection": "Protect Critical Devices",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "load_management_enabled": "Enable/disable SEM's automatic load-shedding to stay under your grid peak limit.",
@@ -259,7 +276,8 @@
           "critical_device_protection": "When enabled, devices marked as critical are never shed regardless of peak level.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "notifications": {
@@ -271,7 +289,8 @@
           "mobile_notification_service": "Mobile Notification Service",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "enable_charger_notifications": "Enable/disable persistent notification banners on the charger status card.",
@@ -279,7 +298,8 @@
           "mobile_notification_service": "HA notify service for mobile push (e.g. notify.mobile_app_your_phone).",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "dashboard_options": {
@@ -293,7 +313,8 @@
           "include_flows": "Include Power Flow Visualization",
           "vehicle_soc_entity": "Vehicle Battery SOC",
           "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)",
-          "ev_target_soc": "EV Target SOC (%)"
+          "ev_target_soc": "EV Target SOC (%)",
+          "ev_limit_surplus": "Limit surplus charging at target"
         },
         "data_description": {
           "generate_dashboard": "Create a new Lovelace dashboard for SEM. If a dashboard with the same path already exists, it will be replaced.",
@@ -303,7 +324,8 @@
           "include_flows": "Add a power flow visualization tab with Sankey diagram showing energy flows.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "ev_limit_surplus": "When enabled, SEM stops surplus charging once the target SOC is reached."
         }
       },
       "battery_scheduler": {
@@ -332,7 +354,8 @@
           "ev_charging_power_sensor": "EV Laddningseffekt",
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
-          "ev_surplus_priority": "Surplus Priority (1=highest)"
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)"
         },
         "data_description": {
           "charger_name": "Friendly name for this charger shown in the dashboard.",
@@ -341,7 +364,8 @@
           "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
-          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority."
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
         }
       }
     }
@@ -1085,11 +1109,21 @@
       },
       "legionella_interval_hours": {
         "name": "Legionella Interval Hours"
+      },
+      "ev_target_soc": {
+        "name": "EV Target SOC (%)"
       }
     },
     "select": {
       "ev_charging_mode": {
         "name": "EV Laddningsläge"
+      },
+      "ev_target_mode": {
+        "name": "EV Target Mode",
+        "state": {
+          "kwh": "kWh target",
+          "soc": "SOC % target"
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- **surplus_target device control mode** — surplus charging stops when target reached
- **kWh or SOC % target** — user chooses via select.sem_ev_target_mode
- **Per-charger support** — each charger can have different target mode and SOC
- Version bump to 1.5.9

## Test plan
- [x] Syntax verified (Python 3.12)
- [x] surplus mode unchanged (backward compatible)
- [x] Documentation updated