### PR TITLE
Release 1.5.15 — SolaX cold-start readings fix (#274)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,9 @@ All SEM entities are removed automatically. Your Energy Dashboard and hardware s
 
 ## Recent Improvements (v1.5.x)
 
+### v1.5.15 — Cold-start readings fix
+- **Readings start automatically after an HA restart** (#274) — SEM derives its real-time power sensors from the source integration's device. On a cold start it could run that derivation before the source integration (e.g. solax-modbus) had registered its entities, leaving every reading at 0 until you manually reloaded the integration. SEM now re-derives the power sensors each update cycle until they resolve, so the readings come up on their own within a cycle or two of the source loading — no reload needed. Bounded and a complete no-op for setups that already resolve normally.
+
 ### v1.5.14 — Multi-device cleanup, EV range targets & night-charge peak safety
 - **Night charging respects the peak limit** (#268) — night-charge current is now sized from the house load alone, so grid import stays ≤ your configured peak limit regardless of battery behaviour. Previously battery discharge could inflate the EV current and push grid import well past the limit.
 - **Per-charger is canonical** (#255) — duplicate global EV settings removed; per-charger entities (night charging, mode, phases, target, current) are the source of truth and globals become read-only summaries. Idempotent v3→v4 config migration.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -267,6 +267,16 @@ Update to SEM v1.2.0 or newer. This issue does not occur on v1.2.0+.
 
 ---
 
+## Values are 0 after an HA restart, but fine after reloading the integration (#274)
+
+**Symptom:** After restarting Home Assistant (soft or hard) the SEM readings stay at **0** / blank. Reloading the SEM integration (**Settings > Devices & Services > Solar Energy Management > ⋮ > Reload**) brings them right back. Reported for SolaX (`solax-modbus`).
+
+**Cause:** SEM derives its real-time power sensors from the source integration's *device* (see the section above). On a cold start, SEM can finish loading **before** the source integration (e.g. solax-modbus) has registered its entities, so that derivation finds nothing — leaving power at 0. A manual reload works because by then the source is fully loaded.
+
+**Fix (automatic):** As of v1.5.15, SEM keeps **re-deriving the power sensors on each update cycle** until they resolve, so the readings start on their own within a cycle or two of the source integration coming up — no manual reload needed. You'll see `Energy Dashboard power sensors resolved on attempt N — readings starting (#274)` in the log once it recovers. The retry is bounded, so an energy-only setup with no power sensor at all simply stops trying instead of looping.
+
+---
+
 ## Debug logging
 
 To enable detailed logging for SEM, add this to your `configuration.yaml`:

--- a/consts/core.py
+++ b/consts/core.py
@@ -8,6 +8,10 @@ DOMAIN: Final = "solar_energy_management"
 # ============================================
 DEFAULT_OBSERVER_MODE: Final = False  # When True, skip all hardware control (read-only monitoring)
 DEFAULT_UPDATE_INTERVAL: Final = 10  # seconds - 10 seconds for highly accurate energy integration
+# Cold-start recovery (#274): re-derive Energy Dashboard power sensors for this many
+# update cycles while they're still unresolved (source integration not yet registered),
+# then give up. ~40 cycles ≈ 7-20 min depending on update_interval.
+ED_RESOLVE_MAX_ATTEMPTS: Final = 40
 DEFAULT_POWER_DELTA: Final = 1000  # Watts - only major changes
 DEFAULT_CURRENT_DELTA: Final = 5  # Amps - significant current changes only
 DEFAULT_SOC_DELTA: Final = 10  # Percent - battery changes slowly anyway

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -28,6 +28,7 @@ from ..const import (
     DOMAIN,
     DEFAULT_UPDATE_INTERVAL,
     DEFAULT_BATTERY_CAPACITY_KWH,
+    ED_RESOLVE_MAX_ATTEMPTS,
     ChargingState,
     ENTITY_OBSERVER_MODE_SWITCH,
     ENTITY_SOLAR_POWER,
@@ -141,6 +142,10 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
 
         # Energy Dashboard config
         self._energy_dashboard_config: Optional[EnergyDashboardConfig] = None
+        # Cold-start recovery (#274): re-derive ED power sensors each cycle while
+        # they're unresolved (source integration registered after SEM), bounded.
+        self._ed_resolve_pending: bool = False
+        self._ed_resolve_attempts: int = 0
 
         # Phase 0: Surplus controller (always-on) & forecast reader
         regulation_offset = config.get("regulation_offset", 50)
@@ -452,8 +457,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         except (OSError, ValueError):
             return "0.0.0"
 
-    async def async_initialize_energy_dashboard(self) -> bool:
-        """Initialize sensors from HA Energy Dashboard."""
+    async def async_initialize_energy_dashboard(self, quiet: bool = False) -> bool:
+        """Initialize sensors from HA Energy Dashboard.
+
+        ``quiet`` demotes the routine INFO logs to DEBUG — used by the
+        cold-start re-derivation retry (#274) so it doesn't spam the log each
+        cycle while waiting for the source integration to register.
+        """
+        _info = _LOGGER.debug if quiet else _LOGGER.info
         try:
             dashboard_config = await read_energy_dashboard_config(self.hass)
 
@@ -465,14 +476,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             if dashboard_config and dashboard_config.is_minimally_configured():
                 self._energy_dashboard_config = dashboard_config
                 self._sensor_reader.set_energy_dashboard_config(dashboard_config)
-                _LOGGER.info(
+                _info(
                     f"Using Energy Dashboard sensors: "
                     f"solar={dashboard_config.solar_power}, "
                     f"grid={dashboard_config.grid_import_power}, "
                     f"battery={dashboard_config.battery_power}"
                 )
             else:
-                _LOGGER.info("Energy Dashboard not configured or incomplete")
+                _info("Energy Dashboard not configured or incomplete")
 
         except Exception as e:
             _LOGGER.warning("Failed to read Energy Dashboard: %s", e)
@@ -486,12 +497,54 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Log EV sensor configuration
         ev_power = self._sensor_reader.config.ev_power_sensor
         ed_ev = getattr(self._energy_dashboard_config, 'ev_power', None) if self._energy_dashboard_config else None
-        _LOGGER.info(
+        _info(
             "EV sensors: ed_power=%s, config_power=%s",
             ed_ev, ev_power,
         )
 
+        # Cold-start recovery flag (#274): if a source has an energy sensor but its
+        # real-time power sensor couldn't be derived yet (the source integration
+        # hadn't registered its entities when we ran), keep re-deriving each cycle.
+        self._ed_resolve_pending = bool(
+            self._energy_dashboard_config
+            and self._energy_dashboard_config.power_resolution_incomplete()
+        )
+
         return self._energy_dashboard_config is not None
+
+    async def _retry_energy_dashboard_resolution(self) -> None:
+        """Re-derive Energy Dashboard power sensors after a cold start (#274).
+
+        On HA restart SEM can run its power-sensor derivation before the source
+        integration (e.g. solax-modbus) has registered its entities, so the
+        device-registry lookup finds nothing and every reading sits at 0 until the
+        user manually reloads. Re-running the derivation each update cycle picks
+        the sensors up the moment the source registers — no reload needed.
+
+        Bounded by ``ED_RESOLVE_MAX_ATTEMPTS`` so a genuinely power-less setup
+        (energy-only sensors) stops retrying instead of re-reading the energy
+        prefs forever. ``async_initialize_energy_dashboard`` recomputes
+        ``_ed_resolve_pending``, so this clears itself the cycle it succeeds.
+        """
+        if self._ed_resolve_attempts >= ED_RESOLVE_MAX_ATTEMPTS:
+            self._ed_resolve_pending = False
+            _LOGGER.warning(
+                "Energy Dashboard power sensors still unresolved after %d attempts "
+                "— giving up (check the source integration is loaded). #274",
+                self._ed_resolve_attempts,
+            )
+            return
+        self._ed_resolve_attempts += 1
+        try:
+            await self.async_initialize_energy_dashboard(quiet=True)
+        except Exception as e:  # never let recovery break the update cycle
+            _LOGGER.debug("Energy Dashboard re-resolution attempt failed: %s", e)
+            return
+        if not self._ed_resolve_pending:
+            _LOGGER.info(
+                "Energy Dashboard power sensors resolved on attempt %d — "
+                "readings starting (#274)", self._ed_resolve_attempts,
+            )
 
     async def async_initialize_load_management(self, config_entry: ConfigEntry) -> None:
         """Initialize load management after coordinator is set up."""
@@ -630,6 +683,13 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                         self._cycle_vehicle_soc = float(_soc_state.state)
                     except (ValueError, TypeError):
                         _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", _vehicle_soc_entity, _soc_state.state)
+
+            # Cold-start recovery (#274): re-derive Energy Dashboard power sensors
+            # if they were unresolved at setup (source integration registered after
+            # SEM). Bounded; clears itself once resolved. Runs BEFORE reading so the
+            # very next read uses the recovered sensors.
+            if self._ed_resolve_pending:
+                await self._retry_energy_dashboard_resolution()
 
             # Step 1: Read power values from sensors
             power = self._sensor_reader.read_power()

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -466,7 +466,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         """
         _info = _LOGGER.debug if quiet else _LOGGER.info
         try:
-            dashboard_config = await read_energy_dashboard_config(self.hass)
+            dashboard_config = await read_energy_dashboard_config(self.hass, quiet=quiet)
 
             # Activate whenever the dashboard is minimally configured (solar + grid),
             # not only when a stat_rate power sensor exists. ha_energy_reader already

--- a/ha_energy_reader.py
+++ b/ha_energy_reader.py
@@ -159,22 +159,27 @@ class EnergyDashboardConfig:
         }
 
 
-async def read_energy_dashboard_config(hass: HomeAssistant) -> Optional[EnergyDashboardConfig]:
+async def read_energy_dashboard_config(
+    hass: HomeAssistant, quiet: bool = False,
+) -> Optional[EnergyDashboardConfig]:
     """Read sensor configuration from HA Energy Dashboard.
 
     Args:
         hass: Home Assistant instance
+        quiet: Demote routine INFO logs to DEBUG. Used by the cold-start
+            re-derivation retry (#274) so it doesn't spam the log each cycle.
 
     Returns:
         EnergyDashboardConfig with extracted sensor entity IDs, or None if not configured
     """
-    _LOGGER.info("Reading Energy Dashboard config from .storage/energy...")
+    _info = _LOGGER.debug if quiet else _LOGGER.info
+    _info("Reading Energy Dashboard config from .storage/energy...")
     try:
         energy_file = os.path.join(hass.config.config_dir, ".storage", "energy")
-        _LOGGER.info("Energy Dashboard file path: %s", energy_file)
+        _info("Energy Dashboard file path: %s", energy_file)
 
         if not os.path.exists(energy_file):
-            _LOGGER.info("Energy Dashboard not configured (file not found)")
+            _info("Energy Dashboard not configured (file not found)")
             return None
 
         # Read the energy configuration file
@@ -217,7 +222,7 @@ async def read_energy_dashboard_config(hass: HomeAssistant) -> Optional[EnergyDa
         # sensor on the same device as the configured energy sensor.
         _derive_missing_power_sensors(hass, config)
 
-        _LOGGER.info(
+        _info(
             "Read Energy Dashboard config: solar=%s (%d sources), grid=%s (%d import, %d export), battery=%s (%d units), ev=%s",
             config.has_solar, len(config.solar_power_list),
             config.has_grid, len(config.grid_import_energy_list), len(config.grid_export_energy_list),

--- a/ha_energy_reader.py
+++ b/ha_energy_reader.py
@@ -100,6 +100,32 @@ class EnergyDashboardConfig:
         """
         return self.has_solar and self.has_grid
 
+    def power_resolution_incomplete(self) -> bool:
+        """True when a source has an energy sensor but no resolved power sensor (#274).
+
+        Real-time power sensors are derived from the energy sensor's *device*
+        (``_derive_missing_power_sensors``). On a cold HA start SEM can run that
+        derivation before the source integration (e.g. solax-modbus) has
+        registered its entities, so nothing is found and SEM reads 0 until a
+        manual reload re-derives. The coordinator re-derives each cycle while
+        this is True, so the readings start on their own.
+
+        Solar (always a single combined PV sensor) and battery are used as the
+        canary. Grid is intentionally excluded — split-grid setups (Growatt,
+        DSMR) resolve grid power via a separate runtime discovery, never here, so
+        a missing ``grid_import_power`` is normal for them and must not trigger
+        endless re-derivation. The source entities all register together, so
+        fixing solar/battery implies the registry is ready and grid re-derives in
+        the same pass.
+        """
+        if not self.is_minimally_configured():
+            return False
+        battery_energy = self.battery_charge_energy or self.battery_discharge_energy
+        return bool(
+            (self.solar_energy and not self.solar_power)
+            or (battery_energy and not self.battery_power)
+        )
+
     def get_missing_components(self) -> List[str]:
         """Return list of missing required components."""
         missing = []

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.14"
+  "version": "1.5.15"
 }

--- a/tests/test_cold_start_recovery.py
+++ b/tests/test_cold_start_recovery.py
@@ -1,0 +1,85 @@
+"""Cold-start recovery for Energy Dashboard power sensors (#274).
+
+On HA restart SEM can derive its real-time power sensors before the source
+integration (e.g. solax-modbus) has registered its entities, so every reading
+sits at 0 until a manual reload. The coordinator re-derives each update cycle
+while resolution is incomplete; these tests cover that retry loop.
+"""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator import SEMCoordinator
+from custom_components.solar_energy_management.const import ED_RESOLVE_MAX_ATTEMPTS
+
+
+def _coord():
+    with patch.object(SEMCoordinator, "__init__", return_value=None):
+        c = SEMCoordinator.__new__(SEMCoordinator)
+    c._ed_resolve_pending = True
+    c._ed_resolve_attempts = 0
+    return c
+
+
+@pytest.mark.asyncio
+async def test_resolves_on_later_attempt():
+    """Pending clears the cycle the source integration finally registers."""
+    c = _coord()
+    calls = {"n": 0}
+
+    async def fake_init(quiet=False):
+        calls["n"] += 1
+        # Source registers on the 3rd attempt → derivation now succeeds.
+        c._ed_resolve_pending = calls["n"] < 3
+
+    c.async_initialize_energy_dashboard = AsyncMock(side_effect=fake_init)
+
+    for _ in range(5):
+        if c._ed_resolve_pending:
+            await c._retry_energy_dashboard_resolution()
+
+    assert c._ed_resolve_pending is False
+    assert c._ed_resolve_attempts == 3          # stopped retrying once resolved
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_attempts():
+    """A genuinely power-less setup stops retrying instead of looping forever."""
+    c = _coord()
+
+    async def never_resolves(quiet=False):
+        c._ed_resolve_pending = True  # still incomplete every time
+
+    c.async_initialize_energy_dashboard = AsyncMock(side_effect=never_resolves)
+
+    # Drive more cycles than the cap; the loop must terminate.
+    for _ in range(ED_RESOLVE_MAX_ATTEMPTS + 5):
+        if c._ed_resolve_pending:
+            await c._retry_energy_dashboard_resolution()
+
+    assert c._ed_resolve_pending is False               # gave up
+    assert c._ed_resolve_attempts == ED_RESOLVE_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_init_exception_does_not_break_cycle():
+    """A failure inside re-derivation must not raise into the update loop."""
+    c = _coord()
+    c.async_initialize_energy_dashboard = AsyncMock(side_effect=RuntimeError("boom"))
+    await c._retry_energy_dashboard_resolution()  # must not raise
+    assert c._ed_resolve_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_uses_quiet_logging():
+    """Re-derivation calls init with quiet=True to avoid per-cycle log spam."""
+    c = _coord()
+
+    async def ok(quiet=False):
+        assert quiet is True
+        c._ed_resolve_pending = False
+
+    c.async_initialize_energy_dashboard = AsyncMock(side_effect=ok)
+    await c._retry_energy_dashboard_resolution()
+    c.async_initialize_energy_dashboard.assert_awaited_once_with(quiet=True)

--- a/tests/test_ha_energy_reader.py
+++ b/tests/test_ha_energy_reader.py
@@ -79,6 +79,50 @@ class TestEnergyDashboardConfig:
         missing = config.get_missing_components()
         assert missing == ["Grid"]
 
+    # --- power_resolution_incomplete (#274 cold-start recovery) ---
+
+    def test_power_incomplete_when_solar_power_unresolved(self):
+        # Solar energy sensor present but power not yet derived (source integration
+        # not registered at cold start) → incomplete → coordinator keeps re-deriving.
+        config = EnergyDashboardConfig(
+            has_solar=True, has_grid=True,
+            solar_energy="sensor.solax_pv_energy_total", solar_power=None,
+            grid_import_power="sensor.solax_grid_power",
+        )
+        assert config.power_resolution_incomplete() is True
+
+    def test_power_complete_when_solar_power_resolved(self):
+        config = EnergyDashboardConfig(
+            has_solar=True, has_grid=True,
+            solar_energy="sensor.solax_pv_energy_total",
+            solar_power="sensor.solax_pv_power_total",
+            grid_import_power="sensor.solax_grid_power",
+        )
+        assert config.power_resolution_incomplete() is False
+
+    def test_power_incomplete_when_battery_power_unresolved(self):
+        config = EnergyDashboardConfig(
+            has_solar=True, has_grid=True,
+            solar_power="sensor.pv_power",
+            battery_charge_energy="sensor.batt_charge_energy", battery_power=None,
+        )
+        assert config.power_resolution_incomplete() is True
+
+    def test_power_complete_ignores_missing_grid_power_for_split_grid(self):
+        # Split-grid setups resolve grid power via runtime discovery, not here —
+        # a missing grid_import_power must NOT trigger endless re-derivation.
+        config = EnergyDashboardConfig(
+            has_solar=True, has_grid=True,
+            solar_power="sensor.pv_power",
+            grid_import_energy="sensor.grid_import_energy", grid_import_power=None,
+        )
+        assert config.power_resolution_incomplete() is False
+
+    def test_power_complete_when_not_minimally_configured(self):
+        config = EnergyDashboardConfig(has_solar=True, has_grid=False,
+                                       solar_energy="s", solar_power=None)
+        assert config.power_resolution_incomplete() is False
+
     def test_config_to_dict(self):
         config = EnergyDashboardConfig(
             solar_power="sensor.solar_power",


### PR DESCRIPTION
## Summary
Patch release **1.5.15**. Contains only the #274 fix on top of 1.5.14 (develop was in sync with main).

Fixes #274

## The bug
After an HA restart, SEM's readings stayed at **0** until the user manually reloaded the integration. Reported on SolaX (`solax-modbus`).

**Root cause:** SEM derives its real-time power sensors from the source integration's *device* (entity/device registry) once at setup. On a cold start it can run that derivation **before** the source integration has registered its entities → nothing is found → readings stay 0 until a manual reload re-derives them.

## The fix
SEM now **re-derives the Energy Dashboard power sensors each update cycle while resolution is incomplete**, so the readings start on their own within a cycle or two of the source integration loading — no reload needed.

- `EnergyDashboardConfig.power_resolution_incomplete()` — solar/battery canary (grid excluded so split-grid setups, which resolve grid power via separate runtime discovery, don't churn).
- Bounded by `ED_RESOLVE_MAX_ATTEMPTS` (40) — an energy-only setup with no derivable power sensor stops retrying instead of looping.
- Self-clears the cycle it resolves; `quiet=` keeps retries out of the log.
- **Zero behavior change** for users who already resolve normally or use manual sensor config.

## Tests / review
- 1958 tests pass (9 new: cold-start recovery loop + incomplete-detection). 
- Independent review: all-SAFE across zero-config behavior, split-grid false-positives, retry-loop correctness, mid-session re-run safety, event-loop blocking.
- TROUBLESHOOTING entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)