### PR TITLE
fix(sensors): derive power sensors when Energy Dashboard has no stat_rate (#250)

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -234,6 +234,25 @@ Update to SEM v1.2.0 or newer. This issue does not occur on v1.2.0+.
 
 ---
 
+## Most values show 0 (SolaX and other energy-only setups)
+
+**Symptom:** SEM installs, but the majority of entities (solar/grid/battery power and everything derived from them) stay at **0**. Reported for SolaX via the *SolaX Inverter Modbus* (`solax-modbus`) integration (#250).
+
+**Cause:** SEM reads real-time power from the HA Energy Dashboard's **power** links (the `stat_rate` field added in HA 2025.12). Those are configured separately from the energy (kWh) sensors and are often missing — many integrations, including SolaX, only get their *energy* sensors wired into the dashboard. With no power link, SEM has no live power to read.
+
+**Fix (automatic):** As of v1.5.13, SEM **auto-derives** the missing power sensor from the same device as the configured energy sensor — e.g. for SolaX it finds `sensor.solax_pv_power_total` (solar), `sensor.solax_measured_power` (grid), and `sensor.solax_battery_power_charge` (battery) on its own. The SolaX SOC sensor (named *Battery Capacity*, `sensor.solax_battery_capacity`) is now detected via its `device_class: battery` + `%` unit. Just update and restart — no manual steps needed in most cases.
+
+**If values are still 0:** add the power sensors to the Energy Dashboard manually:
+1. Go to **Settings > Dashboards > Energy**.
+2. Open each source (Solar / Grid / Battery) and, alongside the energy sensor, add its **power** sensor (W or kW, `state_class: measurement`).
+3. Restart Home Assistant.
+
+**Confirm what SEM resolved:** download diagnostics at **Settings > Devices & Services > Solar Energy Management > ⋮ > Download diagnostics** and check `energy_dashboard.power_sensors` / `energy_dashboard.power_source`. `"derived"` means SEM recovered the sensor itself, `"stat_rate"` means HA provided it, and `null` means none was found (that source reads 0).
+
+**Sign convention:** SolaX uses positive=import for grid (Pattern D) — SEM auto-detects and corrects this from the energy counters; no template sensor needed.
+
+---
+
 ## Debug logging
 
 To enable detailed logging for SEM, add this to your `configuration.yaml`:

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -390,7 +390,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         try:
             dashboard_config = await read_energy_dashboard_config(self.hass)
 
-            if dashboard_config and (dashboard_config.solar_power or dashboard_config.grid_import_power):
+            # Activate whenever the dashboard is minimally configured (solar + grid),
+            # not only when a stat_rate power sensor exists. ha_energy_reader already
+            # derives missing power sensors from the energy sensor's device (#250); if
+            # none can be derived we still want energy counters + SOC working instead
+            # of dropping to the empty legacy path (→ all zeros).
+            if dashboard_config and dashboard_config.is_minimally_configured():
                 self._energy_dashboard_config = dashboard_config
                 self._sensor_reader.set_energy_dashboard_config(dashboard_config)
                 _LOGGER.info(

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -804,9 +804,19 @@ class SensorReader:
                         continue
                     eid = entity_entry.entity_id
                     eid_lower = eid.lower()
-                    # Check if entity name contains SOC keywords
-                    if any(kw in eid_lower for kw in soc_keywords):
-                        state = self.hass.states.get(eid)
+                    state = self.hass.states.get(eid)
+                    # Accept by name keyword OR by the canonical SOC signature:
+                    # device_class "battery" + unit "%". The latter catches
+                    # integrations that name SOC unconventionally — e.g. SolaX
+                    # solax-modbus calls it "Battery Capacity"
+                    # (sensor.*_battery_capacity), which no SOC keyword matches (#250).
+                    by_keyword = any(kw in eid_lower for kw in soc_keywords)
+                    by_signature = False
+                    if state is not None:
+                        dc = state.attributes.get("device_class")
+                        unit = (state.attributes.get("unit_of_measurement") or "").strip()
+                        by_signature = dc == "battery" and unit == "%"
+                    if by_keyword or by_signature:
                         if state and state.state not in ("unknown", "unavailable", None):
                             try:
                                 val = float(state.state)
@@ -876,11 +886,17 @@ class SensorReader:
                 continue
             if state.state in ("unknown", "unavailable", None):
                 continue
+            unit = (state.attributes.get("unit_of_measurement") or "").lower()
+            dc = state.attributes.get("device_class")
+            # Skip SOC sensors: "Battery Capacity" matches the keyword above but on
+            # SolaX (and others) it is the SOC percentage, not rated energy. A 80%
+            # SOC would otherwise be misread as 80 kWh of rated capacity (#250).
+            if dc == "battery" or unit in ("%", "percent"):
+                continue
             try:
                 value = float(state.state)
                 if value <= 0:
                     continue
-                unit = (state.attributes.get("unit_of_measurement") or "").lower()
                 if unit == "wh" or value > 500:
                     value /= 1000  # Wh → kWh
                 if 1 <= value <= 200:  # Sanity: 1-200 kWh

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -59,12 +59,34 @@ async def async_get_config_entry_diagnostics(
     ed_config = getattr(coordinator, "_energy_dashboard_config", None)
     ed_info = {}
     if ed_config:
+        # Resolved power sensors + where each came from. "derived" means it was
+        # recovered from the energy sensor's device because the Energy Dashboard
+        # had no stat_rate power link (#250); "stat_rate" means HA had it; None
+        # means no power sensor — that source reads 0. Makes "all values are 0"
+        # reports diagnosable at a glance.
+        derived = getattr(ed_config, "derived_power", {}) or {}
+
+        def _power_source(kind: str, entity_id) -> str | None:
+            if kind in derived:
+                return "derived"
+            return "stat_rate" if entity_id else None
+
         ed_info = {
             "has_solar": ed_config.has_solar,
             "has_grid": ed_config.has_grid,
             "has_battery": ed_config.has_battery,
             "has_ev": ed_config.has_ev,
             "device_count": len(ed_config.device_consumption),
+            "power_sensors": {
+                "solar": ed_config.solar_power,
+                "grid": ed_config.grid_import_power,
+                "battery": ed_config.battery_power,
+            },
+            "power_source": {
+                "solar": _power_source("solar", ed_config.solar_power),
+                "grid": _power_source("grid", ed_config.grid_import_power),
+                "battery": _power_source("battery", ed_config.battery_power),
+            },
         }
 
     # Split-grid discovery state (issue #166): surface which import/export

--- a/ha_energy_reader.py
+++ b/ha_energy_reader.py
@@ -13,8 +13,40 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 _LOGGER = logging.getLogger(__name__)
+
+# Per-type keyword rules for deriving a power sensor from the energy sensor's
+# device when the Energy Dashboard has no stat_rate power link (issue #250).
+# "include" = entity_id substrings that qualify a candidate; "prefer" = substrings
+# that break ties (earlier = higher priority). Device-scoped search + device_class
+# filtering keeps false positives low even when one device exposes every sensor
+# (as SolaX solax-modbus does).
+_POWER_DERIVE_RULES: Dict[str, Dict[str, tuple]] = {
+    "solar": {
+        "include": ("pv_power", "solar_power", "production_power"),
+        "prefer": ("total",),
+    },
+    "grid": {
+        "include": (
+            "measured_power", "grid_power", "meter_active_power",
+            "active_power_total", "total_active_power", "power_meter",
+            "grid_active_power",
+        ),
+        "prefer": ("measured", "total"),
+    },
+    "battery": {
+        # No "charge"/"discharge" preference on purpose: when a device exposes a
+        # combined `battery_power` AND a `battery_power_charge`, the shortest-name
+        # tie-break favours the combined (bidirectional) sensor. SolaX only has
+        # `battery_power_charge` (which is itself signed), so it is still picked.
+        "include": ("battery_power", "batt_power", "power_battery"),
+        "prefer": ("total",),
+    },
+}
+# Substrings that disqualify a candidate regardless of type (non-real power).
+_POWER_DERIVE_EXCLUDE: tuple = ("reactive", "apparent", "factor")
 
 
 @dataclass
@@ -54,6 +86,12 @@ class EnergyDashboardConfig:
     has_grid: bool = False
     has_battery: bool = False
     has_ev: bool = False
+
+    # Power sensors that were derived from the energy sensor's device because the
+    # Energy Dashboard had no stat_rate link (issue #250). Maps "solar"/"grid"/
+    # "battery" → entity_id. Surfaced in diagnostics to distinguish stat_rate
+    # power from auto-recovered power.
+    derived_power: Dict[str, str] = field(default_factory=dict)
 
     def is_minimally_configured(self) -> bool:
         """Check if Energy Dashboard has minimum required configuration.
@@ -145,6 +183,13 @@ async def read_energy_dashboard_config(hass: HomeAssistant) -> Optional[EnergyDa
         device_consumption = data.get("device_consumption", [])
         config.device_consumption = device_consumption
         _extract_ev_from_devices(device_consumption, config)
+
+        # Derive any power sensors the Energy Dashboard left unset (no stat_rate).
+        # HA 2025.12+ power links are configured manually and are frequently absent
+        # (e.g. SolaX solax-modbus energy-only setups, issue #250). Without them SEM
+        # has no real-time power and every entity reads 0. Recover by finding a power
+        # sensor on the same device as the configured energy sensor.
+        _derive_missing_power_sensors(hass, config)
 
         _LOGGER.info(
             "Read Energy Dashboard config: solar=%s (%d sources), grid=%s (%d import, %d export), battery=%s (%d units), ev=%s",
@@ -340,6 +385,128 @@ def _extract_ev_from_devices(
                 config.ev_power,
             )
             break
+
+
+def _find_power_sensor_on_device(
+    hass: HomeAssistant, energy_entity: str, rule: Dict[str, tuple],
+) -> Optional[str]:
+    """Find a power sensor on the same device as ``energy_entity``.
+
+    Mirrors the device-registry strategy used by
+    ``SensorReader._auto_detect_battery_soc``: resolve the energy sensor's
+    device, then scan its sensor entities for a power sensor whose entity_id
+    matches the rule's ``include`` keywords. Ties are broken by ``prefer``
+    keyword order, then by shortest entity_id (favours the "total"/parent over
+    per-string variants like pv_power_1).
+
+    Returns the entity_id, or None if no suitable candidate exists.
+    """
+    if not energy_entity:
+        return None
+    try:
+        registry = er.async_get(hass)
+        energy_entry = registry.async_get(energy_entity)
+        if not energy_entry or not energy_entry.device_id:
+            return None
+
+        candidates: List[str] = []
+        for entry in er.async_entries_for_device(registry, energy_entry.device_id):
+            if entry.domain != "sensor" or entry.disabled_by is not None:
+                continue
+            eid = entry.entity_id
+            eid_lower = eid.lower()
+            if any(x in eid_lower for x in _POWER_DERIVE_EXCLUDE):
+                continue
+            if not any(kw in eid_lower for kw in rule["include"]):
+                continue
+            # Must look like a live power sensor.
+            state = hass.states.get(eid)
+            if not state:
+                continue
+            dc = state.attributes.get("device_class")
+            unit = (state.attributes.get("unit_of_measurement") or "").lower()
+            if dc != "power" and unit not in ("w", "kw"):
+                continue
+            candidates.append(eid)
+
+        if not candidates:
+            return None
+
+        def _rank(eid: str) -> tuple:
+            low = eid.lower()
+            prefer = rule.get("prefer", ())
+            pref_rank = next(
+                (i for i, kw in enumerate(prefer) if kw in low), len(prefer),
+            )
+            return (pref_rank, len(eid))
+
+        candidates.sort(key=_rank)
+        return candidates[0]
+    except Exception as e:  # noqa: BLE001 — best-effort, never block setup
+        _LOGGER.debug("Power sensor derivation failed for %s: %s", energy_entity, e)
+        return None
+
+
+def _derive_missing_power_sensors(
+    hass: Optional[HomeAssistant], config: EnergyDashboardConfig,
+) -> None:
+    """Recover power sensors not linked in the Energy Dashboard (issue #250).
+
+    SEM reads real-time power from the Energy Dashboard ``stat_rate`` links
+    (HA 2025.12+). Those are configured manually and are frequently absent —
+    the standard SolaX solax-modbus setup wires only energy sensors. Without
+    power links SEM reads 0 for everything. When a source has an energy sensor
+    but no power sensor, derive the power sensor from the same device.
+
+    Sign conventions are intentionally NOT handled here — the runtime
+    ``SensorReader._detect_grid_sign`` / ``_detect_battery_sign`` auto-detection
+    corrects direction from the energy counters (SolaX = grid Pattern D).
+    """
+    if hass is None:
+        return
+
+    # Solar: pv_power_total etc.
+    if not config.solar_power and config.solar_energy:
+        found = _find_power_sensor_on_device(
+            hass, config.solar_energy, _POWER_DERIVE_RULES["solar"],
+        )
+        if found:
+            config.solar_power = found
+            config.solar_power_list.append(found)
+            config.derived_power["solar"] = found
+            _LOGGER.info(
+                "Derived solar power sensor %s from energy device "
+                "(no stat_rate in Energy Dashboard)", found,
+            )
+
+    # Grid: combined meter power (measured_power etc.). Sign auto-detected later.
+    if not config.grid_import_power and config.grid_import_energy:
+        found = _find_power_sensor_on_device(
+            hass, config.grid_import_energy, _POWER_DERIVE_RULES["grid"],
+        )
+        if found:
+            config.grid_import_power = found
+            config.grid_power_list.append(found)
+            config.derived_power["grid"] = found
+            _LOGGER.info(
+                "Derived grid power sensor %s from energy device "
+                "(no stat_rate in Energy Dashboard)", found,
+            )
+
+    # Battery: battery_power* (positive=charge per SEM; sign auto-detected later).
+    battery_energy = config.battery_charge_energy or config.battery_discharge_energy
+    if not config.battery_power and battery_energy:
+        found = _find_power_sensor_on_device(
+            hass, battery_energy, _POWER_DERIVE_RULES["battery"],
+        )
+        if found:
+            config.battery_power = found
+            config.battery_power_list.append(found)
+            config.derived_power["battery"] = found
+            _LOGGER.info(
+                "Derived battery power sensor %s from energy device "
+                "(no stat_rate in Energy Dashboard)", found,
+            )
 
 
 def get_all_individual_devices(config: EnergyDashboardConfig, hass=None) -> List[Dict[str, Any]]:

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.12"
+  "version": "1.5.13-beta.1"
 }

--- a/tests/test_e2e_hardware.py
+++ b/tests/test_e2e_hardware.py
@@ -640,11 +640,14 @@ SMA = MockInverter(
 
 SOLAX = MockInverter(
     name="SolaX",
+    # Entity IDs match the real wills106/homeassistant-solax-modbus integration
+    # (plugin_solax.py keys): pv_power_total, pv_energy_total, measured_power,
+    # grid_import, grid_export, battery_power_charge, battery_capacity, etc.
     solar_power="sensor.solax_pv_power_total",
-    solar_energy="sensor.solax_total_energy",
+    solar_energy="sensor.solax_pv_energy_total",
     grid_power="sensor.solax_measured_power",
-    grid_import_energy="sensor.solax_grid_import_total",
-    grid_export_energy="sensor.solax_grid_export_total",
+    grid_import_energy="sensor.solax_grid_import",
+    grid_export_energy="sensor.solax_grid_export",
     battery_power="sensor.solax_battery_power_charge",
     battery_soc="sensor.solax_battery_capacity",
     battery_charge_energy="sensor.solax_battery_input_energy_total",
@@ -1117,3 +1120,278 @@ class TestE2E_DEYE_Peblar(E2ETestBase):
     """DEYE/Sunsynk (matches SEM) + Peblar (switch charge control)."""
     inverter = DEYE
     charger = PEBLAR
+
+
+# ════════════════════════════════════════════
+# Regression: SolaX energy-only Energy Dashboard (#250)
+# ════════════════════════════════════════════
+
+class TestSolaXEnergyOnlyDerivation:
+    """SolaX solax-modbus with NO stat_rate power links (issue #250).
+
+    The standard SolaX energy-dashboard setup wires only energy (kWh) sensors.
+    Without stat_rate, SEM used to read 0 for everything. SEM must now derive the
+    power sensors from the same device as the configured energy sensors.
+
+    Mirrors the real wills106/homeassistant-solax-modbus entity layout: one device
+    exposes every solar/grid/battery sensor, so derivation must pick the right one
+    by keyword (pv_power_total / measured_power / battery_power_charge).
+    """
+
+    # All entities live on a single solax-modbus device.
+    _DEVICE = "solax_dev_001"
+    _ENTITIES = {
+        # entity_id: (unit, device_class)
+        "sensor.solax_pv_power_1": ("W", "power"),
+        "sensor.solax_pv_power_2": ("W", "power"),
+        "sensor.solax_pv_power_total": ("W", "power"),
+        "sensor.solax_measured_power": ("W", "power"),
+        "sensor.solax_battery_power_charge": ("W", "power"),
+        "sensor.solax_house_load": ("W", "power"),          # no keyword → ignored
+        "sensor.solax_inverter_power_factor": ("", None),    # excluded by _POWER_DERIVE_EXCLUDE
+        "sensor.solax_pv_energy_total": ("kWh", "energy"),
+        "sensor.solax_grid_import": ("kWh", "energy"),
+        "sensor.solax_grid_export": ("kWh", "energy"),
+        "sensor.solax_battery_input_energy_total": ("kWh", "energy"),
+        "sensor.solax_battery_output_energy_total": ("kWh", "energy"),
+        "sensor.solax_battery_capacity": ("%", "battery"),
+    }
+
+    def _energy_only_file(self, tmp_path) -> str:
+        """Energy Dashboard file with energy sensors but NO stat_rate / power."""
+        energy_config = {
+            "version": 1,
+            "data": {
+                "energy_sources": [
+                    {"type": "solar", "stat_energy_from": "sensor.solax_pv_energy_total"},
+                    {
+                        "type": "grid",
+                        "flow_from": [{"stat_energy_from": "sensor.solax_grid_import"}],
+                        "flow_to": [{"stat_energy_to": "sensor.solax_grid_export"}],
+                    },
+                    {
+                        "type": "battery",
+                        "stat_energy_from": "sensor.solax_battery_output_energy_total",
+                        "stat_energy_to": "sensor.solax_battery_input_energy_total",
+                    },
+                ],
+                "device_consumption": [],
+            },
+        }
+        storage_dir = tmp_path / ".storage"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        (storage_dir / "energy").write_text(json.dumps(energy_config))
+        return str(tmp_path)
+
+    def _mock_registry(self):
+        """Mock entity registry: every sensor on one device."""
+        entries = []
+        for eid, (_unit, dc) in self._ENTITIES.items():
+            e = MagicMock()
+            e.entity_id = eid
+            e.domain = "sensor"
+            e.disabled_by = None
+            e.device_id = self._DEVICE
+            e.original_device_class = dc
+            entries.append(e)
+
+        registry = MagicMock()
+        by_id = {e.entity_id: e for e in entries}
+        registry.async_get = lambda eid: by_id.get(eid)
+        return registry, entries
+
+    def _states(self):
+        states = {}
+        for eid, (unit, dc) in self._ENTITIES.items():
+            # Power = a surplus scenario; energy = baselines; SOC = 80%.
+            if dc == "power":
+                val = {
+                    "sensor.solax_pv_power_total": 8000,
+                    "sensor.solax_pv_power_1": 4000,
+                    "sensor.solax_pv_power_2": 4000,
+                    # SolaX Pattern D: positive = import. Exporting 2kW → -2000.
+                    "sensor.solax_measured_power": -2000,
+                    "sensor.solax_battery_power_charge": 500,
+                    "sensor.solax_house_load": 1500,
+                }.get(eid, 0)
+                states[eid] = _state(val, unit=unit, device_class=dc)
+            elif dc == "energy":
+                states[eid] = _state(100, unit=unit, device_class=dc)
+            elif dc == "battery":
+                states[eid] = _state(80, unit=unit, device_class=dc)
+            else:
+                states[eid] = _state(0, unit=unit)
+        return states
+
+    @pytest.mark.asyncio
+    async def test_derives_power_sensors_without_stat_rate(self, tmp_path):
+        """read_energy_dashboard_config derives solar/grid/battery power."""
+        import custom_components.solar_energy_management.ha_energy_reader as har
+
+        config_dir = self._energy_only_file(tmp_path)
+        registry, entries = self._mock_registry()
+        states = self._states()
+
+        hass = MagicMock()
+        hass.config.config_dir = config_dir
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+        hass.states.get = lambda eid: states.get(eid)
+
+        with patch.object(har.er, "async_get", return_value=registry), \
+             patch.object(har.er, "async_entries_for_device", return_value=entries):
+            config = await har.read_energy_dashboard_config(hass)
+
+        assert config is not None
+        # Derived the right power sensor for each source (not the per-string /
+        # house-load / power-factor entities).
+        assert config.solar_power == "sensor.solax_pv_power_total"
+        assert config.grid_import_power == "sensor.solax_measured_power"
+        assert config.battery_power == "sensor.solax_battery_power_charge"
+        # All three recorded as derived (for diagnostics).
+        assert config.derived_power == {
+            "solar": "sensor.solax_pv_power_total",
+            "grid": "sensor.solax_measured_power",
+            "battery": "sensor.solax_battery_power_charge",
+        }
+
+    @pytest.mark.asyncio
+    async def test_no_derivation_when_stat_rate_present(self, tmp_path):
+        """If the Energy Dashboard has stat_rate, derivation must NOT fire.
+
+        Guards the no-regression path for Huawei/SolarEdge/Fronius etc. that
+        already provide power links.
+        """
+        import custom_components.solar_energy_management.ha_energy_reader as har
+
+        energy_config = {
+            "version": 1,
+            "data": {
+                "energy_sources": [
+                    {
+                        "type": "solar",
+                        "stat_energy_from": "sensor.solax_pv_energy_total",
+                        "stat_rate": "sensor.solax_pv_power_total",
+                    },
+                    {
+                        "type": "grid",
+                        "flow_from": [{"stat_energy_from": "sensor.solax_grid_import"}],
+                        "flow_to": [{"stat_energy_to": "sensor.solax_grid_export"}],
+                        "power": [{"stat_rate": "sensor.solax_measured_power"}],
+                    },
+                    {
+                        "type": "battery",
+                        "stat_energy_from": "sensor.solax_battery_output_energy_total",
+                        "stat_energy_to": "sensor.solax_battery_input_energy_total",
+                        "stat_rate": "sensor.solax_battery_power_charge",
+                    },
+                ],
+                "device_consumption": [],
+            },
+        }
+        storage_dir = tmp_path / ".storage"
+        storage_dir.mkdir(parents=True, exist_ok=True)
+        (storage_dir / "energy").write_text(json.dumps(energy_config))
+
+        registry, entries = self._mock_registry()
+        hass = MagicMock()
+        hass.config.config_dir = str(tmp_path)
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+        hass.states.get = lambda eid: self._states().get(eid)
+
+        # async_entries_for_device would raise if derivation tried to run; assert
+        # it is never called because every source already has its power sensor.
+        called = {"n": 0}
+
+        def _spy(*a, **k):
+            called["n"] += 1
+            return entries
+
+        with patch.object(har.er, "async_get", return_value=registry), \
+             patch.object(har.er, "async_entries_for_device", side_effect=_spy):
+            config = await har.read_energy_dashboard_config(hass)
+
+        assert config.solar_power == "sensor.solax_pv_power_total"
+        assert config.grid_import_power == "sensor.solax_measured_power"
+        assert config.battery_power == "sensor.solax_battery_power_charge"
+        assert config.derived_power == {}
+        assert called["n"] == 0, "derivation ran despite stat_rate being present"
+
+    def test_battery_tiebreak_prefers_combined_sensor(self):
+        """Device with both battery_power and battery_power_charge → pick combined."""
+        import custom_components.solar_energy_management.ha_energy_reader as har
+
+        device = "dev1"
+        ents = []
+        for eid in (
+            "sensor.inv_battery_output_energy_total",  # energy anchor
+            "sensor.inv_battery_power_charge",
+            "sensor.inv_battery_power",                # combined — should win
+        ):
+            e = MagicMock()
+            e.entity_id = eid
+            e.domain = "sensor"
+            e.disabled_by = None
+            e.device_id = device
+            ents.append(e)
+
+        registry = MagicMock()
+        registry.async_get = lambda eid: next(
+            (e for e in ents if e.entity_id == eid), None
+        )
+
+        def _state_for(eid):
+            if eid.endswith("energy_total"):
+                return _state(100, unit="kWh", device_class="energy")
+            return _state(300, unit="W", device_class="power")
+
+        hass = MagicMock()
+        hass.states.get = _state_for
+
+        with patch.object(har.er, "async_get", return_value=registry), \
+             patch.object(har.er, "async_entries_for_device", return_value=ents):
+            found = har._find_power_sensor_on_device(
+                hass, "sensor.inv_battery_output_energy_total",
+                har._POWER_DERIVE_RULES["battery"],
+            )
+        assert found == "sensor.inv_battery_power"
+
+    @pytest.mark.asyncio
+    async def test_pipeline_nonzero_including_soc(self, tmp_path):
+        """Full pipeline: derived sensors → non-zero power; SOC via signature."""
+        from custom_components.solar_energy_management.coordinator import (
+            sensor_reader as sr,
+        )
+        import custom_components.solar_energy_management.ha_energy_reader as har
+
+        config_dir = self._energy_only_file(tmp_path)
+        registry, entries = self._mock_registry()
+        states = self._states()
+
+        hass = MagicMock()
+        hass.config.config_dir = config_dir
+        hass.async_add_executor_job = AsyncMock(side_effect=lambda fn: fn())
+        hass.states.get = lambda eid: states.get(eid)
+
+        with patch.object(har.er, "async_get", return_value=registry), \
+             patch.object(har.er, "async_entries_for_device", return_value=entries):
+            ed = await har.read_energy_dashboard_config(hass)
+
+        reader = sr.SensorReader(hass, {"update_interval": 10})
+        reader.set_energy_dashboard_config(ed)
+
+        # Patch the reader's registry so SOC auto-detection resolves on the same
+        # device (SolaX SOC = sensor.solax_battery_capacity, device_class battery/%).
+        with patch.object(sr.er, "async_get", return_value=registry), \
+             patch.object(sr.er, "async_entries_for_device", return_value=entries):
+            power = reader.read_power()
+
+        # Before the fix every one of these read 0.
+        assert power.solar_power == 8000
+        assert power.battery_power == 500            # charging, SEM convention
+        # Grid is non-zero (was 0). The raw measured_power is read directly; sign
+        # correction (SolaX Pattern D) needs energy-counter movement across cycles
+        # and is covered by test_split_grid_integration.py::test_pattern_d_solax.
+        assert power.grid_power != 0
+        # SOC detected via the device_class=battery + unit=% signature (not by name).
+        assert power.battery_soc == 80
+        assert not power.battery_soc_unavailable


### PR DESCRIPTION
## Problem

Fixes #250 — SolaX users (via `wills106/homeassistant-solax-modbus`) see the **majority of SEM entities stuck at 0**.

SEM reads real-time power **only** from the HA Energy Dashboard `stat_rate` power links (a HA 2025.12+ feature configured manually and frequently absent — the standard SolaX setup wires only energy/kWh sensors; HA core even has a bug blocking battery-power, home-assistant/core#157895). With no power link:

- `solar_power` / `grid_import_power` / `battery_power` are all `None`
- the coordinator activation gate rejected the **entire** Energy Dashboard config
- SEM fell back to the empty legacy path → **every power entity reads 0**

There was a device-registry fallback for SOC/capacity, but **none for the power sensors themselves**.

## Fix

- **`ha_energy_reader.py`** — `_derive_missing_power_sensors()` / `_find_power_sensor_on_device()`: when a source has no `stat_rate`, derive the power sensor from the **same device** as the configured energy sensor (per-type keyword rules + `device_class`/unit filtering). Records picks in a new `derived_power` dict. Sign is **not** touched here — left to the existing runtime auto-detect (SolaX grid = Pattern D).
- **`coordinator/coordinator.py`** — activate the Energy Dashboard config on `is_minimally_configured()` instead of requiring a `stat_rate` power sensor.
- **`coordinator/sensor_reader.py`** — detect SOC by the canonical `device_class=battery` + `%` signature (SolaX names its SOC *"Battery Capacity"*, which no SOC keyword matched), and stop the rated-capacity detector from misreading that % SOC as kWh.
- **`diagnostics.py`** — expose resolved power sensors + a `power_source` flag (`stat_rate`/`derived`/`null`) so "all values 0" reports are diagnosable.
- **tests** — corrected the SolaX mock entity names to match the real integration; added energy-only derivation, full-pipeline, no-regression (stat_rate present), and battery tie-break tests.
- **docs** — TROUBLESHOOTING entry for energy-only "all values 0" setups.

Version bumped to **1.5.13-beta.1**.

## Verification

- Full suite: **1884 passed, 7 skipped**. New SolaX energy-only tests fail before the fix, pass after.
- HA-TEST (Huawei, has `stat_rate` → derivation skipped): version `1.5.13-beta.1` loaded, all critical sensors read correctly (Grid 78W, Battery −520W, SOC 91%), coordinator healthy, no SEM errors. No regression.
- Reviewer (ruflo-core:reviewer): no critical findings; substantive warnings addressed (battery tie-break prefers combined sensor, dropped vague `input_power` keyword, added the missing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)