### PR TITLE
i18n: complete HA-native translations (exceptions, issues, #245 help) across 15 langs

### DIFF
--- a/translations/cs.json
+++ b/translations/cs.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
+          "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce.",
+          "ev_kwh_per_100km": "Slouží k odhadu dojezdu, pokud není nakonfigurován senzor dojezdu.",
+          "vehicle_range_entity": "Volitelný skutečný senzor dojezdu. Jinak se dojezd odhaduje z SOC × kapacita × účinnost."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
+          "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limit solárního nabíjení (kWh)",
           "ev_target_soc_max": "Limit solárního nabíjení (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
+          "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Cíl SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Nepodařilo se vygenerovat řídicí panel SEM. Podrobnosti najdete v protokolech Home Assistant."
+    },
+    "load_management_not_initialized": {
+      "message": "Správa zátěže ještě není připravena. Počkejte, až se integrace plně spustí, a zkuste to znovu."
+    },
+    "device_registry_not_initialized": {
+      "message": "Registr zařízení ještě není připraven. Počkejte, až se integrace plně spustí, a zkuste to znovu."
+    },
+    "mapping_service_required": {
+      "message": "Když je typ ovládání „služba“, je vyžadována služba. Zadejte službu, která se má volat."
+    },
+    "mapping_entity_required": {
+      "message": "Pro tento typ ovládání je vyžadována ovládací entita. Zadejte ovládací entitu."
+    },
+    "device_not_found": {
+      "message": "Zařízení „{device_id}“ nebylo nalezeno."
+    },
+    "invalid_device_property": {
+      "message": "Neplatná vlastnost zařízení: „{property}“."
+    },
+    "invalid_deadline_format": {
+      "message": "Neplatný formát termínu: „{deadline}“. Použijte formát ISO 8601, například 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Nabíječka EV není nakonfigurována",
+      "description": "Nejsou nakonfigurovány žádné senzory nabíječky EV, takže funkce nabíjení EV nejsou dostupné. Chcete-li povolit nabíjení EV, přidejte v možnostech integrace senzor „připojeno“ nebo senzor nabíjecího výkonu."
     }
   }
 }

--- a/translations/da.json
+++ b/translations/da.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
+          "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen.",
+          "ev_kwh_per_100km": "Bruges til at estimere rækkevidden, når der ikke er konfigureret en rækkeviddesensor.",
+          "vehicle_range_entity": "Valgfri reel rækkeviddesensor. Ellers estimeres rækkevidden ud fra SOC × kapacitet × effektivitet."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
+          "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Solopladningsgrænse (kWh)",
           "ev_target_soc_max": "Solopladningsgrænse (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
+          "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC-%-mål"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "SEM-dashboardet kunne ikke genereres. Se Home Assistant-loggene for detaljer."
+    },
+    "load_management_not_initialized": {
+      "message": "Belastningsstyringen er ikke klar endnu. Vent, til integrationen er færdig med at starte, og prøv igen."
+    },
+    "device_registry_not_initialized": {
+      "message": "Enhedsregistret er ikke klar endnu. Vent, til integrationen er færdig med at starte, og prøv igen."
+    },
+    "mapping_service_required": {
+      "message": "Der kræves en tjeneste, når styringstypen er ”tjeneste”. Angiv en tjeneste, der skal kaldes."
+    },
+    "mapping_entity_required": {
+      "message": "Der kræves en styringsentitet til denne styringstype. Angiv en styringsentitet."
+    },
+    "device_not_found": {
+      "message": "Enheden ”{device_id}” blev ikke fundet."
+    },
+    "invalid_device_property": {
+      "message": "Ugyldig enhedsegenskab: ”{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Ugyldigt deadlineformat: ”{deadline}”. Brug ISO 8601-format, for eksempel 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV-lader ikke konfigureret",
+      "description": "Der er ikke konfigureret nogen sensorer til EV-laderen, så EV-opladningsfunktionerne er ikke tilgængelige. Tilføj en ”tilsluttet”-sensor eller en opladningseffektsensor i integrationsindstillingerne for at aktivere EV-opladning."
     }
   }
 }

