### PR TITLE
fix: surface user-impacting silent failures (#259)

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -125,6 +125,9 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         self._ev_charge_refused_per_charger: Dict[str, bool] = {}
         self._daily_ev_per_charger: Dict[str, float] = {}  # Per-charger daily energy (#193)
         self._daily_ev_per_charger_date: Optional[str] = None
+        # Warn-once guards so per-cycle surfacing (#259) doesn't spam the log.
+        self._tariff_rate_warned: bool = False
+        self._night_global_fallback_logged: set[str] = set()
         self._notification_manager = NotificationManager(hass, config)
 
         # Storage will be initialized with entry_id later
@@ -575,8 +578,16 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 _tariff = self._tariff_provider.get_tariff_data()
                 self._energy_calculator._import_rate = _tariff.current_import_rate
                 self._energy_calculator._export_rate = _tariff.current_export_rate
-            except (ValueError, TypeError, AttributeError):
-                pass  # Use previous rates
+                if self._tariff_rate_warned:
+                    _LOGGER.info("Tariff rate update recovered")
+                    self._tariff_rate_warned = False
+            except (ValueError, TypeError, AttributeError) as e:
+                # Surface once at warning (#259): on failure cost calculations silently
+                # keep using stale rates, so users get wrong cost feedback with no signal.
+                # Warn on the first failure (and on recovery above); stay quiet otherwise.
+                if not self._tariff_rate_warned:
+                    _LOGGER.warning("Tariff rate update failed; using previous rates: %s", e)
+                    self._tariff_rate_warned = True
 
             # Step 2: Calculate energy from power integration
             energy = self._energy_calculator.calculate_energy(power)
@@ -734,6 +745,15 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             target = cfg.get("daily_ev_target")
                             if target is None:
                                 target = self.config.get("daily_ev_target", 10)
+                                # Surface the inheritance once per charger (#259): a charger
+                                # with no own target silently adopts the global floor (the
+                                # #256 class). Behaviour change deferred to #255.
+                                if cid not in self._night_global_fallback_logged:
+                                    _LOGGER.info(
+                                        "Charger %s has no per-charger night target; "
+                                        "inheriting global %.1f kWh", cid, target,
+                                    )
+                                    self._night_global_fallback_logged.add(cid)
                             daily = self._daily_ev_per_charger.get(cid, 0.0)
                             self._night_target_per_charger_map[cid] = max(0, target - daily)
 

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -87,6 +87,9 @@ class SensorReader:
             "warned": False,
         }
         self._uses_split_grid: bool = False
+        # Warn-once guard for the discovery-*exception* path (#259); distinct from the
+        # dict "warned" key (which guards "no sensor found"). Reset on cache invalidate.
+        self._split_grid_discovery_warned: bool = False
 
     def _parse_config(self, config: Dict[str, Any]) -> SensorConfig:
         """Parse configuration into SensorConfig."""
@@ -543,7 +546,14 @@ class SensorReader:
                 _LOGGER.debug("No split grid power sensors found")
 
         except Exception as e:
-            _LOGGER.debug("Split grid power discovery failed: %s", e)
+            # Surface once at warning (#259): a discovery failure leaves split-meter
+            # setups (Growatt, P1/DSMR) reading 0 grid power with no signal. Warn on
+            # the first failure, then drop to debug so we don't spam every cycle.
+            if not self._split_grid_discovery_warned:
+                _LOGGER.warning("Split grid power discovery failed: %s", e)
+                self._split_grid_discovery_warned = True
+            else:
+                _LOGGER.debug("Split grid power discovery failed: %s", e)
             import_power = None
             export_power = None
             confidence = None
@@ -562,6 +572,9 @@ class SensorReader:
             "confidence": None,
             "warned": self._split_grid_discovery.get("warned", False),
         }
+        # Re-allow the discovery-exception warning after a rediscovery (#259) — circumstances
+        # have changed (e.g. a new sensor appeared), so a fresh failure is worth surfacing.
+        self._split_grid_discovery_warned = False
 
     def _get_device_for_entity(self, entity_id: str) -> Optional[str]:
         """Get device_id for an entity from the entity registry."""

--- a/ha_energy_reader.py
+++ b/ha_energy_reader.py
@@ -443,7 +443,9 @@ def _find_power_sensor_on_device(
         candidates.sort(key=_rank)
         return candidates[0]
     except Exception as e:  # noqa: BLE001 — best-effort, never block setup
-        _LOGGER.debug("Power sensor derivation failed for %s: %s", energy_entity, e)
+        # Surface at warning (#259): a failure here is the #250 class — power can't be
+        # derived, so the affected source silently reads 0 everywhere. Make it visible.
+        _LOGGER.warning("Power sensor derivation failed for %s: %s", energy_entity, e)
         return None
 
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.13-beta.4"
+  "version": "1.5.13-beta.5"
 }

