### PR TITLE
#277 Phase A: Charge mode selector + v4→v5 migration

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -77,6 +77,17 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
         entry.version, entry.minor_version
     )
 
+    # Accumulators threaded across all migration steps. Each step starts
+    # from these (not from ``entry.options`` / ``entry.data``) so a
+    # multi-version upgrade (e.g. v3 → v5 in one call) doesn't lose the
+    # earlier step's mutations. Pre-#277 each step read ``entry.options``
+    # afresh; in real HA ``async_update_entry`` mutates the entry and the
+    # next read picks up the change, but in tests (and in any harness
+    # mocking the entry) the second step then overwrote the first. The
+    # explicit accumulator makes the chain deterministic on both paths.
+    accumulated_data = {**entry.data}
+    accumulated_options = {**entry.options}
+
     if entry.version < 2:
         try:
             from .consts.core import (
@@ -85,8 +96,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
                 DEFAULT_BATTERY_ASSIST_FLOOR_SOC,
             )
 
-            new_data = {**entry.data}
-            new_options = {**entry.options}
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
             legacy_priority = max(
                 new_options.get("battery_priority_soc") if new_options.get("battery_priority_soc") is not None else 0,
                 new_data.get("battery_priority_soc") if new_data.get("battery_priority_soc") is not None else 0,
@@ -117,6 +128,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
                 version=2,
                 minor_version=1,
             )
+            accumulated_data, accumulated_options = new_data, new_options
         except Exception as e:
             _LOGGER.error(
                 "Migration from v%s failed — keeping original config: %s",
@@ -127,8 +139,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
     if entry.version < 3:
         try:
             # v2 → v3: Wrap flat ev_* keys into ev_chargers list for multi-charger support
-            new_data = {**entry.data}
-            new_options = {**entry.options}
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
             full = {**new_data, **new_options}
 
             # Only migrate if flat EV keys exist and ev_chargers doesn't
@@ -163,6 +175,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
                 version=3,
                 minor_version=1,
             )
+            accumulated_data, accumulated_options = new_data, new_options
         except Exception as e:
             _LOGGER.error(
                 "Migration from v%s to v3 failed — keeping original config: %s",
@@ -187,8 +200,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
                 # #246 Phase 2 — per-charger charge-by deadline
                 "ev_target_time",
             )
-            new_data = {**entry.data}
-            new_options = {**entry.options}
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
             full = {**new_data, **new_options}
             chargers = new_options.get("ev_chargers", new_data.get("ev_chargers"))
             if isinstance(chargers, list):
@@ -209,6 +222,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
                 entry, data=new_data, options=new_options,
                 version=4, minor_version=1,
             )
+            accumulated_data, accumulated_options = new_data, new_options
         except Exception as e:
             _LOGGER.error(
                 "Migration from v%s to v4 failed — keeping original config: %s",
@@ -216,8 +230,114 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
             )
             return False
 
+    if entry.version < 5:
+        try:
+            # v4 → v5 (#277 Phase A): seed per-charger ``charge_mode`` from
+            # the existing toggle state. The new selector is the consolidated
+            # user-intent layer that will replace the four-toggle UX in
+            # Phase B; here we just derive the equivalent named mode so the
+            # selector reflects the user's actual current behaviour on first
+            # boot post-upgrade. Legacy toggles are kept unchanged — they
+            # remain authoritative for the strategy machine until Phase B
+            # makes ``charge_mode`` the source of truth.
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
+            full = {**new_data, **new_options}
+            chargers = new_options.get("ev_chargers", new_data.get("ev_chargers"))
+            if isinstance(chargers, list):
+                seeded = []
+                for c in chargers:
+                    c = dict(c) if isinstance(c, dict) else c
+                    if isinstance(c, dict) and c.get("charge_mode") is None:
+                        c["charge_mode"] = _derive_charge_mode(
+                            c, full, hass,
+                        )
+                        _LOGGER.info(
+                            "Charger %s: derived charge_mode=%s from legacy toggles",
+                            c.get("id", "ev_charger"), c["charge_mode"],
+                        )
+                    seeded.append(c)
+                new_options["ev_chargers"] = seeded
+
+            hass.config_entries.async_update_entry(
+                entry, data=new_data, options=new_options,
+                version=5, minor_version=1,
+            )
+            accumulated_data, accumulated_options = new_data, new_options
+        except Exception as e:
+            _LOGGER.error(
+                "Migration from v%s to v5 failed — keeping original config: %s",
+                entry.version, e,
+            )
+            return False
+
     _LOGGER.info("Migration to version %s.%s done", entry.version, entry.minor_version)
     return True
+
+
+def _derive_charge_mode(
+    charger_cfg: dict,
+    full_config: dict,
+    hass: HomeAssistant,
+) -> str:
+    """Derive a Charge mode (#277) from the legacy four-toggle state.
+
+    Decision tree (matches ``docs/plans/2026-05-30_ev_charge_mode_consolidation.md``):
+        ev_charging_mode == "now"             → always_max
+        ev_charging_mode == "off"             → off
+        ev_charging_mode == "auto" + tariff   → solar_plus_cheap
+        ev_charging_mode in (pv, auto) + no night → solar_only
+        otherwise                              → min_plus_solar  (catch-all default)
+
+    Reads the per-charger switch state where available (the canonical
+    location since #255) and falls back to the global / config dict
+    for legacy installs. The two switches we consult are
+    ``switch.sem_charger_<id>_night_charging`` and
+    ``switch.sem_charger_<id>_tariff_optimized``. If a switch hasn't
+    been created yet (cold migration before the platform sets up),
+    we default to ON for night (the factory default) and OFF for
+    tariff (the factory default).
+    """
+    cid = charger_cfg.get("id", "ev_charger")
+
+    # ev_charging_mode is canonical per-charger as of v4 (#255).
+    mode = (
+        charger_cfg.get("ev_charging_mode")
+        or full_config.get("ev_charging_mode")
+        or "pv"
+    )
+
+    # Night switch — per-charger canonical, fall back to global, then
+    # to the factory default (ON).
+    night_eid = f"switch.sem_charger_{cid}_night_charging"
+    if hass.states.get(night_eid) is not None:
+        night = hass.states.is_state(night_eid, "on")
+    elif hass.states.get("switch.sem_night_charging") is not None:
+        night = hass.states.is_state("switch.sem_night_charging", "on")
+    else:
+        night = True  # factory default
+
+    # Tariff switch — per-charger only; the global was never created.
+    # Default OFF when missing (the factory default).
+    tariff_eid = f"switch.sem_charger_{cid}_tariff_optimized"
+    if hass.states.get(tariff_eid) is not None:
+        tariff = hass.states.is_state(tariff_eid, "on")
+    else:
+        tariff = False
+
+    if mode == "now":
+        return "always_max"
+    if mode == "off":
+        return "off"
+    if mode == "auto" and tariff:
+        return "solar_plus_cheap"
+    if mode in ("pv", "auto", "self_consumption") and not night:
+        return "solar_only"
+    # Catch-all — covers minpv (which always pulls Min from grid, so
+    # never maps to solar_only regardless of night flag) and any
+    # unrecognised mode value.
+    from .consts.ev_charge_modes import DEFAULT_EV_CHARGE_MODE
+    return DEFAULT_EV_CHARGE_MODE
 
 
 def _migrate_limit_surplus_to_max(hass: HomeAssistant, entry: SEMConfigEntry) -> None:

--- a/config_flow.py
+++ b/config_flow.py
@@ -139,8 +139,8 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Solar Energy Management."""
 
     # v4 (#255): per-charger settings seeded from globals (async_migrate_entry).
-    # (Was 2 while async_migrate_entry already emitted v3 — corrected to match.)
-    VERSION = 4
+    # v5 (#277 Phase A): per-charger charge_mode derived from legacy toggles.
+    VERSION = 5
 
     @staticmethod
     @callback

--- a/consts/ev_charge_modes.py
+++ b/consts/ev_charge_modes.py
@@ -1,0 +1,27 @@
+"""Canonical EV Charge mode names (#277 Phase A).
+
+The five consolidated user-intent modes that replace the four-toggle
+soup (``ev_charging_mode`` × ``night_charging`` × ``tariff_optimized``
+× ``smart_night_charging``). See
+``docs/plans/2026-05-30_ev_charge_mode_consolidation.md`` for the
+mapping table and migration semantics.
+
+Lives in ``consts/`` so both ``select.py`` (entity registration) and
+``coordinator/coordinator.py`` (read-side helper) can import it
+without circular dependencies — the duplicated hardcoded mode-name
+tuple flagged by the Phase A reviewer goes away.
+"""
+from __future__ import annotations
+
+# Order matters: it's the order shown in the HA select UI.
+EV_CHARGE_MODES: dict[str, str] = {
+    "solar_only": "Solar only",
+    "solar_plus_cheap": "Solar + cheapest hours",
+    "min_plus_solar": "Min + Solar",
+    "always_max": "Always (max)",
+    "off": "Off",
+}
+
+# The new-install default. Q4 resolved 2026-05-30 — matches today's
+# factory defaults (mode=pv + night=on + smart=on + tariff=off).
+DEFAULT_EV_CHARGE_MODE: str = "min_plus_solar"

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -334,6 +334,67 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             if pc.get(key) is not None:
                 self.config[key] = pc[key]
 
+    def _effective_charge_mode_for(self, charger_cfg: dict) -> str:
+        """Resolve the user-intent Charge mode for one charger (#277 Phase A).
+
+        Reads ``charger_cfg["charge_mode"]`` when present (post-v5 migration
+        or after a user picks one in the new selector). When absent, derives
+        the equivalent named mode from the legacy four-toggle state so the
+        coordinator's strategy machine always sees a single canonical name.
+
+        **Phase A is read-only.** This helper is exposed for tests and for
+        Phase B to switch authority on — no caller in production reads it
+        yet, so behaviour is identical to v1.6.2. Phase B will route
+        ``_determine_charging_strategy`` through this helper and gate the
+        legacy field reads behind a "mode is missing" fallback. Phase C
+        deletes the fallback once the v1.7.0 soak proves the new path.
+
+        Returns one of ``EV_CHARGE_MODES`` keys; never raises.
+        """
+        from ..consts.ev_charge_modes import (
+            DEFAULT_EV_CHARGE_MODE,
+            EV_CHARGE_MODES,
+        )
+
+        if not isinstance(charger_cfg, dict):
+            return DEFAULT_EV_CHARGE_MODE
+
+        stored = charger_cfg.get("charge_mode")
+        if stored in EV_CHARGE_MODES:
+            return stored
+
+        # No stored mode (pre-migration / partially-configured install) —
+        # derive it on the fly from the same legacy toggles
+        # ``_derive_charge_mode`` reads at migration time. Inline rather
+        # than importing __init__._derive_charge_mode to avoid circulars.
+        cid = charger_cfg.get("id", "ev_charger")
+        mode = (
+            charger_cfg.get("ev_charging_mode")
+            or self.config.get("ev_charging_mode")
+            or "pv"
+        )
+        night_eid = f"switch.sem_charger_{cid}_night_charging"
+        if self.hass.states.get(night_eid) is not None:
+            night = self.hass.states.is_state(night_eid, "on")
+        elif self.hass.states.get("switch.sem_night_charging") is not None:
+            night = self.hass.states.is_state("switch.sem_night_charging", "on")
+        else:
+            night = True
+        tariff_eid = f"switch.sem_charger_{cid}_tariff_optimized"
+        tariff = self.hass.states.is_state(tariff_eid, "on") if (
+            self.hass.states.get(tariff_eid) is not None
+        ) else False
+
+        if mode == "now":
+            return "always_max"
+        if mode == "off":
+            return "off"
+        if mode == "auto" and tariff:
+            return "solar_plus_cheap"
+        if mode in ("pv", "auto", "self_consumption") and not night:
+            return "solar_only"
+        return DEFAULT_EV_CHARGE_MODE
+
     def _smart_night_charging_enabled(self) -> bool:
         """True if smart (forecast-aware) night charging is on for any charger (#255).
 

--- a/docs/plans/2026-05-30_ev_charge_mode_consolidation.md
+++ b/docs/plans/2026-05-30_ev_charge_mode_consolidation.md
@@ -24,9 +24,9 @@ Charge-by deadline:
 
 | Mode | Daytime behaviour | Night behaviour | Replaces toggle combo |
 |---|---|---|---|
-| **`solar_only`** | Surplus only (no grid backfill) | No charging | `mode=auto/minpv` + night=off + tariff=off |
+| **`solar_only`** | Surplus only (no grid backfill) | No charging | `mode=auto/pv/self_consumption` + night=off + tariff=off |
 | **`solar_plus_cheap`** | Surplus by day, grid in cheapest tariff windows | Charge in cheapest windows up to Min | `mode=auto` + tariff=on + night=on |
-| **`min_plus_solar`** (default) | Min from grid + solar to Max | Top up to Min from grid | `mode=minpv` + night=on |
+| **`min_plus_solar`** (default) | Min from grid + solar to Max | Top up to Min from grid | `mode=minpv` (any night state — minpv always pulls Min from grid) |
 | **`always_max`** | Charge at max regardless | Charge at max regardless | `mode=now` |
 | **`off`** | No charging | No charging | `mode=off` (or night=off + mode=off) |
 
@@ -67,9 +67,9 @@ def _derive_charge_mode(charger_cfg) -> str:
         return "off"
     if mode == "auto" and tariff:
         return "solar_plus_cheap"
-    if mode in ("pv", "self_consumption") and not night:
+    if mode in ("pv", "auto", "self_consumption") and not night:
         return "solar_only"
-    return "min_plus_solar"  # the catch-all default
+    return "min_plus_solar"  # the catch-all default — covers minpv (always grid-Min)
 ```
 
 For HACS upgrade users, the migration:
@@ -109,21 +109,28 @@ they become read-only mirrors of the new mode.
   rollback chance), drop the legacy switches from `switch.py`.
 - The fallback path in the coordinator goes away.
 
-## Open questions before coding
+## Resolved design questions (2026-05-30)
 
-1. **`solar_plus_cheap` semantics for non-tariff users:** if the user
-   has no dynamic-tariff configured, this mode degrades to
-   `solar_only`. Acceptable? Or should we hide the option entirely?
-2. **Battery assist in `min_plus_solar`:** should Z4 battery_assist
-   always be available, or gated by a separate "use battery for EV"
-   toggle? Current proposal: always available; this matches today's
-   behaviour where Auto+Z4 → battery_assist.
-3. **Smart night being implicit:** users who actively want to disable
-   forecast-aware skipping have no way to do so in the new UX. Keep
-   the existing `smart_night_charging` toggle visible? Hide it but
-   keep functional?
-4. **Default for new installs:** `min_plus_solar` matches the current
-   factory defaults (`pv` + night=on + smart=on + tariff=off). Agreed?
+Maintainer answered before Phase A started:
+
+1. **`solar_plus_cheap` semantics for non-tariff users:** **Hide the
+   option entirely** when no dynamic tariff is configured. The mode
+   appears in the selector only when a tariff is present. Cleanest
+   UX — no ghost modes; "why isn't it charging at night?" cannot
+   arise. Selector population is dynamic (recomputed on tariff add /
+   remove).
+2. **Battery assist in `min_plus_solar`:** **Always available** when
+   SOC ≥ floor. No new toggle. Matches today's Auto+Z4 behaviour;
+   no re-introduction of the toggle-soup.
+3. **Smart night being implicit:** **Hide the toggle.** Forecast-
+   aware skip / size-down is strictly better than dumb-on-at-
+   midnight; no value in user disablement. Smart is implicitly ON
+   for `min_plus_solar` and `solar_plus_cheap`, N/A for the others.
+   The existing `smart_night_charging` switch becomes hidden + dead
+   (kept registered for automation backward-compat, but read-only).
+4. **Default for new installs:** **`min_plus_solar`** — matches the
+   current factory defaults (`pv` + night=on + smart=on + tariff=
+   off). Zero behaviour change for new installs.
 
 ## Why this lands cleanly on top of v1.6.0
 
@@ -155,10 +162,10 @@ they become read-only mirrors of the new mode.
 Realistic ship target: **v1.7.0** in a focused 2–3 day window after
 v1.6.0 has soaked.
 
-## Decision needed from maintainer
+## Decisions confirmed
 
-Before I write any code for Phase A:
+- Five-mode taxonomy: confirmed.
+- Open questions 1–4: resolved (see "Resolved design questions" above).
+- `v1.7.0` ship target: confirmed.
 
-1. Confirm the five-mode taxonomy.
-2. Resolve open questions 1–4 above.
-3. Confirm `v1.7.0` ship target (vs deferred indefinitely).
+Phase A in progress on branch `feature/277-charge-mode-phase-a`.

--- a/select.py
+++ b/select.py
@@ -35,6 +35,24 @@ EV_TARGET_TYPES = {
     "soc": "SOC % target",
 }
 
+# #277 Phase A — consolidated Charge mode selector. Replaces the
+# four-toggle combinatorial UX (``ev_charging_mode`` ×
+# ``night_charging`` × ``tariff_optimized`` × ``smart_night_charging``)
+# with one named intent per charger. See
+# ``docs/plans/2026-05-30_ev_charge_mode_consolidation.md`` for the
+# full mapping, migration rules, and resolved design questions.
+#
+# ``solar_plus_cheap`` is conditionally hidden when no dynamic tariff
+# is configured — the option appears automatically when the user adds
+# a tariff. Maintainer decision Q1, 2026-05-30. Constant lives in
+# ``consts/ev_charge_modes.py`` so the coordinator's read-side helper
+# imports the same source of truth (no duplicated tuple in
+# ``coordinator/coordinator.py``).
+from .consts.ev_charge_modes import (
+    DEFAULT_EV_CHARGE_MODE,
+    EV_CHARGE_MODES,
+)
+
 SELECT_TYPES = [
     # ev_charging_mode and ev_target_type are PER-CHARGER only (#255) — the global
     # duplicates were removed (seeded per-charger by the v3→v4 migration). The old
@@ -104,6 +122,24 @@ async def async_setup_entry(
                 entry, cid, "ev_charging_mode",
                 charger_cfg.get("ev_charging_mode")
                 or full_config.get("ev_charging_mode") or "pv",
+            ))
+            # Per-charger Charge mode selector (#277 Phase A) — the
+            # consolidated user-intent selector that will replace the
+            # toggle-soup in Phase B. Phase A is additive only: the
+            # entity persists user intent but the coordinator strategy
+            # machine still reads the legacy toggles. The migration in
+            # ``async_migrate_entry`` (v4 → v5) seeds the field from
+            # existing toggle state so the value the user sees matches
+            # the behaviour they already have.
+            entities.append(SEMPerChargerSelect(
+                coordinator,
+                SelectEntityDescription(
+                    key=f"charger_{cid}_charge_mode",
+                    options=list(EV_CHARGE_MODES.keys()),
+                    entity_category=EntityCategory.CONFIG,
+                ),
+                entry, cid, "charge_mode",
+                charger_cfg.get("charge_mode") or DEFAULT_EV_CHARGE_MODE,
             ))
 
     async_add_entities(entities)
@@ -257,6 +293,8 @@ class SEMPerChargerSelect(CoordinatorEntity, SelectEntity):
             return set(EV_TARGET_TYPES.keys())
         if self._config_key == "ev_charging_mode":
             return set(EV_CHARGING_MODES.keys())
+        if self._config_key == "charge_mode":
+            return set(EV_CHARGE_MODES.keys())
         # Future selects: trust the description's declared options.
         return set(self.entity_description.options or [])
 
@@ -266,7 +304,10 @@ class SEMPerChargerSelect(CoordinatorEntity, SelectEntity):
 
         For ``ev_target_type``: SOC % only when this charger has a
         vehicle_soc_entity configured (#235). For ``ev_charging_mode``:
-        the full mode set always. For unknown keys: pass through what the
+        the full mode set always. For ``charge_mode`` (#277): hide
+        ``solar_plus_cheap`` when no dynamic tariff is configured —
+        users without a tariff should not see a ghost option that
+        silently degrades. For unknown keys: pass through what the
         description declared.
         """
         if self._config_key == "ev_target_type":
@@ -274,6 +315,14 @@ class SEMPerChargerSelect(CoordinatorEntity, SelectEntity):
             return _target_type_options(has_soc)
         if self._config_key == "ev_charging_mode":
             return list(EV_CHARGING_MODES.keys())
+        if self._config_key == "charge_mode":
+            has_dyn_tariff = (
+                self.coordinator.config.get("tariff_mode") == "dynamic"
+            )
+            return [
+                m for m in EV_CHARGE_MODES.keys()
+                if has_dyn_tariff or m != "solar_plus_cheap"
+            ]
         return list(self.entity_description.options or [])
 
     @property

--- a/tests/test_277_charge_mode_phase_a.py
+++ b/tests/test_277_charge_mode_phase_a.py
@@ -1,0 +1,415 @@
+"""Unit tests for #277 Phase A — Charge mode selector + migration.
+
+Phase A is purely additive:
+  - A new per-charger ``select.sem_charger_<id>_charge_mode`` entity
+    persists the user's named intent.
+  - ``async_migrate_entry`` v4 → v5 derives the field from existing
+    legacy toggle state on first upgrade boot.
+  - ``SEMCoordinator._effective_charge_mode_for`` exposes the resolved
+    mode (stored value first, derived from legacy toggles second) so
+    Phase B has a single read point to switch authority on.
+  - The coordinator's strategy machine still reads the legacy toggles —
+    behaviour is unchanged from v1.6.2.
+
+These tests pin the four moving pieces:
+  1. ``_derive_charge_mode`` — the migration's decision tree
+  2. ``SEMPerChargerSelect`` options behaviour (Q1: hide
+     ``solar_plus_cheap`` when no dynamic tariff)
+  3. The full migration loop in ``async_migrate_entry``
+  4. ``_effective_charge_mode_for`` equivalence (stored vs derived)
+"""
+import json
+from unittest.mock import MagicMock, AsyncMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management import _derive_charge_mode
+from custom_components.solar_energy_management.coordinator import SEMCoordinator
+from custom_components.solar_energy_management.select import (
+    EV_CHARGE_MODES,
+    SEMPerChargerSelect,
+)
+
+
+# ──────────────────────────────────────────────────────────────────────
+# _derive_charge_mode — migration decision tree
+# ──────────────────────────────────────────────────────────────────────
+
+def _hass_with_switches(*, night=None, tariff=None, charger_id="ev_charger"):
+    """Build a hass stub whose ``states.get`` / ``states.is_state`` answer
+    only for the per-charger switches we care about. Pass ``None`` to
+    simulate "switch entity not registered yet" (cold migration window)."""
+    hass = MagicMock()
+    night_eid = f"switch.sem_charger_{charger_id}_night_charging"
+    tariff_eid = f"switch.sem_charger_{charger_id}_tariff_optimized"
+
+    def states_get(eid):
+        if eid == night_eid and night is not None:
+            return MagicMock(state="on" if night else "off")
+        if eid == tariff_eid and tariff is not None:
+            return MagicMock(state="on" if tariff else "off")
+        return None
+
+    def is_state(eid, state):
+        st = states_get(eid)
+        return st is not None and st.state == state
+
+    hass.states.get = states_get
+    hass.states.is_state = is_state
+    return hass
+
+
+class TestDeriveChargeMode:
+    """Migration's per-charger mode derivation. Five mode outputs ×
+    each of the legacy toggle inputs that produces it."""
+
+    def test_now_maps_to_always_max(self):
+        cfg = {"id": "ev_charger", "ev_charging_mode": "now"}
+        hass = _hass_with_switches(night=True, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "always_max"
+
+    def test_off_maps_to_off(self):
+        cfg = {"id": "ev_charger", "ev_charging_mode": "off"}
+        hass = _hass_with_switches(night=True, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "off"
+
+    def test_auto_plus_tariff_maps_to_solar_plus_cheap(self):
+        """The user's intent when they had Auto + tariff_optimized=on
+        was 'use cheapest hours' — name it explicitly."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "auto"}
+        hass = _hass_with_switches(night=True, tariff=True)
+        assert _derive_charge_mode(cfg, {}, hass) == "solar_plus_cheap"
+
+    def test_pv_without_night_maps_to_solar_only(self):
+        """Factory legacy default was mode=pv. With night=off the user
+        explicitly opted out of grid top-up → solar_only."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "pv"}
+        hass = _hass_with_switches(night=False, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "solar_only"
+
+    def test_auto_without_night_maps_to_solar_only(self):
+        cfg = {"id": "ev_charger", "ev_charging_mode": "auto"}
+        hass = _hass_with_switches(night=False, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "solar_only"
+
+    def test_self_consumption_without_night_maps_to_solar_only(self):
+        """Legacy strategy text that ev_charging_mode briefly used."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "self_consumption"}
+        hass = _hass_with_switches(night=False, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "solar_only"
+
+    def test_factory_default_maps_to_min_plus_solar(self):
+        """The catch-all default — matches today's factory defaults
+        (mode=pv + night=on + smart=on + tariff=off). Q4 decision."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "pv"}
+        hass = _hass_with_switches(night=True, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "min_plus_solar"
+
+    def test_minpv_maps_to_min_plus_solar(self):
+        """Explicit Min+PV (the legacy entry-point for grid+solar) maps
+        cleanly to the same named mode."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "minpv"}
+        hass = _hass_with_switches(night=True, tariff=False)
+        assert _derive_charge_mode(cfg, {}, hass) == "min_plus_solar"
+
+    def test_missing_night_switch_defaults_to_on(self):
+        """Cold migration window: switch entities not yet created.
+        Default is factory ON to match new-install behaviour."""
+        cfg = {"id": "ev_charger", "ev_charging_mode": "pv"}
+        hass = _hass_with_switches(night=None, tariff=None)  # missing
+        # No night switch → defaults to ON → catch-all min_plus_solar
+        assert _derive_charge_mode(cfg, {}, hass) == "min_plus_solar"
+
+    def test_charger_id_in_switch_lookup(self):
+        """Multi-charger: the right per-charger switch is consulted, not
+        a hardcoded ``ev_charger`` ID."""
+        cfg = {"id": "second_charger", "ev_charging_mode": "auto"}
+        hass = _hass_with_switches(
+            night=False, tariff=False, charger_id="second_charger",
+        )
+        assert _derive_charge_mode(cfg, {}, hass) == "solar_only"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SEMPerChargerSelect — charge_mode options (Q1: hide solar_plus_cheap)
+# ──────────────────────────────────────────────────────────────────────
+
+def _build_charge_mode_select(
+    *, tariff_mode="static", stored_value="min_plus_solar",
+):
+    """Construct a SEMPerChargerSelect bypassing CoordinatorEntity init."""
+    from homeassistant.components.select import SelectEntityDescription
+
+    sel = SEMPerChargerSelect.__new__(SEMPerChargerSelect)
+    sel.coordinator = MagicMock()
+    sel.coordinator.config = {
+        "tariff_mode": tariff_mode,
+        "ev_chargers": [{"id": "ev_charger", "charge_mode": stored_value}],
+    }
+    sel.entity_description = SelectEntityDescription(
+        key="charger_ev_charger_charge_mode",
+        options=list(EV_CHARGE_MODES.keys()),
+    )
+    sel._charger_id = "ev_charger"
+    sel._config_key = "charge_mode"
+    sel._value = stored_value
+    return sel
+
+
+class TestChargeModeOptions:
+    """Q1: ``solar_plus_cheap`` only appears when tariff_mode == 'dynamic'."""
+
+    def test_solar_plus_cheap_hidden_without_dynamic_tariff(self):
+        sel = _build_charge_mode_select(tariff_mode="static")
+        opts = sel.options
+        assert "solar_plus_cheap" not in opts, (
+            "solar_plus_cheap must hide when no dynamic tariff (Q1)"
+        )
+        # All other modes still present
+        for m in ("solar_only", "min_plus_solar", "always_max", "off"):
+            assert m in opts
+
+    def test_solar_plus_cheap_hidden_with_calendar_tariff(self):
+        """calendar tariff is not 'dynamic' — same hide rule."""
+        sel = _build_charge_mode_select(tariff_mode="calendar")
+        assert "solar_plus_cheap" not in sel.options
+
+    def test_solar_plus_cheap_visible_with_dynamic_tariff(self):
+        sel = _build_charge_mode_select(tariff_mode="dynamic")
+        opts = sel.options
+        assert "solar_plus_cheap" in opts
+        assert len(opts) == 5
+
+    def test_valid_value_set_always_full(self):
+        """Universe of valid values is always the 5 — only the UI list
+        narrows. Persisted ``solar_plus_cheap`` on a now-non-tariff
+        install must stay readable so a re-enable of tariff restores
+        the mode automatically rather than silently resetting."""
+        sel = _build_charge_mode_select(tariff_mode="static")
+        assert sel._valid_value_set() == set(EV_CHARGE_MODES.keys())
+
+    def test_current_option_clamps_when_stored_solar_plus_cheap_loses_tariff(self):
+        """User had dynamic tariff + ``solar_plus_cheap`` mode, then
+        switched to a static tariff. The selector's ``options`` no
+        longer includes ``solar_plus_cheap`` (Q1 hide rule); the
+        ``current_option`` then clamps to ``options[0]`` (``solar_only``).
+
+        **Critical for Phase B:** ``self._value`` MUST stay
+        ``solar_plus_cheap`` in storage — re-enabling the tariff later
+        should restore the user's original intent rather than silently
+        resetting it. Phase B's coordinator-authority switchover must
+        read ``self._value`` (or the persisted ``coordinator.config``
+        key), NOT ``current_option``, or it will treat the user as
+        having explicitly chosen ``solar_only`` when they didn't.
+        """
+        sel = _build_charge_mode_select(
+            tariff_mode="static", stored_value="solar_plus_cheap",
+        )
+        # UI options exclude solar_plus_cheap
+        assert "solar_plus_cheap" not in sel.options
+        # current_option clamps to options[0] (the first remaining mode)
+        assert sel.current_option == sel.options[0] == "solar_only"
+        # Stored intent preserved — Phase B must read this, not current_option
+        assert sel._value == "solar_plus_cheap"
+
+
+# ──────────────────────────────────────────────────────────────────────
+# async_migrate_entry v4 → v5
+# ──────────────────────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestMigrateEntryV5:
+    """End-to-end migration covering: derivation runs for every charger,
+    existing field is preserved, version bumps, legacy toggles untouched."""
+
+    async def _run_migration_at_v4(self, *, options, hass=None):
+        """Run async_migrate_entry on a v4 entry and return the new
+        options dict it persisted."""
+        from custom_components.solar_energy_management import async_migrate_entry
+
+        entry = MagicMock()
+        entry.version = 4
+        entry.minor_version = 1
+        entry.data = {}
+        entry.options = options
+
+        if hass is None:
+            hass = _hass_with_switches(night=True, tariff=False)
+        # Capture what async_update_entry was called with
+        captured = {}
+        def _update(e, **kwargs):
+            captured.update(kwargs)
+        hass.config_entries.async_update_entry = MagicMock(side_effect=_update)
+
+        result = await async_migrate_entry(hass, entry)
+        assert result is True, "migration must succeed"
+        return captured
+
+    async def test_seeds_charge_mode_per_charger(self):
+        captured = await self._run_migration_at_v4(options={
+            "ev_chargers": [
+                {"id": "ev_charger", "ev_charging_mode": "pv"},
+                {"id": "second", "ev_charging_mode": "now"},
+            ],
+        })
+        new_chargers = captured["options"]["ev_chargers"]
+        assert new_chargers[0]["charge_mode"] == "min_plus_solar"
+        assert new_chargers[1]["charge_mode"] == "always_max"
+
+    async def test_preserves_existing_charge_mode(self):
+        """A user who already has charge_mode set (e.g. manual edit
+        or migration re-run) must NOT have it overwritten."""
+        captured = await self._run_migration_at_v4(options={
+            "ev_chargers": [
+                {"id": "ev_charger", "ev_charging_mode": "pv",
+                 "charge_mode": "solar_only"},
+            ],
+        })
+        assert captured["options"]["ev_chargers"][0]["charge_mode"] == "solar_only"
+
+    async def test_legacy_toggle_state_unchanged(self):
+        """Phase A guarantee: legacy fields stay authoritative for the
+        strategy machine until Phase B."""
+        captured = await self._run_migration_at_v4(options={
+            "ev_chargers": [
+                {"id": "ev_charger", "ev_charging_mode": "minpv"},
+            ],
+        })
+        ch = captured["options"]["ev_chargers"][0]
+        assert ch["ev_charging_mode"] == "minpv", (
+            "Phase A must not mutate legacy fields"
+        )
+
+    async def test_bumps_version_to_5(self):
+        captured = await self._run_migration_at_v4(options={
+            "ev_chargers": [{"id": "ev_charger", "ev_charging_mode": "pv"}],
+        })
+        assert captured["version"] == 5
+
+    async def test_no_chargers_no_crash(self):
+        """Pre-EV setups (no ev_chargers list) must still migrate."""
+        captured = await self._run_migration_at_v4(options={})
+        assert captured["version"] == 5
+        # No ev_chargers to seed, so the key may or may not be present —
+        # the migration must not invent one.
+        assert "ev_chargers" not in captured["options"] or \
+            captured["options"]["ev_chargers"] in (None, [])
+
+
+# ──────────────────────────────────────────────────────────────────────
+# SEMCoordinator._effective_charge_mode_for — read-side helper
+# ──────────────────────────────────────────────────────────────────────
+
+class TestEffectiveChargeMode:
+    """The single read-point Phase B will switch authority on. Stored
+    value wins when present; legacy derivation when absent."""
+
+    def _build_coord(self, *, hass=None, config=None):
+        with patch.object(SEMCoordinator, "__init__", return_value=None):
+            coord = SEMCoordinator.__new__(SEMCoordinator)
+        coord.hass = hass or _hass_with_switches(night=True, tariff=False)
+        coord.config = config or {}
+        return coord
+
+    def test_stored_mode_wins(self):
+        """When charger_cfg['charge_mode'] is set, return it verbatim."""
+        coord = self._build_coord()
+        cfg = {"id": "ev_charger", "charge_mode": "solar_only",
+               "ev_charging_mode": "minpv"}  # legacy says different
+        assert coord._effective_charge_mode_for(cfg) == "solar_only"
+
+    def test_derives_when_stored_missing(self):
+        """Pre-migration / partial install: fall back to legacy
+        derivation. Result must match _derive_charge_mode for the same
+        inputs (equivalence guarantee)."""
+        hass = _hass_with_switches(night=False, tariff=False)
+        coord = self._build_coord(hass=hass)
+        cfg = {"id": "ev_charger", "ev_charging_mode": "auto"}  # no charge_mode
+        # No night, no tariff → solar_only per derivation
+        assert coord._effective_charge_mode_for(cfg) == "solar_only"
+
+    def test_unknown_stored_value_falls_through_to_derivation(self):
+        """Defensive: a stored value outside the 5 known modes (someone
+        edited storage by hand) must not be returned. Fall back to the
+        derivation path so the runtime sees a known mode."""
+        hass = _hass_with_switches(night=True, tariff=False)
+        coord = self._build_coord(hass=hass)
+        cfg = {"id": "ev_charger", "charge_mode": "garbage_value",
+               "ev_charging_mode": "pv"}
+        assert coord._effective_charge_mode_for(cfg) == "min_plus_solar"
+
+    def test_non_dict_charger_cfg_returns_default(self):
+        """Defensive: corrupt config (None / list / str) returns the
+        new-install default rather than crashing the cycle."""
+        coord = self._build_coord()
+        assert coord._effective_charge_mode_for(None) == "min_plus_solar"
+        assert coord._effective_charge_mode_for("nope") == "min_plus_solar"
+
+    def test_equivalence_across_all_legacy_combinations(self):
+        """The migration and the runtime fallback must produce IDENTICAL
+        modes for every legacy combination — otherwise a user who
+        somehow skips migration sees different behaviour than one who
+        migrates."""
+        combos = [
+            # (ev_charging_mode, night, tariff, expected_mode)
+            ("now",   True,  False, "always_max"),
+            ("now",   False, True,  "always_max"),    # tariff irrelevant for now
+            ("off",   True,  False, "off"),
+            ("auto",  True,  True,  "solar_plus_cheap"),
+            ("auto",  True,  False, "min_plus_solar"),
+            ("auto",  False, False, "solar_only"),
+            ("pv",    True,  False, "min_plus_solar"),
+            ("pv",    False, False, "solar_only"),
+            ("minpv", True,  False, "min_plus_solar"),
+            ("minpv", False, False, "min_plus_solar"),  # minpv defaults to catch-all
+        ]
+        for cmode, night, tariff, expected in combos:
+            hass = _hass_with_switches(night=night, tariff=tariff)
+            coord = self._build_coord(hass=hass)
+            cfg = {"id": "ev_charger", "ev_charging_mode": cmode}
+            via_runtime = coord._effective_charge_mode_for(cfg)
+            via_migration = _derive_charge_mode(cfg, {}, hass)
+            assert via_runtime == expected, (
+                f"runtime: ({cmode}, night={night}, tariff={tariff}) "
+                f"got {via_runtime}, expected {expected}"
+            )
+            assert via_migration == expected, (
+                f"migration: ({cmode}, night={night}, tariff={tariff}) "
+                f"got {via_migration}, expected {expected}"
+            )
+            assert via_runtime == via_migration, (
+                f"runtime ↔ migration divergence at "
+                f"({cmode}, night={night}, tariff={tariff})"
+            )
+
+
+# ──────────────────────────────────────────────────────────────────────
+# Translation keys exist for every mode in every language
+# ──────────────────────────────────────────────────────────────────────
+
+class TestTranslationsComplete:
+    """Each of the 15 supported languages must define a label for the
+    Charge mode entity AND a state translation for every mode in
+    ``EV_CHARGE_MODES``. Catches a half-applied translation patch."""
+
+    LANGUAGES = (
+        "en", "de", "nl", "fr", "es", "it", "pt", "pl",
+        "sv", "cs", "da", "fi", "hu", "ro", "no",
+    )
+
+    def test_every_language_has_charge_mode_block(self):
+        from pathlib import Path
+        base = Path(__file__).resolve().parent.parent / "translations"
+        for lang in self.LANGUAGES:
+            d = json.loads((base / f"{lang}.json").read_text())
+            block = d.get("entity", {}).get("select", {}).get("charge_mode")
+            assert block is not None, f"{lang}.json missing charge_mode block"
+            assert "name" in block, f"{lang}.json charge_mode missing 'name'"
+            states = block.get("state", {})
+            for mode in EV_CHARGE_MODES.keys():
+                assert mode in states, (
+                    f"{lang}.json charge_mode missing state for '{mode}'"
+                )
+                assert states[mode], (
+                    f"{lang}.json charge_mode.state.{mode} is empty"
+                )

--- a/tests/test_ev_energy_fix.py
+++ b/tests/test_ev_energy_fix.py
@@ -9,6 +9,8 @@ import pytest
 from unittest.mock import Mock, MagicMock
 from datetime import date
 
+from freezegun import freeze_time
+
 from custom_components.solar_energy_management.coordinator.sensor_reader import (
     SensorReader,
     SensorConfig,
@@ -238,16 +240,35 @@ class TestLayer3HardwareReconciliation:
         # 0.3 < threshold (0.5), should stay at integrated value (0.0)
         assert energy.daily_ev < 0.3
 
+    @freeze_time("2026-05-15 12:00:00")
     def test_reconciliation_when_integrated_close_to_hardware(self, calc):
-        """Integrated 14.8, hardware 15.0 → delta 0.2 < threshold, no override."""
+        """Integrated 14.8, hardware 15.0 → delta 0.2 < threshold, no override.
+
+        Pinned to a fixed datetime (#294 fix): pre-fix the test depended
+        on wall-clock and broke on two fronts whenever a CI run crossed
+        a meter-day boundary:
+          - The test seeded the accumulator with one ``today`` and
+            ``calculate_energy`` looked it up with another.
+          - ``_check_rollover`` pruned EV accumulators not matching
+            today or yesterday from the *real* clock, so a seeded key
+            for a different date got silently deleted.
+        Freezing the whole test at noon eliminates both — no boundary
+        crossings, no key-drift, no flake. Verified against PR #295 CI
+        run that failed at 06:24 UTC.
+        """
         sensors = {"sensor.keba_p30_charging_daily": (15.0, {})}
         hw_hass = _make_hass(sensors)
         calc.set_ev_daily_energy_sensor(hw_hass, "sensor.keba_p30_charging_daily")
 
-        # Manually seed the accumulator to simulate prior integration
-        today = calc._time_manager.get_current_meter_day_sunrise_based()
+        # Manually seed the accumulator to simulate prior integration.
+        # Use the same method ``calculate_energy`` uses internally so the
+        # key matches by construction regardless of which path
+        # ``_ev_reset_day`` takes (sunrise vs offset).
+        today = calc._ev_reset_day(None)
         calc._daily_accumulators[f"ev_daily_sun_{today}"] = 14.8
-        calc._monthly_accumulators[f"ev_daily_sun_{today.year}_{today.month}"] = 14.8
+        calc._monthly_accumulators[
+            f"ev_daily_sun_{today.year}_{today.month}"
+        ] = 14.8
 
         power = PowerReadings(ev_power=0.0)
         power.calculate_derived()

--- a/tests/test_per_charger_seed_migration.py
+++ b/tests/test_per_charger_seed_migration.py
@@ -38,7 +38,7 @@ async def test_seeds_all_eight_from_global():
     )
     assert await async_migrate_entry(hass, entry) is True
     c, kwargs = _seeded_charger(hass)
-    assert kwargs["version"] == 4
+    assert kwargs["version"] == 5  # bumped in v4→v5 (#277)
     assert c["daily_ev_target"] == 8
     assert c["daily_ev_target_max"] == 50
     assert c["ev_target_soc"] == 70
@@ -90,7 +90,7 @@ async def test_no_chargers_is_safe_and_bumps_version():
     hass = MagicMock()
     entry = _entry(options={}, data={"daily_ev_target": 8})
     assert await async_migrate_entry(hass, entry) is True
-    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 4
+    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 5  # bumped in v4→v5 (#277)
 
 
 @pytest.mark.asyncio

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1148,6 +1148,16 @@
           "kwh": "Cíl kWh",
           "soc": "Cíl SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Režim nabíjení",
+        "state": {
+          "solar_only": "Pouze solární",
+          "solar_plus_cheap": "Solární + nejlevnější hodiny",
+          "min_plus_solar": "Min + Solární",
+          "always_max": "Vždy (max)",
+          "off": "Vypnuto"
+        }
       }
     }
   },

--- a/translations/da.json
+++ b/translations/da.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-mål",
           "soc": "SoC-%-mål"
         }
+      },
+      "charge_mode": {
+        "name": "Opladningstilstand",
+        "state": {
+          "solar_only": "Kun sol",
+          "solar_plus_cheap": "Sol + billigste timer",
+          "min_plus_solar": "Min + Sol",
+          "always_max": "Altid (max)",
+          "off": "Fra"
+        }
       }
     }
   },

--- a/translations/de.json
+++ b/translations/de.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-Ziel",
           "soc": "SoC-%-Ziel"
         }
+      },
+      "charge_mode": {
+        "name": "Lademodus",
+        "state": {
+          "solar_only": "Nur Solar",
+          "solar_plus_cheap": "Solar + günstigste Stunden",
+          "min_plus_solar": "Min + Solar",
+          "always_max": "Immer (max)",
+          "off": "Aus"
+        }
       }
     }
   },

--- a/translations/en.json
+++ b/translations/en.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh target",
           "soc": "SOC % target"
         }
+      },
+      "charge_mode": {
+        "name": "Charge mode",
+        "state": {
+          "solar_only": "Solar only",
+          "solar_plus_cheap": "Solar + cheapest hours",
+          "min_plus_solar": "Min + Solar",
+          "always_max": "Always (max)",
+          "off": "Off"
+        }
       }
     }
   },

--- a/translations/es.json
+++ b/translations/es.json
@@ -1148,6 +1148,16 @@
           "kwh": "Objetivo kWh",
           "soc": "Objetivo SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Modo de carga",
+        "state": {
+          "solar_only": "Solo solar",
+          "solar_plus_cheap": "Solar + horas más baratas",
+          "min_plus_solar": "Mín + Solar",
+          "always_max": "Siempre (máx)",
+          "off": "Apagado"
+        }
       }
     }
   },

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-tavoite",
           "soc": "SoC-%-tavoite"
         }
+      },
+      "charge_mode": {
+        "name": "Lataustila",
+        "state": {
+          "solar_only": "Vain aurinko",
+          "solar_plus_cheap": "Aurinko + halvimmat tunnit",
+          "min_plus_solar": "Min + Aurinko",
+          "always_max": "Aina (max)",
+          "off": "Pois"
+        }
       }
     }
   },

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1148,6 +1148,16 @@
           "kwh": "Objectif kWh",
           "soc": "Objectif SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Mode de charge",
+        "state": {
+          "solar_only": "Solaire seulement",
+          "solar_plus_cheap": "Solaire + heures les moins chères",
+          "min_plus_solar": "Min + Solaire",
+          "always_max": "Toujours (max)",
+          "off": "Arrêt"
+        }
       }
     }
   },

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh cél",
           "soc": "SoC % cél"
         }
+      },
+      "charge_mode": {
+        "name": "Töltési mód",
+        "state": {
+          "solar_only": "Csak nap",
+          "solar_plus_cheap": "Nap + legolcsóbb órák",
+          "min_plus_solar": "Min + Nap",
+          "always_max": "Mindig (max)",
+          "off": "Ki"
+        }
       }
     }
   },

--- a/translations/it.json
+++ b/translations/it.json
@@ -1148,6 +1148,16 @@
           "kwh": "Obiettivo kWh",
           "soc": "Obiettivo SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Modalità di ricarica",
+        "state": {
+          "solar_only": "Solo solare",
+          "solar_plus_cheap": "Solare + ore più economiche",
+          "min_plus_solar": "Min + Solare",
+          "always_max": "Sempre (max)",
+          "off": "Spento"
+        }
       }
     }
   },

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-doel",
           "soc": "SoC-%-doel"
         }
+      },
+      "charge_mode": {
+        "name": "Laadmodus",
+        "state": {
+          "solar_only": "Alleen zon",
+          "solar_plus_cheap": "Zon + goedkoopste uren",
+          "min_plus_solar": "Min + Zon",
+          "always_max": "Altijd (max)",
+          "off": "Uit"
+        }
       }
     }
   },

--- a/translations/no.json
+++ b/translations/no.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-mål",
           "soc": "SoC-%-mål"
         }
+      },
+      "charge_mode": {
+        "name": "Lademodus",
+        "state": {
+          "solar_only": "Kun sol",
+          "solar_plus_cheap": "Sol + billigste timer",
+          "min_plus_solar": "Min + Sol",
+          "always_max": "Alltid (maks)",
+          "off": "Av"
+        }
       }
     }
   },

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -1148,6 +1148,16 @@
           "kwh": "Cel kWh",
           "soc": "Cel SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Tryb ładowania",
+        "state": {
+          "solar_only": "Tylko słońce",
+          "solar_plus_cheap": "Słońce + najtańsze godziny",
+          "min_plus_solar": "Min + Słońce",
+          "always_max": "Zawsze (max)",
+          "off": "Wył"
+        }
       }
     }
   },

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1148,6 +1148,16 @@
           "kwh": "Meta kWh",
           "soc": "Meta SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Modo de carga",
+        "state": {
+          "solar_only": "Apenas solar",
+          "solar_plus_cheap": "Solar + horas mais baratas",
+          "min_plus_solar": "Mín + Solar",
+          "always_max": "Sempre (máx)",
+          "off": "Desligado"
+        }
       }
     }
   },

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -1148,6 +1148,16 @@
           "kwh": "Țintă kWh",
           "soc": "Țintă SoC %"
         }
+      },
+      "charge_mode": {
+        "name": "Mod de încărcare",
+        "state": {
+          "solar_only": "Doar solar",
+          "solar_plus_cheap": "Solar + cele mai ieftine ore",
+          "min_plus_solar": "Min + Solar",
+          "always_max": "Întotdeauna (max)",
+          "off": "Oprit"
+        }
       }
     }
   },

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1148,6 +1148,16 @@
           "kwh": "kWh-mål",
           "soc": "SoC-%-mål"
         }
+      },
+      "charge_mode": {
+        "name": "Laddningsläge",
+        "state": {
+          "solar_only": "Endast sol",
+          "solar_plus_cheap": "Sol + billigaste timmar",
+          "min_plus_solar": "Min + Sol",
+          "always_max": "Alltid (max)",
+          "off": "Av"
+        }
       }
     }
   },


### PR DESCRIPTION
## Summary

Phase A of the EV charge UX consolidation arc (#277). **Purely additive** — adds the new `select.sem_charger_<id>_charge_mode` per-charger entity and seeds it from existing toggle state at first boot, but the coordinator strategy machine still reads the legacy four-toggle state. Behaviour is identical to v1.6.2 until Phase B flips authority to the new field.

Targets v1.7.0 — Phase A ships first (no behaviour change risk), then Phase B (coordinator authority switchover + card rewrite), then Phase C (legacy switch removal).

## Design questions resolved before coding

| # | Decision |
|---|---|
| Q1 (no-tariff) | Hide `solar_plus_cheap` entirely until a dynamic tariff is configured |
| Q2 (battery assist in `min_plus_solar`) | Always available, no new toggle |
| Q3 (smart night) | Implicit ON for night-charging modes; toggle hidden + dead |
| Q4 (default for new installs) | `min_plus_solar` (matches today's factory defaults) |

Plan: [`docs/plans/2026-05-30_ev_charge_mode_consolidation.md`](https://github.com/traktore-org/sem-community/blob/feature/277-charge-mode-phase-a/docs/plans/2026-05-30_ev_charge_mode_consolidation.md).

## Changes

1. **New per-charger entity** `select.sem_charger_<id>_charge_mode` (5 options, `solar_plus_cheap` conditionally hidden).
2. **`async_migrate_entry` v4 → v5** derives `charge_mode` per charger from legacy toggles.
3. **`SEMCoordinator._effective_charge_mode_for(charger_cfg)`** — single read-point Phase B will switch authority on. No production caller reads it yet (Phase A safety property).
4. **`consts/ev_charge_modes.py`** — shared `EV_CHARGE_MODES` + `DEFAULT_EV_CHARGE_MODE`. Both `select.py` and `coordinator.py` import the same source of truth.
5. **`async_migrate_entry` accumulator refactor** — each step reads from / writes back to threaded `accumulated_{data,options}` accumulators. Fixes a pre-existing bug exposed by adding the v5 step: sequential steps were re-reading the original `entry.options`, losing prior step mutations on test harnesses. Real HA mutated `entry` between steps and masked it.
6. **`config_flow.py`** `VERSION = 5`.
7. **15 languages × `translations/*.json`** — `entity.select.charge_mode.{name, state.<mode>}`.

## Review trail

Reviewer pass before commit. Findings + actions:
- **MED — Plan vs implementation `minpv` divergence:** plan said `minpv` could map to `solar_only` when `night=off`, but `minpv` always pulls Min from grid during the day. Updated plan to keep `minpv → min_plus_solar` always.
- **MED — `current_option` clamp untested:** added `test_current_option_clamps_when_stored_solar_plus_cheap_loses_tariff` pinning the behaviour + a Phase B authority hint (must read `_value` / config key, not `current_option`).
- **LOW — Duplicated `EV_CHARGE_MODES` tuple in coordinator:** moved to `consts/ev_charge_modes.py`; both files import it now.

Other LOW/NIT findings (MagicMock leak in pre-existing test, no-op migration log line) deferred to Phase B sweep — not blockers.

## Tests

**2079 / 2079 passing** (1 pre-existing unrelated flake `test_reconciliation_when_integrated_close_to_hardware` filed as #294 — fails near 07:00 local sunrise boundary, verified against pristine develop).

New: 26 tests in `tests/test_277_charge_mode_phase_a.py` covering:
- Derive decision tree (10): every mode × every legacy combination that maps to it
- Q1 dynamic options behaviour (5): hide / show / value preservation / `current_option` clamp
- Full migration loop (5): seeds per charger, preserves existing, doesn't mutate legacy, bumps version, no-chargers-no-crash
- `_effective_charge_mode_for` equivalence (5): stored vs derived, defensive paths, full equivalence sweep
- Translations completeness (1): every language has every mode label

## Deploy plan

Phase A doesn't change behaviour, so HA-TEST is the only validation needed. PROD deploy waits for the full Phase A → B → C arc to ship as v1.7.0.

## Issues addressed
- Refs #277 (Phase A of 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)