--- a/translations/de.json
+++ b/translations/de.json
@@ -156,7 +156,6 @@
           "battery_assist_max_power": "Batterie-Unterstützung Max. Leistung (W)",
           "battery_capacity_kwh": "Batteriekapazität (kWh)",
           "battery_discharge_protection_enabled": "Batterieentladeschutz aktivieren",
-          "battery_min_discharge_power": "Minimale Entladeleistung (W)",
           "battery_max_discharge_power": "Maximale Entladeleistung (W)",
           "electricity_import_rate": "Stromimporttarif (pro kWh)",
           "electricity_export_rate": "Stromexporttarif (pro kWh)",
@@ -1150,6 +1149,38 @@
           "soc": "SoC-%-Ziel"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Das SEM-Dashboard konnte nicht erstellt werden. Details finden Sie in den Home-Assistant-Protokollen."
+    },
+    "load_management_not_initialized": {
+      "message": "Das Lastmanagement ist noch nicht bereit. Bitte warten Sie, bis die Integration vollständig gestartet ist, und versuchen Sie es erneut."
+    },
+    "device_registry_not_initialized": {
+      "message": "Die Geräteregistrierung ist noch nicht bereit. Bitte warten Sie, bis die Integration vollständig gestartet ist, und versuchen Sie es erneut."
+    },
+    "mapping_service_required": {
+      "message": "Beim Steuerungstyp „Dienst“ ist ein Dienst erforderlich. Bitte geben Sie einen aufzurufenden Dienst an."
+    },
+    "mapping_entity_required": {
+      "message": "Für diesen Steuerungstyp ist eine Steuerungs-Entität erforderlich. Bitte geben Sie eine Steuerungs-Entität an."
+    },
+    "device_not_found": {
+      "message": "Gerät „{device_id}“ wurde nicht gefunden."
+    },
+    "invalid_device_property": {
+      "message": "Ungültige Geräteeigenschaft: „{property}“."
+    },
+    "invalid_deadline_format": {
+      "message": "Ungültiges Fristformat: „{deadline}“. Verwenden Sie das ISO-8601-Format, zum Beispiel 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV-Ladegerät nicht konfiguriert",
+      "description": "Es sind keine Sensoren für das EV-Ladegerät konfiguriert, daher sind die EV-Ladefunktionen nicht verfügbar. Fügen Sie in den Integrationsoptionen einen „Verbunden“-Sensor oder einen Ladeleistungssensor hinzu, um das EV-Laden zu aktivieren."
     }
   }
 }

--- a/translations/en.json
+++ b/translations/en.json
@@ -1150,5 +1150,37 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Failed to generate the SEM dashboard. Check the Home Assistant logs for details."
+    },
+    "load_management_not_initialized": {
+      "message": "Load management is not ready yet. Please wait for the integration to finish starting and try again."
+    },
+    "device_registry_not_initialized": {
+      "message": "The device registry is not ready yet. Please wait for the integration to finish starting and try again."
+    },
+    "mapping_service_required": {
+      "message": "A service is required when the control type is “service”. Please provide a service to call."
+    },
+    "mapping_entity_required": {
+      "message": "A control entity is required for this control type. Please provide a control entity."
+    },
+    "device_not_found": {
+      "message": "Device “{device_id}” was not found."
+    },
+    "invalid_device_property": {
+      "message": "Invalid device property: “{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Invalid deadline format: “{deadline}”. Use ISO 8601 format, for example 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV charger not configured",
+      "description": "No EV charger sensors are configured, so EV charging features are unavailable. Add an EV “connected” sensor or a charging-power sensor in the integration options to enable EV charging."
+    }
   }
 }

--- a/translations/es.json
+++ b/translations/es.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
+          "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol.",
+          "ev_kwh_per_100km": "Se usa para estimar la autonomía cuando no hay un sensor de autonomía configurado.",
+          "vehicle_range_entity": "Sensor de autonomía real opcional. De lo contrario, la autonomía se estima a partir de SOC × capacidad × eficiencia."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
+          "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Límite de carga solar (kWh)",
           "ev_target_soc_max": "Límite de carga solar (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
