### PR TITLE
docs: night charging is opt-in (off by default) (#256)

### DIFF
--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -147,14 +147,14 @@ Once installed, SEM runs without manual intervention:
 - **Clouds roll in** — EV charging reduces or pauses, resumes when surplus returns
 - **Battery reaches priority SOC** — surplus is redirected to EV charging
 - **Evening** — solar charging stops; system monitors overnight
-- **Night charging** — if enabled, grid-charges the EV to your daily target
+- **Night charging** — *opt-in (off by default)*; when enabled, grid-charges the EV to your daily-target floor
 - **Smart forecast** — if tomorrow is sunny, tonight's grid charging is reduced or skipped
 
 The three switches that matter most:
 
 | Switch | Default | Purpose |
 |--------|---------|---------|
-| `switch.sem_night_charging` | ON | Grid-charges EV overnight to daily target |
+| `switch.sem_night_charging` | OFF | Opt-in: grid-charges EV overnight to the daily-target floor (off by default → solar surplus only) |
 | `switch.sem_observer_mode` | OFF | Monitor-only, no hardware control |
 | `switch.sem_smart_night_charging` | OFF | Reduces overnight charging when a good solar forecast exists |
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -279,7 +279,7 @@ The options flow is organized into these pages:
 | EV battery capacity (kWh) | 40 kWh | Your EV's battery size (10–120 kWh). Used to convert SOC percentage to kWh remaining. Per-charger configurable. |
 | Min solar power to start EV charging (W) | 500 W | How much surplus must appear before solar EV charging begins. The default prevents SEM from starting the charger for tiny, transient surplus spikes. Raise it if your surplus is noisy and the charger starts and stops too often. |
 | Max grid import for Min+PV mode (W) | 1380 W | In Min+PV mode the EV runs at minimum current and uses grid to fill the gap. This cap limits how much grid power is used. Lower it to keep Min+PV fully solar; raise it if you want the charger to run continuously even when solar is weak. |
-| Night charging | On | When on, SEM charges the EV from the grid overnight (during the cheap-rate window) to reach the daily target. Turn it off if you only want solar charging or manage overnight charging yourself. |
+| Night charging | **Off** | **Opt-in** (#256). When on, SEM charges the EV from the grid overnight (during the cheap-rate window) to reach the daily-target floor. Off by default so a fresh install charges on **solar surplus only** — turn it on if you want grid-assisted overnight charging. Existing installs keep their previous setting on upgrade. |
 | Smart night charging | Off | When on, SEM evaluates whether tonight's grid charge is actually needed. If tomorrow's solar forecast is strong and the battery is reasonably full, SEM reduces or skips the overnight charge. Enable after SEM has been running for a week and you have a calibrated forecast integration. |
 
 ### Battery SOC Zone settings


### PR DESCRIPTION
Corrects SETUP_GUIDE and QUICK_START, which still listed `night_charging` as default ON after the #256 opt-in change flipped it to OFF. Adds the opt-in + preserve-existing-on-upgrade note. The Min/Max EV-target docs (USER_GUIDE/ARCHITECTURE/SETUP_GUIDE) were already current from #245.

Part of the 1.5.13 docs sweep. Refs #256