### PR TITLE
fix(ev): night charge respects peak limit, never leans on battery (#268)

### DIFF
--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -129,8 +129,15 @@ class EVControlMixin:
 
             if not ev._session_active:
                 # Fresh start: set_current BEFORE start_session
-                # (KEBA ignores enable at 0A)
-                initial_current = min(ev.max_current, initial_amps)
+                # (KEBA ignores enable at 0A). Cap the kickstart to the peak
+                # headroom too: the car is not drawing yet, so estimate W/A from
+                # phases*voltage. Without this the first cycle starts at
+                # initial_amps (default 10A ~ 6.9kW) which alone can exceed the
+                # peak limit before the dynamic loop takes over.
+                est_wpa = ev.phases * ev.voltage
+                peak_amps = self._night_peak_managed_amps(
+                    power, est_wpa, min_amps, ev.max_current)
+                initial_current = min(initial_amps, peak_amps)
                 await ev._set_current(initial_current)
                 await ev.start_session(energy_target_kwh=0)
                 self._ev_last_change_time = dt_util.now()
@@ -150,16 +157,9 @@ class EVControlMixin:
                 if power.ev_power > 100:
                     # W/A from actual charger readings (adapts to any car)
                     watts_per_amp = power.ev_power / max(1, ev._current_setpoint)
-
-                    peak_limit_w = self._get_peak_limit_w()
-                    # Subtract EV's own draw: grid_import includes EV, so
-                    # non_ev_grid = home + other loads (what the grid would
-                    # import if the EV were off)
-                    non_ev_grid = power.grid_import_power - power.ev_power
-                    target = (peak_limit_w - non_ev_grid) / max(1, watts_per_amp)
-
-                    # Clamp: configurable min current, max from charger config
-                    target = min(ev.max_current, max(min_amps, round(target)))
+                    target = self._night_peak_managed_amps(
+                        power, watts_per_amp, min_amps, ev.max_current)
+                    peak_limit_w = self._get_peak_limit_w()  # for the log line
 
                     # Ramp limit: configurable ±N amps per cycle
                     ramp_rate = int(self.config.get("ev_ramp_rate_amps", 2))
@@ -297,6 +297,37 @@ class EVControlMixin:
             except Exception:
                 pass
         return self.config.get("target_peak_limit", 5.0) * 1000
+
+    def _night_peak_managed_amps(
+        self,
+        power: PowerReadings,
+        watts_per_amp: float,
+        min_amps: int,
+        max_amps: int,
+    ) -> int:
+        """Charging current that keeps grid import <= the peak limit at night.
+
+        Sized from the pure house load (``home_consumption_power``), NOT from
+        ``grid_import - ev_power``. The latter equals ``home + batt_charge -
+        batt_discharge`` (see ``PowerReadings.calculate_derived``), so battery
+        discharge drives it negative and inflates the apparent headroom — the EV
+        ramps up while the battery is discharging, then grid import overshoots
+        the peak the instant the battery backs off (observed on PROD: EV 10kW /
+        grid 10kW against a 6kW limit). ``home_consumption_power`` excludes both
+        EV and battery, so ``grid = home + ev`` stays <= peak regardless of what
+        the battery does — night charging must not lean on the home battery
+        (the battery may still reduce grid below peak, it is just never relied
+        upon). Result is clamped to ``[min_amps, max_amps]``.
+
+        Residual limitation: if the inverter autonomously charges the battery
+        from the grid during the night window (e.g. a dynamic-tariff or timed
+        grid-charge SEM does not command), ``grid = peak + net_batt_charge`` and
+        the peak may still be exceeded by that charge. SEM cannot size around
+        inverter-managed charging it doesn't control.
+        """
+        headroom_w = self._get_peak_limit_w() - power.home_consumption_power
+        target = round(headroom_w / max(1.0, watts_per_amp))
+        return min(max_amps, max(min_amps, target))
 
     def _calculate_solar_ev_budget(
         self, state: str, power: PowerReadings, context: ChargingContext,

--- a/tests/test_night_peak_managed.py
+++ b/tests/test_night_peak_managed.py
@@ -1,0 +1,85 @@
+"""Regression: night-charge peak management must size the EV from the pure
+house load, never from ``grid_import - ev_power``.
+
+Live PROD bug (2026-05-26): with a 6kW peak limit the EV ramped to 10kW and grid
+import hit ~10kW. Root cause: the night current was derived from
+``grid_import_power - ev_power`` which equals ``home + batt_charge -
+batt_discharge`` (see PowerReadings.calculate_derived). Battery discharge drove
+that term negative and inflated the apparent headroom, so the EV ramped up while
+the battery discharged and grid import overshot the peak the moment the battery
+backed off.
+
+``_night_peak_managed_amps`` now uses ``home_consumption_power`` (excludes both
+EV and battery), so ``grid = home + ev`` stays <= peak regardless of the battery.
+"""
+from unittest.mock import Mock
+
+from custom_components.solar_energy_management.coordinator.ev_control import (
+    EVControlMixin,
+)
+from custom_components.solar_energy_management.coordinator.types import PowerReadings
+
+
+def _amps(home_w, peak_w, wpa, *, min_a=6, max_a=16, ev_w=0.0, grid_w=0.0,
+          batt_w=0.0):
+    """Call the helper with a fake self that reports peak_w as the peak limit."""
+    obj = Mock()
+    obj._get_peak_limit_w = Mock(return_value=peak_w)
+    p = PowerReadings()
+    p.home_consumption_power = home_w
+    p.ev_power = ev_w
+    p.grid_import_power = grid_w
+    p.battery_power = batt_w
+    return EVControlMixin._night_peak_managed_amps(obj, p, wpa, min_a, max_a)
+
+
+def test_target_uses_home_not_grid_minus_ev():
+    """THE regression guard: battery discharge must not inflate the target.
+
+    Scenario mirrors the PROD trace — EV pulling 10kW, battery covering 2.5kW so
+    grid_import is 7.5kW (``grid - ev = -2500``), home only 0.5kW, 6kW peak.
+    """
+    amps = _amps(home_w=500.0, peak_w=6000.0, wpa=690.0,
+                 ev_w=10000.0, grid_w=7500.0, batt_w=-2500.0)
+    # home-based: (6000 - 500) / 690 = 7.97 -> 8A  (~5.5kW, grid stays <= peak)
+    assert amps == 8
+    # the OLD grid-minus-ev formula would give (6000 - (-2500)) / 690 = 12.3 ->
+    # 12A (~8.3kW) and blow past the peak. Must NOT happen.
+    assert amps != 12
+
+
+def test_low_home_leaves_most_headroom():
+    # 0.5kW home, 6kW peak -> ~5.5kW for the EV -> 8A at 690 W/A
+    assert _amps(home_w=500.0, peak_w=6000.0, wpa=690.0) == 8
+
+
+def test_high_home_clamps_to_min():
+    # House already at/over the peak -> no headroom -> clamp to the min current
+    assert _amps(home_w=6000.0, peak_w=6000.0, wpa=690.0, min_a=6) == 6
+    assert _amps(home_w=9000.0, peak_w=6000.0, wpa=690.0, min_a=6) == 6
+
+
+def test_clamps_to_max():
+    # Huge headroom must not exceed the charger's max current
+    assert _amps(home_w=0.0, peak_w=22000.0, wpa=690.0, max_a=16) == 16
+
+
+def test_single_phase_estimate_yields_fewer_amps():
+    """Kickstart uses est. W/A = phases*voltage; 1-phase (230) allows more amps
+    of headroom for the same watts than 3-phase (690)."""
+    three_phase = _amps(home_w=500.0, peak_w=6000.0, wpa=3 * 230.0)
+    one_phase = _amps(home_w=500.0, peak_w=6000.0, wpa=1 * 230.0, max_a=32)
+    # same ~5.5kW headroom: 3-phase -> 8A, 1-phase -> 24A
+    assert three_phase == 8
+    assert one_phase == 24
+
+
+def test_battery_state_never_changes_result():
+    """The result must be identical whether the battery is idle, charging, or
+    discharging, for a fixed home load + peak + W/A."""
+    base = _amps(home_w=700.0, peak_w=6000.0, wpa=690.0, batt_w=0.0)
+    discharging = _amps(home_w=700.0, peak_w=6000.0, wpa=690.0, batt_w=-3000.0,
+                        grid_w=2000.0, ev_w=5000.0)
+    charging = _amps(home_w=700.0, peak_w=6000.0, wpa=690.0, batt_w=3000.0,
+                     grid_w=8000.0, ev_w=5000.0)
+    assert base == discharging == charging


### PR DESCRIPTION
Fixes #268

## Problem (live grid-safety bug on HA-PROD)

With `target_peak_limit = 6.0 kW`, a night charge ramped the EV to **10 kW** and **grid import hit 9977 W** — over 1.6× the contract limit, then sat at 6.3–7.7 kW for the rest of the charge.

## Root cause

Night current was sized from `grid_import_power - ev_power` as the "house load". Per `PowerReadings.calculate_derived`, that term equals `home + batt_charge - batt_discharge`, so battery discharge drove it **negative** and inflated the apparent peak headroom: the EV ramped up while the battery discharged, then grid overshot the peak the instant the battery backed off. An unstable loop that leaned on the battery to hold the line.

## Fix

- New `EVControlMixin._night_peak_managed_amps(power, watts_per_amp, min_amps, max_amps)` sizes current from `home_consumption_power` (excludes **both** EV and battery), so `grid = home + ev <= peak` regardless of battery state — the battery can only push grid *below* peak, never be relied upon. This is the intended "battery protection during night charging".
- Reused for the kickstart, which now caps the initial current to the peak headroom (estimated W/A = `phases × voltage`) instead of starting at the raw `ev_night_initial_current` (10 A ≈ 6.9 kW, already over a 6 kW limit).
- Documented residual limitation (not a regression): if the inverter autonomously grid-charges the battery during the night window, grid = peak + net_batt_charge.

## Tests & verification

- 6 regression tests (`tests/test_night_peak_managed.py`), incl. a guard that fails on a revert to the old formula. Full suite **1949 passed**.
- ruflo-core:reviewer: no criticals/majors, safe to deploy.
- **Verified live on HA-PROD**: re-test with battery discharging 2.6 kW held grid import at **~3.4 kW vs the 6 kW limit** (max 3393 W, 0 violations), charge stopped cleanly at target.