+          "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Objetivo SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "No se pudo generar el panel de SEM. Consulta los registros de Home Assistant para más detalles."
+    },
+    "load_management_not_initialized": {
+      "message": "La gestión de carga aún no está lista. Espera a que la integración termine de iniciarse e inténtalo de nuevo."
+    },
+    "device_registry_not_initialized": {
+      "message": "El registro de dispositivos aún no está listo. Espera a que la integración termine de iniciarse e inténtalo de nuevo."
+    },
+    "mapping_service_required": {
+      "message": "Se requiere un servicio cuando el tipo de control es «servicio». Indica un servicio que llamar."
+    },
+    "mapping_entity_required": {
+      "message": "Se requiere una entidad de control para este tipo de control. Indica una entidad de control."
+    },
+    "device_not_found": {
+      "message": "No se encontró el dispositivo «{device_id}»."
+    },
+    "invalid_device_property": {
+      "message": "Propiedad de dispositivo no válida: «{property}»."
+    },
+    "invalid_deadline_format": {
+      "message": "Formato de fecha límite no válido: «{deadline}». Usa el formato ISO 8601, por ejemplo 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Cargador de VE no configurado",
+      "description": "No hay sensores del cargador de VE configurados, por lo que las funciones de carga de VE no están disponibles. Añade un sensor de «conectado» o un sensor de potencia de carga en las opciones de la integración para habilitar la carga de VE."
     }
   }
 }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
+          "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta.",
+          "ev_kwh_per_100km": "Käytetään toimintamatkan arviointiin, kun matka-anturia ei ole määritetty.",
+          "vehicle_range_entity": "Valinnainen todellinen matka-anturi. Muuten matka arvioidaan: SOC × kapasiteetti × hyötysuhde."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
+          "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Aurinkolatauksen raja (kWh)",
           "ev_target_soc_max": "Aurinkolatauksen raja (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
+          "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC-%-tavoite"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "SEM-koontinäytön luominen epäonnistui. Katso lisätiedot Home Assistantin lokeista."
+    },
+    "load_management_not_initialized": {
+      "message": "Kuormanhallinta ei ole vielä valmis. Odota, että integraatio on käynnistynyt kokonaan, ja yritä uudelleen."
+    },
+    "device_registry_not_initialized": {
+      "message": "Laiterekisteri ei ole vielä valmis. Odota, että integraatio on käynnistynyt kokonaan, ja yritä uudelleen."
+    },
+    "mapping_service_required": {
+      "message": "Palvelu vaaditaan, kun ohjaustyyppi on ”palvelu”. Anna kutsuttava palvelu."
+    },
+    "mapping_entity_required": {
+      "message": "Tämä ohjaustyyppi vaatii ohjausentiteetin. Anna ohjausentiteetti."
+    },
+    "device_not_found": {
+      "message": "Laitetta ”{device_id}” ei löytynyt."
+    },
+    "invalid_device_property": {
+      "message": "Virheellinen laiteominaisuus: ”{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Virheellinen määräajan muoto: ”{deadline}”. Käytä ISO 8601 -muotoa, esimerkiksi 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Latauslaitetta ei ole määritetty",
+      "description": "Sähköauton latauslaitteen antureita ei ole määritetty, joten latausominaisuudet eivät ole käytettävissä. Ota lataus käyttöön lisäämällä integraation asetuksiin ”yhdistetty”-anturi tai lataustehon anturi."
     }
   }
 }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
+          "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil.",
+          "ev_kwh_per_100km": "Utilisé pour estimer l’autonomie lorsqu’aucun capteur d’autonomie n’est configuré.",
+          "vehicle_range_entity": "Capteur d’autonomie réel optionnel. Sinon, l’autonomie est estimée à partir de SOC × capacité × efficacité."
         }
       },
       "settings": {
@@ -152,7 +156,6 @@
           "battery_assist_max_power": "Puissance Max. Assistance Batterie (W)",
           "battery_capacity_kwh": "Capacité Batterie (kWh)",
           "battery_discharge_protection_enabled": "Activer la Protection de Décharge Batterie",
-          "battery_min_discharge_power": "Puissance de Décharge Minimale (W)",
           "battery_max_discharge_power": "Puissance de Décharge Maximale (W)",
           "electricity_import_rate": "Tarif d'Import d'Électricité (par kWh)",
           "electricity_export_rate": "Tarif d'Export d'Électricité (par kWh)",
@@ -362,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
+          "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limite de charge solaire (kWh)",
           "ev_target_soc_max": "Limite de charge solaire (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
+          "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil."
         }
       }
     }
