### PR TITLE
fix(#259): debug-log remaining silent parse/lookup failures

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -601,7 +601,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     try:
                         self._cycle_vehicle_soc = float(_soc_state.state)
                     except (ValueError, TypeError):
-                        pass
+                        _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", _vehicle_soc_entity, _soc_state.state)
 
             # Step 1: Read power values from sensors
             power = self._sensor_reader.read_power()
@@ -662,7 +662,10 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                                 if unit == "kW":
                                     cp *= 1000
                             except (ValueError, TypeError):
-                                pass
+                                _LOGGER.debug(
+                                    "Charger %s power not numeric: %r (#259)",
+                                    cid, getattr(pstate, "state", None),
+                                )
                     charger_powers[cid] = cp
                 total_charger_power = sum(charger_powers.values())
 
@@ -703,7 +706,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             try:
                                 self._cycle_vehicle_soc = float(soc_state.state)
                             except (ValueError, TypeError):
-                                pass
+                                _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_charger_soc_entity, soc_state.state)
                     self._ev_device = ev_dev
                     self._session_data = self._session_data_per_charger[cid]
                     self._last_ev_connected = self._last_ev_connected_per_charger[cid]
@@ -868,7 +871,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             try:
                                 self._cycle_vehicle_soc = float(soc_st.state)
                             except (ValueError, TypeError):
-                                pass
+                                _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_soc_entity, soc_st.state)
                     # Ceiling (Max) gates surplus; floor (Min) drives night top-up (#245)
                     per_remaining = self._calculate_remaining_need(
                         energy, self._cycle_vehicle_soc, charger_cfg, bound="max"
@@ -2615,7 +2618,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     try:
                         per_charger_vehicle_soc = float(soc_state.state)
                     except (ValueError, TypeError):
-                        pass
+                        _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_charger_soc_entity, soc_state.state)
 
             # If we have no real SOC and the detector has no calibration data,
             # the virtual 100% default is misleading — return None so the sensor

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -584,7 +584,8 @@ class SensorReader:
             registry = er.async_get(self.hass)
             entry = registry.async_get(entity_id)
             return entry.device_id if entry else None
-        except Exception:
+        except Exception as e:
+            _LOGGER.debug("Device lookup failed for %s: %s (#259)", entity_id, e)
             return None
 
     def _read_battery_soc_average(self, battery_power_entities: list) -> float:
@@ -842,7 +843,7 @@ class SensorReader:
                                         self._battery_soc_logged = True
                                     return eid
                             except (ValueError, TypeError):
-                                pass
+                                _LOGGER.debug("Battery SOC candidate %s not numeric: %r (#259)", eid, state.state)
         except Exception as e:
             _LOGGER.debug("Device registry SOC lookup failed: %s", e)
 
@@ -862,7 +863,7 @@ class SensorReader:
                             self._battery_soc_logged = True
                         return candidate
                 except (ValueError, TypeError):
-                    pass
+                    _LOGGER.debug("Battery SOC candidate %s not numeric: %r (#259)", candidate, state.state)
         return None
 
     def auto_detect_battery_capacity_kwh(self) -> Optional[float]:


### PR DESCRIPTION
Follow-up MED items from the #259 audit: add debug-level logging to silent parse/lookup catches (SOC/charger-power float parses, battery-SOC candidates, device lookup) so they're traceable. **Observability only — no behaviour change.** 1939 tests pass. Refs #259