### PR TITLE
Smooth one-cycle home-consumption dips by holding last value (#237)

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -336,6 +336,37 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             self._negative_balance_count = max(0, getattr(self, '_negative_balance_count', 0) - 1)
         return False
 
+    # Max consecutive cycles to hold the last home-consumption value (#237).
+    # ~2 cycles (≈20-30s) smooths single/double-cycle sensor-lag dips while a
+    # genuinely sustained zero is still reported after the hold window.
+    HOME_HOLD_MAX_CYCLES = 2
+
+    def _smooth_home_consumption(self, power) -> None:
+        """Hold the last positive home-consumption value through transient dips to 0 (#237).
+
+        The energy balance clamps ``home_consumption_power`` to 0 when instantaneous
+        sensor readings momentarily lag a large load. Rather than emit a one-cycle 0,
+        hold the last positive value for up to ``HOME_HOLD_MAX_CYCLES``; a zero that
+        persists beyond that is reported as real. Runs before energy integration so
+        the held value also keeps the home-energy total from under-counting.
+        """
+        if power.home_consumption_power > 0:
+            self._last_home_consumption = power.home_consumption_power
+            self._home_hold_count = 0
+            return
+        last = getattr(self, "_last_home_consumption", 0.0)
+        held = getattr(self, "_home_hold_count", 0)
+        if last > 0 and held < self.HOME_HOLD_MAX_CYCLES:
+            self._home_hold_count = held + 1
+            power.home_consumption_power = last
+            _LOGGER.debug(
+                "Home consumption clamped to 0 — holding last value %.0fW (%d/%d)",
+                last, self._home_hold_count, self.HOME_HOLD_MAX_CYCLES,
+            )
+        else:
+            # Sustained zero (beyond the hold window) — accept it as real.
+            self._home_hold_count = held + 1
+
     @staticmethod
     def _get_version() -> str:
         """Read version from manifest.json (single source of truth with HACS)."""
@@ -520,6 +551,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 flipped = self._check_sign_flip(power)
                 if flipped:
                     power = self._sensor_reader.read_power()
+
+            # Smooth transient one-cycle home-consumption dips to 0 (#237).
+            # Under a large load (EV ramp) the source sensors update on slightly
+            # different cadences, so the energy balance momentarily clamps home to 0
+            # for a single cycle. Hold the last positive value through brief dips.
+            self._smooth_home_consumption(power)
 
             # Update tariff rates before energy/cost calculation so cost accumulators
             # use the current rate for this cycle (fixes dynamic tariff mid-day bug)

--- a/tests/test_home_consumption_smoothing.py
+++ b/tests/test_home_consumption_smoothing.py
@@ -1,0 +1,65 @@
+"""Tests for transient home-consumption dip smoothing (#237).
+
+The energy balance clamps home_consumption_power to 0 when instantaneous sensor
+readings momentarily lag a large load. _smooth_home_consumption() holds the last
+positive value through brief dips, but reports a sustained zero as real.
+"""
+from types import SimpleNamespace
+
+from custom_components.solar_energy_management.coordinator.coordinator import SEMCoordinator
+
+
+def _coord():
+    return SEMCoordinator.__new__(SEMCoordinator)
+
+
+def _p(home):
+    return SimpleNamespace(home_consumption_power=home)
+
+
+def test_positive_value_passes_through_and_is_remembered():
+    coord = _coord()
+    p = _p(900.0)
+    coord._smooth_home_consumption(p)
+    assert p.home_consumption_power == 900.0
+    assert coord._last_home_consumption == 900.0
+
+
+def test_single_cycle_dip_holds_last_value():
+    coord = _coord()
+    coord._smooth_home_consumption(_p(900.0))   # establish last
+    dip = _p(0.0)
+    coord._smooth_home_consumption(dip)
+    assert dip.home_consumption_power == 900.0   # held, not 0
+
+
+def test_hold_capped_at_max_cycles_then_reports_zero():
+    coord = _coord()
+    coord._smooth_home_consumption(_p(800.0))
+    # Dips: first HOME_HOLD_MAX_CYCLES are held, the next is reported as real 0
+    held = []
+    for _ in range(SEMCoordinator.HOME_HOLD_MAX_CYCLES + 1):
+        d = _p(0.0)
+        coord._smooth_home_consumption(d)
+        held.append(d.home_consumption_power)
+    assert held[:SEMCoordinator.HOME_HOLD_MAX_CYCLES] == [800.0] * SEMCoordinator.HOME_HOLD_MAX_CYCLES
+    assert held[-1] == 0.0  # sustained zero is real
+
+
+def test_recovery_resets_hold():
+    coord = _coord()
+    coord._smooth_home_consumption(_p(700.0))
+    coord._smooth_home_consumption(_p(0.0))      # 1 held
+    coord._smooth_home_consumption(_p(1200.0))   # recovers
+    assert coord._home_hold_count == 0
+    # A subsequent dip is held again from the fresh value
+    d = _p(0.0)
+    coord._smooth_home_consumption(d)
+    assert d.home_consumption_power == 1200.0
+
+
+def test_zero_with_no_prior_value_stays_zero():
+    coord = _coord()
+    d = _p(0.0)
+    coord._smooth_home_consumption(d)
+    assert d.home_consumption_power == 0.0  # nothing to hold


### PR DESCRIPTION
Closes #237.

Under a large load (EV ramp), the grid/battery/solar source sensors update on slightly different cadences, so the home-consumption energy balance momentarily clamps to **0 W** for a single coordinator cycle before self-correcting. (Observed on HA-PROD: 10 isolated one-cycle 0 W readings over 4 h under heavy EV charging.)

## Change
- `_smooth_home_consumption()` in the coordinator main loop (after power is finalized, before energy integration) holds the last positive `home_consumption_power` for up to `HOME_HOLD_MAX_CYCLES` (2) through a dip; a zero that persists beyond the window is reported as real.
- The `max(0, …)` clamp in `PowerReadings.calculate_derived()` is unchanged.
- Holding before energy integration also avoids under-counting home energy during the lagged cycle.

## Testing
- 5 new unit tests (`test_home_consumption_smoothing.py`); **1863 passing** total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)