@@ -1140,6 +1149,38 @@
           "soc": "Objectif SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Échec de la génération du tableau de bord SEM. Consultez les journaux de Home Assistant pour plus de détails."
+    },
+    "load_management_not_initialized": {
+      "message": "La gestion de charge n’est pas encore prête. Veuillez attendre que l’intégration ait fini de démarrer, puis réessayez."
+    },
+    "device_registry_not_initialized": {
+      "message": "Le registre des appareils n’est pas encore prêt. Veuillez attendre que l’intégration ait fini de démarrer, puis réessayez."
+    },
+    "mapping_service_required": {
+      "message": "Un service est requis lorsque le type de commande est « service ». Veuillez indiquer un service à appeler."
+    },
+    "mapping_entity_required": {
+      "message": "Une entité de commande est requise pour ce type de commande. Veuillez indiquer une entité de commande."
+    },
+    "device_not_found": {
+      "message": "Appareil « {device_id} » introuvable."
+    },
+    "invalid_device_property": {
+      "message": "Propriété d’appareil invalide : « {property} »."
+    },
+    "invalid_deadline_format": {
+      "message": "Format d’échéance invalide : « {deadline} ». Utilisez le format ISO 8601, par exemple 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Chargeur VE non configuré",
+      "description": "Aucun capteur de chargeur VE n’est configuré, les fonctions de charge VE sont donc indisponibles. Ajoutez un capteur « connecté » ou un capteur de puissance de charge dans les options de l’intégration pour activer la charge VE."
     }
   }
 }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
+          "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból.",
+          "ev_kwh_per_100km": "A hatótáv becsléséhez használatos, ha nincs hatótáv-érzékelő konfigurálva.",
+          "vehicle_range_entity": "Opcionális valós hatótáv-érzékelő. Egyébként a hatótáv becslése: SOC × kapacitás × hatékonyság."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
+          "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Napelemes töltési limit (kWh)",
           "ev_target_soc_max": "Napelemes töltési limit (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
+          "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC % cél"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "A SEM irányítópult létrehozása sikertelen. A részletekért tekintse meg a Home Assistant naplóit."
+    },
+    "load_management_not_initialized": {
+      "message": "A terheléskezelés még nem áll készen. Várja meg, amíg az integráció elindul, majd próbálja újra."
+    },
+    "device_registry_not_initialized": {
+      "message": "Az eszköznyilvántartás még nem áll készen. Várja meg, amíg az integráció elindul, majd próbálja újra."
+    },
+    "mapping_service_required": {
+      "message": "Ha a vezérlés típusa „szolgáltatás”, szolgáltatás megadása szükséges. Adjon meg egy meghívandó szolgáltatást."
+    },
+    "mapping_entity_required": {
+      "message": "Ehhez a vezérléstípushoz vezérlőentitás szükséges. Adjon meg egy vezérlőentitást."
+    },
+    "device_not_found": {
+      "message": "A(z) „{device_id}” eszköz nem található."
+    },
+    "invalid_device_property": {
+      "message": "Érvénytelen eszköztulajdonság: „{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Érvénytelen határidőformátum: „{deadline}”. Használjon ISO 8601 formátumot, például 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Az EV-töltő nincs konfigurálva",
+      "description": "Nincsenek konfigurálva EV-töltő érzékelők, ezért az EV-töltési funkciók nem érhetők el. Az EV-töltés engedélyezéséhez adjon hozzá egy „csatlakoztatva” érzékelőt vagy egy töltési teljesítmény érzékelőt az integráció beállításaiban."
     }
   }
 }