--- a/switch.py
+++ b/switch.py
@@ -180,6 +180,10 @@ class SEMSolarSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         """Turn the switch on."""
         _LOGGER.info("Turning on %s", self.entity_description.key)
         self._is_on = True
+        # Push the new state immediately (#259): otherwise the UI only reflects the
+        # toggle on the next coordinator push, and a swallowed refresh error below
+        # would silently leave HA showing the old state.
+        self.async_write_ha_state()
 
         try:
             await self.coordinator.async_request_refresh()
@@ -190,6 +194,7 @@ class SEMSolarSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         """Turn the switch off."""
         _LOGGER.info("Turning off %s", self.entity_description.key)
         self._is_on = False
+        self.async_write_ha_state()  # reflect immediately (#259)
 
         try:
             await self.coordinator.async_request_refresh()
@@ -244,10 +249,12 @@ class SEMPerChargerSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on night charging for this charger."""
         self._is_on = True
+        self.async_write_ha_state()  # reflect immediately (#259)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off night charging for this charger."""
         self._is_on = False
+        self.async_write_ha_state()  # reflect immediately (#259)
         await self.coordinator.async_request_refresh()
 

--- a/tests/test_per_charger_entities.py
+++ b/tests/test_per_charger_entities.py
@@ -210,12 +210,14 @@ class TestPerChargerSwitches:
         coord.async_request_refresh = AsyncMock()
         desc = SwitchEntityDescription(key="charger_ev_charger_night_charging")
         switch = SEMPerChargerSwitch(coord, desc, "test", "ev_charger", "KEBA")
+        switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
 
         assert switch.is_on is False  # opt-in default (#256)
         await switch.async_turn_on()
         assert switch.is_on is True
         await switch.async_turn_off()
         assert switch.is_on is False
+        assert switch.async_write_ha_state.call_count == 2  # both toggles pushed state (#259)
 
     def test_per_charger_switch_available(self):
         """Per-charger switch should be unavailable when coordinator fails."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -83,10 +83,12 @@ class TestSEMSwitches:
         description = create_switch_description("night_charging")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
         switch._is_on = False
+        switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
 
         await switch.async_turn_on()
 
         assert switch._is_on is True
+        switch.async_write_ha_state.assert_called()  # state pushed immediately (#259)
         mock_coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
@@ -95,10 +97,12 @@ class TestSEMSwitches:
         description = create_switch_description("night_charging")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
         switch._is_on = True
+        switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
 
         await switch.async_turn_off()
 
         assert switch._is_on is False
+        switch.async_write_ha_state.assert_called()  # state pushed immediately (#259)
         mock_coordinator.async_request_refresh.assert_called_once()
 
     @pytest.mark.asyncio
@@ -138,6 +142,7 @@ class TestSEMSwitches:
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
 
         mock_coordinator.async_request_refresh = AsyncMock(side_effect=Exception("Refresh error"))
+        switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
 
         # Should not raise
         await switch.async_turn_on()


### PR DESCRIPTION
## Surface user-impacting silent failures (#259)

A targeted audit (#259) found several **silent degradations** — code that quietly did the wrong thing with no visible signal (the class behind #250 all-zeros and #256). This PR surfaces the **high-impact** ones. **Observability-only — no control-flow / behaviour changes.**

- **`switch.py`** — `async_turn_on/off` now call `async_write_ha_state()` so a toggle reflects immediately and a swallowed coordinator-refresh error can't leave HA showing stale state (reviewer finding from #260).
- **`ha_energy_reader.py`** — power-sensor derivation failure logs at **WARNING** (was debug). This is the #250 case: a source silently reads 0 everywhere.
- **`coordinator/sensor_reader.py`** — split-grid discovery failure **warns once** then debug (split-meter setups were silently reading 0 grid power). Flag reset on cache-invalidate.
- **`coordinator/coordinator.py`** — tariff rate-update failure **warns once + logs recovery** instead of silently using stale rates for cost calc; and logs **once per charger** when a charger inherits the global night floor (the #256 fallback; behaviour change stays in #255).

Per-cycle paths warn-once to avoid log spam; warn guards declared in `__init__`. MED parse-failure catches deliberately left (debug-level, don't surface to users).

### Verification
- `1927 passed, 7 skipped` locally.
- `ruflo-core:reviewer`: observability items confirmed correct/safe; valid findings (split-grid flag reset, `__init__` declarations, test assertions) applied.
- HA-TEST `1.5.13-beta.5`: 0 errors, warn-once paths correctly silent on a healthy system.

`Refs #259, #250, #256, #255`
