### PR TITLE
fix(ev): make night charging opt-in — default OFF, preserve existing (#256)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ SEM is designed to be mostly automatic. There are only 3 switches to manage:
 
 | Switch | Default | What it does |
 |--------|---------|-------------|
-| `switch.sem_night_charging` | ON | Enable/disable overnight grid charging |
+| `switch.sem_night_charging` | OFF | Enable/disable overnight grid charging (opt-in — solar surplus only until you turn it on; #256) |
 | `switch.sem_observer_mode` | OFF | Read-only mode — SEM monitors but doesn't control hardware |
 | `switch.sem_smart_night_charging` | OFF | Intelligently skip or reduce night charges based on EV SOC, solar forecast, temperature, and learned driving patterns |
 
@@ -214,9 +214,7 @@ Set via integration options: `ev_charging_mode = "minpv"`.
 
 ### Night Charging
 
-Overnight grid charging starts automatically after sunset. SEM charges at a peak-managed rate to avoid demand spikes and stops when the daily EV target is reached. Battery discharge protection prevents the home battery from powering the EV overnight.
-
-Enable/disable with `switch.sem_night_charging`.
+**Opt-in (off by default).** SEM charges on solar surplus only until you enable overnight grid charging — so a fresh install never pulls from the grid unasked. Once enabled with `switch.sem_night_charging` (and the per-charger switch in a multi-charger setup), overnight grid charging starts automatically after sunset, runs at a peak-managed rate to avoid demand spikes, and stops when the daily EV target is reached. Battery discharge protection prevents the home battery from powering the EV overnight. Upgrading users keep their existing setting.
 
 ### Battery-Assisted Charging
 

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -25,7 +25,19 @@
    - 3-phase chargers: ~4140 W (6 A × 3 × 230 V)
 
    The `min_solar_power` setting (default 500 W in the Optimization Settings step) is the surplus *floor* below which SEM won't even attempt to start the charger — keep it well **below** the hardware minimum so SEM has headroom to ramp up before the cliff.
-5. For night charging: check that `switch.sem_night_charging` is enabled and it's within the night window
+5. For night charging: it is **opt-in (off by default)** — turn on `switch.sem_night_charging` (and the per-charger `…_night_charging` switch in a multi-charger setup), and make sure it's within the night window
+
+---
+
+## Car charged overnight when I only wanted solar surplus
+
+**Cause:** Grid-assisted **night charging** is enabled, with a charge target (a daily kWh target or a target SOC %) the car hadn't reached, so SEM topped it up from the grid overnight. On fresh installs this is now off by default, but it stays enabled on upgraded systems that already had it on, and a multi-charger setup tracks an enable switch *per charger*.
+
+**Fix:** To make a charger surplus-only, either:
+1. Turn **off** that charger's `…_night_charging` switch (or the global `switch.sem_night_charging` to disable night charging for all chargers), **or**
+2. Set that charger's **Night Target to 0** (kWh mode) / its **Target SOC to its current level** (SOC mode).
+
+With the floor at zero and/or night charging off, the charger only draws solar surplus. *(#256)*
 
 ---
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -264,7 +264,9 @@ Once battery-assist mode activates (Zone 3 or 4), it stays active even if SOC dr
 
 ## Night Charging
 
-Night charging starts automatically when night mode activates (after sunset + 10 minutes, or 20:30, whichever comes first).
+> **Night charging is opt-in (off by default).** SEM is a *solar* energy manager, so out of the box it charges your car on solar surplus only and never pulls from the grid overnight unasked. To enable grid-assisted night charging, turn on **`switch.sem_night_charging`** (and, for a multi-charger setup, the per-charger `…_night_charging` switch for each charger you want to top up). Upgrading users keep whatever state they already had — only fresh installs and newly-added chargers start off. *(#256)*
+
+Once enabled, night charging starts automatically when night mode activates (after sunset + 10 minutes, or 20:30, whichever comes first).
 
 ### How it works
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.13-beta.3"
+  "version": "1.5.13-beta.4"
 }

--- a/switch.py
+++ b/switch.py
@@ -150,7 +150,10 @@ class SEMSolarSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         self.entity_id = f"switch.sem_{description.key}"
 
         if description.key == "night_charging":
-            self._is_on = True  # Default to ON (will be restored from last state if available)
+            # Opt-in (#256): default OFF so a fresh install charges on solar surplus only
+            # and never grid-charges the car overnight unasked. RestoreEntity below
+            # preserves existing users — they keep whatever state they already had.
+            self._is_on = False
         elif description.key == "observer_mode":
             self._is_on = coordinator.config_entry.options.get("observer_mode", False)
         else:
@@ -216,7 +219,10 @@ class SEMPerChargerSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         self._attr_device_info = coordinator.device_info
         self.entity_id = f"switch.sem_{description.key}"
         self._charger_id = charger_id
-        self._is_on = True  # Default: night charging enabled
+        # Opt-in (#256): default OFF. A newly-added charger won't night-charge until
+        # the user enables it, so it can't silently inherit a grid top-up. Existing
+        # chargers keep their state via RestoreEntity in async_added_to_hass below.
+        self._is_on = False
 
     async def async_added_to_hass(self) -> None:
         """Restore previous state."""

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -124,10 +124,11 @@ class TestCurrencyConfiguration:
 class TestSwitchDefaults:
     """Verify switch default states."""
 
-    def test_night_charging_default_on(self, mock_coordinator):
+    def test_night_charging_default_off(self, mock_coordinator):
+        # Opt-in (#256): surplus-only by default; existing users preserved via RestoreEntity.
         desc = SWITCH_TYPES[0]  # night_charging
         switch = SEMSolarSwitch(mock_coordinator, desc, "test")
-        assert switch._is_on is True
+        assert switch._is_on is False
 
     def test_observer_mode_default_off(self, mock_coordinator):
         mock_coordinator.config_entry.options = {}

--- a/tests/test_per_charger_entities.py
+++ b/tests/test_per_charger_entities.py
@@ -178,7 +178,21 @@ class TestPerChargerSwitches:
         )
         assert switch._charger_id == "ev_charger_1"
         assert switch.entity_id == "switch.sem_charger_ev_charger_1_night_charging"
-        assert switch.is_on is True  # default ON
+        assert switch.is_on is False  # opt-in (#256): default OFF, won't night-charge until enabled
+
+    @pytest.mark.asyncio
+    async def test_per_charger_switch_existing_state_preserved(self):
+        """Existing per-charger switches keep their state on upgrade: a restored 'on'
+        wins over the new default-OFF, so multi-charger users aren't silently changed (#256)."""
+        from homeassistant.helpers.update_coordinator import CoordinatorEntity
+        coord = _mock_coordinator(TWO_CHARGERS)
+        desc = SwitchEntityDescription(key="charger_ev_charger_1_night_charging")
+        switch = SEMPerChargerSwitch(coord, desc, "test", "ev_charger_1", "Wallbox")
+        assert switch.is_on is False  # new default
+        switch.async_get_last_state = AsyncMock(return_value=MagicMock(state="on"))
+        with patch.object(CoordinatorEntity, "async_added_to_hass", AsyncMock()):
+            await switch.async_added_to_hass()
+        assert switch.is_on is True  # prior state restored, not overwritten
 
     def test_per_charger_switch_unique_ids(self):
         """Each per-charger switch should have a unique ID."""
@@ -197,11 +211,11 @@ class TestPerChargerSwitches:
         desc = SwitchEntityDescription(key="charger_ev_charger_night_charging")
         switch = SEMPerChargerSwitch(coord, desc, "test", "ev_charger", "KEBA")
 
+        assert switch.is_on is False  # opt-in default (#256)
+        await switch.async_turn_on()
         assert switch.is_on is True
         await switch.async_turn_off()
         assert switch.is_on is False
-        await switch.async_turn_on()
-        assert switch.is_on is True
 
     def test_per_charger_switch_available(self):
         """Per-charger switch should be unavailable when coordinator fails."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -31,11 +31,27 @@ class TestSEMSwitches:
         assert keys == ["night_charging", "observer_mode", "smart_night_charging"]
 
     @pytest.mark.asyncio
-    async def test_night_charging_default_on(self, mock_coordinator):
-        """Test night_charging defaults to ON."""
+    async def test_night_charging_default_off(self, mock_coordinator):
+        """night_charging defaults to OFF — opt-in (#256). A fresh install charges on
+        solar surplus only; existing users keep their state via RestoreEntity."""
         description = create_switch_description("night_charging")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
-        assert switch._is_on is True
+        assert switch._is_on is False
+
+    @pytest.mark.asyncio
+    async def test_night_charging_existing_state_preserved(self, mock_coordinator):
+        """Existing users are preserved: a restored 'on' state wins over the new
+        default-OFF, so upgrading doesn't silently stop anyone's night charging (#256)."""
+        from unittest.mock import patch
+        from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+        description = create_switch_description("night_charging")
+        switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
+        assert switch._is_on is False  # new default
+        switch.async_get_last_state = AsyncMock(return_value=MagicMock(state="on"))
+        with patch.object(CoordinatorEntity, "async_added_to_hass", AsyncMock()):
+            await switch.async_added_to_hass()
+        assert switch._is_on is True  # prior state restored, not overwritten by the default
 
     @pytest.mark.asyncio
     async def test_observer_mode_default_from_config(self, mock_coordinator):


### PR DESCRIPTION
## Make night charging opt-in (#256)

**Problem:** A connected car was grid-charged overnight out of the box — the global *and* per-charger `night_charging` switches defaulted **ON** with a non-zero charge floor. For a *solar* energy manager, the default should be surplus-only. (RienduPre, #256 — an unconfigured second charger.)

**Fix:** Flip both `night_charging` switch defaults to **OFF**.

- **Fresh installs / newly-added chargers** → surplus-only; never pull from the grid overnight unasked.
- **Existing users** → HA `RestoreEntity` restores their stored switch state over the new default, so upgrading **never silently stops anyone's night charging**. No config migration needed.
- Opt in by turning `switch.sem_night_charging` on (plus the per-charger switch in multi-charger setups).

Chosen over a floor-defaults-to-none approach, which was far more invasive (widening 6 SOC sliders to allow 0, scattered `10`/`80` literals, a config-data migration, plus a latent `VERSION` bug) — higher risk of introducing exactly the kind of silent bug we're trying to remove.

### Verification
- `1927 passed, 7 skipped` locally.
- New tests: default-OFF + **restore-preserves-existing** for both the global and per-charger switch.
- `ruflo-core:reviewer`: **safe to PR, no must-fix items.**
- Deployed + verified on HA-TEST (`1.5.13-beta.4`): existing switch states preserved, 0 errors.
- Docs: README / USER_GUIDE / TROUBLESHOOTING updated (incl. a "car charged overnight unexpectedly" entry).

### Notes
- `Refs #256` (no auto-close — reporter not yet confirmed).
- A pre-existing silent-failure the reviewer flagged (`async_turn_on/off` don't call `async_write_ha_state` + swallowed refresh exception) is routed to the silent-errors sweep in **#259**, not this PR.
- Related: **#255** (global-vs-per-charger config duplication).