--- a/translations/it.json
+++ b/translations/it.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
+          "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole.",
+          "ev_kwh_per_100km": "Usato per stimare l’autonomia quando non è configurato un sensore di autonomia.",
+          "vehicle_range_entity": "Sensore di autonomia reale opzionale. Altrimenti l’autonomia è stimata da SOC × capacità × efficienza."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
+          "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limite di carica solare (kWh)",
           "ev_target_soc_max": "Limite di carica solare (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
+          "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Obiettivo SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Impossibile generare la dashboard SEM. Controlla i log di Home Assistant per i dettagli."
+    },
+    "load_management_not_initialized": {
+      "message": "La gestione del carico non è ancora pronta. Attendi che l’integrazione completi l’avvio e riprova."
+    },
+    "device_registry_not_initialized": {
+      "message": "Il registro dei dispositivi non è ancora pronto. Attendi che l’integrazione completi l’avvio e riprova."
+    },
+    "mapping_service_required": {
+      "message": "È richiesto un servizio quando il tipo di controllo è «servizio». Indica un servizio da chiamare."
+    },
+    "mapping_entity_required": {
+      "message": "Per questo tipo di controllo è richiesta un’entità di controllo. Indica un’entità di controllo."
+    },
+    "device_not_found": {
+      "message": "Dispositivo «{device_id}» non trovato."
+    },
+    "invalid_device_property": {
+      "message": "Proprietà del dispositivo non valida: «{property}»."
+    },
+    "invalid_deadline_format": {
+      "message": "Formato scadenza non valido: «{deadline}». Usa il formato ISO 8601, ad esempio 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Caricatore EV non configurato",
+      "description": "Nessun sensore del caricatore EV è configurato, quindi le funzioni di ricarica EV non sono disponibili. Aggiungi un sensore «connesso» o un sensore di potenza di ricarica nelle opzioni dell’integrazione per abilitare la ricarica EV."
     }
   }
 }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Zonne-overschot laadt tot deze waarde en stopt dan. Laat op vol staan om vrij op zon te laden.",
+          "ev_target_soc_max": "Zonne-overschot laadt tot deze SOC en stopt dan. Laat op 100% staan om vrij op zon te laden.",
+          "ev_kwh_per_100km": "Gebruikt om het rijbereik te schatten wanneer er geen bereiksensor is geconfigureerd.",
+          "vehicle_range_entity": "Optionele echte bereiksensor. Anders wordt het bereik geschat op basis van SOC × capaciteit × efficiëntie."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Zonne-overschot laadt tot deze waarde en stopt dan. Laat op vol staan om vrij op zon te laden.",
+          "ev_target_soc_max": "Zonne-overschot laadt tot deze SOC en stopt dan. Laat op 100% staan om vrij op zon te laden."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Zonne-laadlimiet (kWh)",
           "ev_target_soc_max": "Zonne-laadlimiet (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Zonne-overschot laadt tot deze waarde en stopt dan. Laat op vol staan om vrij op zon te laden.",
+          "ev_target_soc_max": "Zonne-overschot laadt tot deze SOC en stopt dan. Laat op 100% staan om vrij op zon te laden."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC-%-doel"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Het SEM-dashboard kon niet worden gegenereerd. Raadpleeg de Home Assistant-logboeken voor details."
+    },
+    "load_management_not_initialized": {
+      "message": "Lastbeheer is nog niet gereed. Wacht tot de integratie volledig is opgestart en probeer het opnieuw."
+    },
+    "device_registry_not_initialized": {
+      "message": "Het apparaatregister is nog niet gereed. Wacht tot de integratie volledig is opgestart en probeer het opnieuw."
+    },
+    "mapping_service_required": {
+      "message": "Bij besturingstype “service” is een service vereist. Geef een aan te roepen service op."
+    },
+    "mapping_entity_required": {
+      "message": "Voor dit besturingstype is een besturingsentiteit vereist. Geef een besturingsentiteit op."
+    },
+    "device_not_found": {
+      "message": "Apparaat “{device_id}” is niet gevonden."
+    },
+    "invalid_device_property": {
+      "message": "Ongeldige apparaateigenschap: “{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Ongeldig deadlineformaat: “{deadline}”. Gebruik de ISO 8601-notatie, bijvoorbeeld 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV-lader niet geconfigureerd",
+      "description": "Er zijn geen sensoren voor de EV-lader geconfigureerd, dus EV-laadfuncties zijn niet beschikbaar. Voeg in de integratieopties een “verbonden”-sensor of een laadvermogenssensor toe om EV-laden in te schakelen."
     }
   }
 }

--- a/translations/no.json
+++ b/translations/no.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
+          "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol.",
+          "ev_kwh_per_100km": "Brukes til å anslå rekkevidden når ingen rekkeviddesensor er konfigurert.",
+          "vehicle_range_entity": "Valgfri reell rekkeviddesensor. Ellers anslås rekkevidden fra SOC × kapasitet × effektivitet."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
+          "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Solladegrense (kWh)",
           "ev_target_soc_max": "Solladegrense (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
+          "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC-%-mål"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Kunne ikke generere SEM-dashbordet. Se Home Assistant-loggene for detaljer."
+    },
+    "load_management_not_initialized": {
+      "message": "Laststyringen er ikke klar ennå. Vent til integrasjonen er ferdig med å starte, og prøv igjen."
+    },
+    "device_registry_not_initialized": {
+      "message": "Enhetsregisteret er ikke klart ennå. Vent til integrasjonen er ferdig med å starte, og prøv igjen."
+    },
+    "mapping_service_required": {
+      "message": "En tjeneste kreves når styringstypen er «tjeneste». Angi en tjeneste som skal kalles."
+    },
+    "mapping_entity_required": {
+      "message": "En styringsentitet kreves for denne styringstypen. Angi en styringsentitet."
+    },
+    "device_not_found": {
+      "message": "Enheten «{device_id}» ble ikke funnet."
+    },
+    "invalid_device_property": {
+      "message": "Ugyldig enhetsegenskap: «{property}»."
+    },
+    "invalid_deadline_format": {
+      "message": "Ugyldig fristformat: «{deadline}». Bruk ISO 8601-format, for eksempel 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV-lader er ikke konfigurert",
+      "description": "Ingen sensorer for EV-laderen er konfigurert, så EV-ladefunksjonene er utilgjengelige. Legg til en «tilkoblet»-sensor eller en ladeeffektsensor i integrasjonsalternativene for å aktivere EV-lading."
     }
   }
 }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
+          "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca.",
+          "ev_kwh_per_100km": "Używane do szacowania zasięgu, gdy nie skonfigurowano czujnika zasięgu.",
+          "vehicle_range_entity": "Opcjonalny rzeczywisty czujnik zasięgu. W przeciwnym razie zasięg jest szacowany na podstawie SOC × pojemność × wydajność."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
+          "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limit ładowania słonecznego (kWh)",
           "ev_target_soc_max": "Limit ładowania słonecznego (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
+          "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Cel SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Nie udało się wygenerować pulpitu SEM. Szczegóły znajdziesz w dziennikach Home Assistant."
+    },
+    "load_management_not_initialized": {
+      "message": "Zarządzanie obciążeniem nie jest jeszcze gotowe. Poczekaj, aż integracja zakończy uruchamianie, i spróbuj ponownie."
+    },
+    "device_registry_not_initialized": {
+      "message": "Rejestr urządzeń nie jest jeszcze gotowy. Poczekaj, aż integracja zakończy uruchamianie, i spróbuj ponownie."
+    },
+    "mapping_service_required": {
+      "message": "Gdy typ sterowania to „usługa”, wymagana jest usługa. Podaj usługę do wywołania."
+    },
+    "mapping_entity_required": {
+      "message": "Dla tego typu sterowania wymagana jest encja sterująca. Podaj encję sterującą."
+    },
+    "device_not_found": {
+      "message": "Nie znaleziono urządzenia „{device_id}”."
+    },
+    "invalid_device_property": {
+      "message": "Nieprawidłowa właściwość urządzenia: „{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Nieprawidłowy format terminu: „{deadline}”. Użyj formatu ISO 8601, na przykład 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Ładowarka EV nie jest skonfigurowana",
+      "description": "Nie skonfigurowano żadnych czujników ładowarki EV, więc funkcje ładowania EV są niedostępne. Dodaj czujnik „podłączony” lub czujnik mocy ładowania w opcjach integracji, aby włączyć ładowanie EV."
     }
   }
 }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
+          "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol.",
+          "ev_kwh_per_100km": "Usado para estimar a autonomia quando não há um sensor de autonomia configurado.",
+          "vehicle_range_entity": "Sensor de autonomia real opcional. Caso contrário, a autonomia é estimada a partir de SOC × capacidade × eficiência."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
+          "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limite de carga solar (kWh)",
           "ev_target_soc_max": "Limite de carga solar (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
+          "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Meta SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Falha ao gerar o painel SEM. Consulte os registos do Home Assistant para mais detalhes."
+    },
+    "load_management_not_initialized": {
+      "message": "A gestão de carga ainda não está pronta. Aguarde que a integração termine de iniciar e tente novamente."
+    },
+    "device_registry_not_initialized": {
+      "message": "O registo de dispositivos ainda não está pronto. Aguarde que a integração termine de iniciar e tente novamente."
+    },
+    "mapping_service_required": {
+      "message": "É necessário um serviço quando o tipo de controlo é «serviço». Indique um serviço a chamar."
+    },
+    "mapping_entity_required": {
+      "message": "É necessária uma entidade de controlo para este tipo de controlo. Indique uma entidade de controlo."
+    },
+    "device_not_found": {
+      "message": "Dispositivo «{device_id}» não encontrado."
+    },
+    "invalid_device_property": {
+      "message": "Propriedade de dispositivo inválida: «{property}»."
+    },
+    "invalid_deadline_format": {
+      "message": "Formato de prazo inválido: «{deadline}». Use o formato ISO 8601, por exemplo 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Carregador de VE não configurado",
+      "description": "Não há sensores do carregador de VE configurados, por isso as funções de carregamento de VE estão indisponíveis. Adicione um sensor de «ligado» ou um sensor de potência de carregamento nas opções da integração para ativar o carregamento de VE."
     }
   }
 }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
+          "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare.",
+          "ev_kwh_per_100km": "Folosit pentru a estima autonomia când nu este configurat un senzor de autonomie.",
+          "vehicle_range_entity": "Senzor de autonomie real opțional. Altfel, autonomia este estimată din SOC × capacitate × eficiență."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
+          "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Limită încărcare solară (kWh)",
           "ev_target_soc_max": "Limită încărcare solară (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
+          "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "Țintă SoC %"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Generarea panoului SEM a eșuat. Consultați jurnalele Home Assistant pentru detalii."
+    },
+    "load_management_not_initialized": {
+      "message": "Gestionarea sarcinii nu este încă pregătită. Așteptați ca integrarea să termine pornirea și încercați din nou."
+    },
+    "device_registry_not_initialized": {
+      "message": "Registrul de dispozitive nu este încă pregătit. Așteptați ca integrarea să termine pornirea și încercați din nou."
+    },
+    "mapping_service_required": {
+      "message": "Este necesar un serviciu când tipul de control este „serviciu”. Indicați un serviciu de apelat."
+    },
+    "mapping_entity_required": {
+      "message": "Este necesară o entitate de control pentru acest tip de control. Indicați o entitate de control."
+    },
+    "device_not_found": {
+      "message": "Dispozitivul „{device_id}” nu a fost găsit."
+    },
+    "invalid_device_property": {
+      "message": "Proprietate de dispozitiv invalidă: „{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Format de termen invalid: „{deadline}”. Folosiți formatul ISO 8601, de exemplu 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "Încărcătorul EV nu este configurat",
+      "description": "Nu este configurat niciun senzor pentru încărcătorul EV, deci funcțiile de încărcare EV nu sunt disponibile. Adăugați un senzor „conectat” sau un senzor de putere de încărcare în opțiunile integrării pentru a activa încărcarea EV."
     }
   }
 }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -132,7 +132,11 @@
           "ev_total_energy_sensor": "Optional cumulative kWh counter for energy delivered to the vehicle.",
           "vehicle_soc_entity": "Optional sensor reporting the vehicle's current state of charge (0–100%).",
           "ev_battery_capacity_kwh": "Total usable capacity of the EV battery in kWh. Used to estimate SOC and charge time.",
-          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged."
+          "ev_target_soc": "Target SOC (%) at which SEM considers the EV fully charged.",
+          "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
+          "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen.",
+          "ev_kwh_per_100km": "Används för att uppskatta räckvidden när ingen räckviddssensor är konfigurerad.",
+          "vehicle_range_entity": "Valfri verklig räckviddssensor. Annars uppskattas räckvidden från SOC × kapacitet × verkningsgrad."
         }
       },
       "settings": {
@@ -361,13 +365,19 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers."
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
+          "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen."
         }
       },
       "ev_charger_add": {
         "data": {
           "daily_ev_target_max": "Solladdningsgräns (kWh)",
           "ev_target_soc_max": "Solladdningsgräns (SOC %)"
+        },
+        "data_description": {
+          "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
+          "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen."
         }
       }
     }
@@ -1139,6 +1149,38 @@
           "soc": "SoC-%-mål"
         }
       }
+    }
+  },
+  "exceptions": {
+    "dashboard_generation_failed": {
+      "message": "Det gick inte att generera SEM-instrumentpanelen. Se Home Assistant-loggarna för detaljer."
+    },
+    "load_management_not_initialized": {
+      "message": "Lasthanteringen är inte redo ännu. Vänta tills integrationen har startat klart och försök igen."
+    },
+    "device_registry_not_initialized": {
+      "message": "Enhetsregistret är inte redo ännu. Vänta tills integrationen har startat klart och försök igen."
+    },
+    "mapping_service_required": {
+      "message": "En tjänst krävs när styrtypen är ”tjänst”. Ange en tjänst att anropa."
+    },
+    "mapping_entity_required": {
+      "message": "En styrentitet krävs för den här styrtypen. Ange en styrentitet."
+    },
+    "device_not_found": {
+      "message": "Enheten ”{device_id}” hittades inte."
+    },
+    "invalid_device_property": {
+      "message": "Ogiltig enhetsegenskap: ”{property}”."
+    },
+    "invalid_deadline_format": {
+      "message": "Ogiltigt deadlineformat: ”{deadline}”. Använd ISO 8601-format, till exempel 2026-05-27T07:00:00."
+    }
+  },
+  "issues": {
+    "ev_charger_not_configured": {
+      "title": "EV-laddare ej konfigurerad",
+      "description": "Inga sensorer för EV-laddaren är konfigurerade, så EV-laddningsfunktionerna är inte tillgängliga. Lägg till en ”ansluten”-sensor eller en laddningseffektsensor i integrationsalternativen för att aktivera EV-laddning."
     }
   }
 }


### PR DESCRIPTION
Refs #245 #259

Audit of both translation systems found the **dashboard** side complete (777 keys × 15 langs) but three gaps on the **HA-native** side:

### 1. No `exceptions` / `issues` sections existed in any file (incl. en) — functional
The 8 `HomeAssistantError`/`ServiceValidationError` raises and the `ev_charger_not_configured` repair issue surfaced as **raw translation keys** in every language. This was the user-facing payoff of #259 (silent-failure surfacing). Added:
- `exceptions`: `dashboard_generation_failed`, `load_management_not_initialized`, `device_registry_not_initialized`, `mapping_service_required`, `mapping_entity_required`, `device_not_found` `{device_id}`, `invalid_device_property` `{property}`, `invalid_deadline_format` `{deadline}` — placeholders preserved.
- `issues`: `ev_charger_not_configured` (title + description).

### 2. #245 EV Min/Max config-flow help — only in en + de
The `data_description` strings (`daily_ev_target_max`, `ev_target_soc_max`, `ev_kwh_per_100km`, `vehicle_range_entity` across the `ev_charger`/`_add`/`_edit` steps) were missing in the other **13 languages**. Backfilled.

### 3. Stale key
Removed `options.step.settings.data.battery_min_discharge_power` lingering in de + fr only (not in en, not a real field).

### Verification
- All 15 files valid JSON; full leaf-key parity vs en (**552 keys**).
- Every `translation_key=` used in code now resolves to a definition.
- Hassfest (CI) validates the translation schema.