### PR TITLE
#277 Phase B.2: per-charger card UI uses the new Charge mode selector

### DIFF
--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -2587,15 +2587,11 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     <div class="range-handle range-handle-max" style="left:${g}%"
                         @pointerdown=${i=>this._rangeHandleStart(i,"max",t,e,n,l)}></div>
                 </div>
-            </div>`}_rangeHandleStart(t,e,i,s,r,a){t.stopPropagation(),t.preventDefault();const o=t.currentTarget.closest(".range-track");if(!o)return;const n="min"===e?i:s,l="min"===e?s:i,c=this._hass?.states[n],d=parseFloat(c?.attributes?.step)||(a>50?1:.5),h=a-r||1,p=t=>{const i=o.getBoundingClientRect();let s=(t-i.left)/(i.width||1);s=Math.max(0,Math.min(1,s));let n=Math.round((r+s*h)/d)*d;const c=this._entityVal(l,"min"===e?a:r);return n="min"===e?Math.min(n,c):Math.max(n,c),Math.max(r,Math.min(a,n))},g=t=>{this._freezeEntity(n,p(t.clientX)),this.requestUpdate()},u=t=>{window.removeEventListener("pointermove",g),window.removeEventListener("pointerup",u),window.removeEventListener("pointercancel",u),this._setNumber(n,p(t.clientX))};window.addEventListener("pointermove",g),window.addEventListener("pointerup",u),window.addEventListener("pointercancel",u)}_renderChargerSection(t,e){const i=Qt[e%Qt.length],s=this._val(`charger_${t}_power`,0),r=this._val(`charger_${t}_session_energy`,0),a=this._val(`charger_${t}_daily_energy`,0),o=this._val(`charger_${t}_session_solar_share`,0),n=this._val(`charger_${t}_vehicle_soc`,null)??this._val("vehicle_soc",null),l=this._val(`charger_${t}_estimated_soc`,null),c=null!=n?n:l,d=this._entityVal(`number.sem_charger_${t}_nights_until_charge`,null),h=this._valStr(`charger_${t}_charge_needed`),p=this._chargerName(t),g=this._hass?.states[`binary_sensor.sem_charger_${t}_connected`],u="on"===g?.state,_=s>50,f=_?this._t("charging"):u?this._t("connected"):this._t("idle"),m=this._entityVal(`number.sem_charger_${t}_night_initial_current`,10),v=this._entityVal(`number.sem_charger_${t}_minimum_current`,6),y=this._entityVal(`number.sem_charger_${t}_ev_battery_capacity_kwh`,40),x=this._entityVal(`number.sem_charger_${t}_ev_kwh_per_100km`,18),b="True"===h||"true"===h,$=b?"mdi:battery-alert":"mdi:battery-check",w=b?"#f06292":"#8DC892",k=b?this._t("yes"):this._t("no"),S=`switch.sem_charger_${t}_night_charging`,C=`select.sem_charger_${t}_ev_target_type`,E=this._stateStr(C)||"kwh",M=this._stateAttrs(C).options||["kwh"],z="soc"===E,D=z?`number.sem_charger_${t}_target_soc`:`number.sem_charger_${t}_daily_ev_target`,F=z?`number.sem_charger_${t}_target_soc_max`:`number.sem_charger_${t}_daily_ev_target_max`,A="on"===this._stateStr(S),T=`switch.sem_charger_${t}_tariff_optimized`,I="on"===this._stateStr(T),R=`time.sem_charger_${t}_target_time`,N=this._stateStr(R),L=N?N.slice(0,5):"—",O=`button.sem_charger_${t}_set_default_target`,B=this._stateAttrs(`${this._prefix}charging_state`),P=!1===B.ev_deadline_reachable,U=B.ev_next_cheap_window;let W="";if(U)try{const t=new Date(U);isNaN(t)||(W=t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"}))}catch(t){}const G=this._entityVal(D,z?80:10),j=z?Math.max(0,(G-c)/100*y):Math.max(0,G-a),Y=x>0?Math.round(j/x*100):null,q=(t,e)=>H`
-            <span class="ct-sw ${t?"on":"off"}"
-                @click=${t=>{t.stopPropagation(),this._toggleSwitch(e)}}>
-                <span class="ct-knob"></span>
-            </span>`,V=M.length>1?H`<select class="ct-unit" .value=${E}
+            </div>`}_rangeHandleStart(t,e,i,s,r,a){t.stopPropagation(),t.preventDefault();const o=t.currentTarget.closest(".range-track");if(!o)return;const n="min"===e?i:s,l="min"===e?s:i,c=this._hass?.states[n],d=parseFloat(c?.attributes?.step)||(a>50?1:.5),h=a-r||1,p=t=>{const i=o.getBoundingClientRect();let s=(t-i.left)/(i.width||1);s=Math.max(0,Math.min(1,s));let n=Math.round((r+s*h)/d)*d;const c=this._entityVal(l,"min"===e?a:r);return n="min"===e?Math.min(n,c):Math.max(n,c),Math.max(r,Math.min(a,n))},g=t=>{this._freezeEntity(n,p(t.clientX)),this.requestUpdate()},u=t=>{window.removeEventListener("pointermove",g),window.removeEventListener("pointerup",u),window.removeEventListener("pointercancel",u),this._setNumber(n,p(t.clientX))};window.addEventListener("pointermove",g),window.addEventListener("pointerup",u),window.addEventListener("pointercancel",u)}_renderChargerSection(t,e){const i=Qt[e%Qt.length],s=this._val(`charger_${t}_power`,0),r=this._val(`charger_${t}_session_energy`,0),a=this._val(`charger_${t}_daily_energy`,0),o=this._val(`charger_${t}_session_solar_share`,0),n=this._val(`charger_${t}_vehicle_soc`,null)??this._val("vehicle_soc",null),l=this._val(`charger_${t}_estimated_soc`,null),c=null!=n?n:l,d=this._entityVal(`number.sem_charger_${t}_nights_until_charge`,null),h=this._valStr(`charger_${t}_charge_needed`),p=this._chargerName(t),g=this._hass?.states[`binary_sensor.sem_charger_${t}_connected`],u="on"===g?.state,_=s>50,f=_?this._t("charging"):u?this._t("connected"):this._t("idle"),m=this._entityVal(`number.sem_charger_${t}_night_initial_current`,10),v=this._entityVal(`number.sem_charger_${t}_minimum_current`,6),y=this._entityVal(`number.sem_charger_${t}_ev_battery_capacity_kwh`,40),x=this._entityVal(`number.sem_charger_${t}_ev_kwh_per_100km`,18),b="True"===h||"true"===h,$=b?"mdi:battery-alert":"mdi:battery-check",w=b?"#f06292":"#8DC892",k=b?this._t("yes"):this._t("no"),S=`select.sem_charger_${t}_charge_mode`,C=this._stateAttrs(S),E=this._stateStr(S)||"min_plus_solar",M=C.options||["solar_only","min_plus_solar","always_max","off"],z={solar_only:this._t("charge_mode_solar_only"),solar_plus_cheap:this._t("charge_mode_solar_plus_cheap"),min_plus_solar:this._t("charge_mode_min_plus_solar"),always_max:this._t("charge_mode_always_max"),off:this._t("charge_mode_off")},D={solar_only:this._t("charge_mode_hint_solar_only"),solar_plus_cheap:this._t("charge_mode_hint_solar_plus_cheap"),min_plus_solar:this._t("charge_mode_hint_min_plus_solar"),always_max:this._t("charge_mode_hint_always_max"),off:this._t("charge_mode_hint_off")},F=`select.sem_charger_${t}_ev_target_type`,A=this._stateStr(F)||"kwh",T=this._stateAttrs(F).options||["kwh"],I="soc"===A,R=I?`number.sem_charger_${t}_target_soc`:`number.sem_charger_${t}_daily_ev_target`,N=I?`number.sem_charger_${t}_target_soc_max`:`number.sem_charger_${t}_daily_ev_target_max`,L=`time.sem_charger_${t}_target_time`,O=this._stateStr(L),B=O?O.slice(0,5):"—",P=`button.sem_charger_${t}_set_default_target`,U=this._stateAttrs(`${this._prefix}charging_state`),W=!1===U.ev_deadline_reachable,G=U.ev_next_cheap_window;let j="";if(G)try{const t=new Date(G);isNaN(t)||(j=t.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit"}))}catch(t){}const Y="solar_plus_cheap"===E&&j,q=this._entityVal(R,I?80:10),V=I?Math.max(0,(q-c)/100*y):Math.max(0,q-a),X=x>0?Math.round(V/x*100):null,Z=T.length>1?H`<select class="ct-unit" .value=${A}
                     @click=${t=>t.stopPropagation()}
-                    @change=${t=>this._selectOption(C,t.target.value)}>
-                    ${M.map(t=>H`<option value=${t} ?selected=${t===E}>${"soc"===t?"%":"kWh"}</option>`)}
-                </select>`:H`<span class="ct-unit-static">${z?"%":"kWh"}</span>`;return H`
+                    @change=${t=>this._selectOption(F,t.target.value)}>
+                    ${T.map(t=>H`<option value=${t} ?selected=${t===A}>${"soc"===t?"%":"kWh"}</option>`)}
+                </select>`:H`<span class="ct-unit-static">${I?"%":"kWh"}</span>`;return H`
             <div class="charger-section">
                 <div class="charger-header">
                     <div class="charger-dot" style="background:${i}"></div>
@@ -2646,38 +2642,48 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     <div class="ct-title">
                         <ha-icon icon="mdi:target" style="--mdc-icon-size:14px;color:#8DC892"></ha-icon>
                         ${this._t("charge_target")}
-                        ${null!=Y&&Y>0?H`<span class="ct-range">· +${Y} km</span>`:K}
+                        ${null!=X&&X>0?H`<span class="ct-range">· +${X} km</span>`:K}
                         <span class="ct-spacer"></span>
-                        ${V}
+                        ${Z}
                     </div>
-                    ${this._renderRangeSlider(D,F,z)}
+                    ${this._renderRangeSlider(R,N,I)}
+                    <!-- #277 Phase B.2: one named Charge mode selector
+                         replaces the legacy ev_grid_charging + nested
+                         ev_tariff_mode toggles. Options come from the HA
+                         entity itself (solar_plus_cheap is hidden when no
+                         dynamic tariff is configured, per Q1). The hint
+                         line under it explains what the selected mode
+                         actually does — cuts the toggle-soup mystery the
+                         #247 review flagged. -->
                     <div class="ct-row">
-                        <span class="ct-label">${this._t("ev_grid_charging")}</span>
-                        <span class="ct-ctl">${q(A,S)}</span>
+                        <span class="ct-label">${this._t("charge_mode")}</span>
+                        <span class="ct-ctl">
+                            <select class="ct-mode-select"
+                                    .value=${E}
+                                    @click=${t=>t.stopPropagation()}
+                                    @change=${t=>this._selectOption(S,t.target.value)}>
+                                ${M.map(t=>H`
+                                    <option value=${t} ?selected=${t===E}>
+                                        ${z[t]||t}
+                                    </option>`)}
+                            </select>
+                        </span>
                     </div>
-                    <!-- Tariff is a refinement OF grid charging (when, not whether): nest it.
-                         Hidden when overnight grid charging is OFF so the hierarchy is enforced visually -
-                         the switch cannot be toggled in isolation (D2). -->
-                    ${A?H`
-                        <div class="ct-row ct-subrow">
-                            <span class="ct-label">${this._t("ev_tariff_mode")}</span>
-                            <span class="ct-ctl">${q(I,T)}</span>
-                        </div>
-                        ${I?H`
-                            <div class="ct-subhint">
-                                ${this._t("ev_tariff_hint")}${W?H` · ${this._t("ev_next_cheap")} <b style="color:#8DC892">${W}</b>`:K}
-                            </div>
+                    <div class="ct-subhint">
+                        ${D[E]||""}
+                        ${Y?H`
+                            · ${this._t("ev_next_cheap")} <b style="color:#8DC892">${j}</b>
                         `:K}
-                    `:K}
+                    </div>
                     <div class="ct-row clickable"
-                        @click=${()=>this.dispatchEvent(new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:R}}))}>
+                        @click=${()=>this.dispatchEvent(new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:L}}))}>
                         <span class="ct-label">${this._t("ev_charge_by")}</span>
                         <span class="ct-ctl ct-time">
                             <ha-icon icon="mdi:clock-end" style="--mdc-icon-size:13px;color:#5BC8D8"></ha-icon>
-                            ${L}
+                            ${B}
                         </span>
                     </div>
-                    ${P?H`
+                    ${W?H`
                         <div class="ct-warn">
                             <ha-icon icon="mdi:clock-alert" style="--mdc-icon-size:14px;color:#f06292"></ha-icon>
                             <span>${this._t("ev_deadline_unreachable_short")}</span>
@@ -2686,7 +2692,7 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     ${this._renderPlanStrip()}
                     <div class="ct-row">
                         <span class="ct-set-default"
-                            @click=${()=>this._callService("button","press",{entity_id:O})}>
+                            @click=${()=>this._callService("button","press",{entity_id:P})}>
                             <ha-icon icon="mdi:content-save-cog" style="--mdc-icon-size:13px"></ha-icon>
                             ${this._t("set_as_default")}
                         </span>
@@ -2724,7 +2730,7 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                     </div>
                 </div>
             </div>
-        `}render(){if(!this._config||!this._hass)return K;const t=this._binaryState("ev_connected"),e=this._binaryState("ev_charging"),i=this._val("ev_power",0);this._val("calculated_current",0),this._val("session_energy",0);const s=this._val("energy_ev_solar_percentage",0),r=this._val("session_cost",0),a=this._val("daily_ev_energy",0);this._valStr("charging_state");const o=ut(this._hass);this._hass?.states[this._pcEntity("select","ev_charging_mode","select.sem_ev_charging_mode")];this._t("mode_auto"),this._t("mode_minpv"),this._t("maximum"),this._t("off");const n=e?"wrap state-charging":t?"wrap state-connected":"wrap state-disconnected",l=e?this._t("charging"):t?this._t("connected"):this._t("disconnected"),c=e?"status-value charging":t?"status-value connected":"status-value disconnected";return H`
+        `}render(){if(!this._config||!this._hass)return K;const t=this._binaryState("ev_connected"),e=this._binaryState("ev_charging"),i=this._val("ev_power",0);this._val("calculated_current",0),this._val("session_energy",0);const s=this._val("energy_ev_solar_percentage",0),r=this._val("session_cost",0),a=this._val("daily_ev_energy",0);this._valStr("charging_state");const o=ut(this._hass),n=e?"wrap state-charging":t?"wrap state-connected":"wrap state-disconnected",l=e?this._t("charging"):t?this._t("connected"):this._t("disconnected"),c=e?"status-value charging":t?"status-value connected":"status-value disconnected";return H`
             <svg class="glow-svg">
                 <defs>
                     <filter id="ev-glow" x="-50%" y="-50%" width="200%" height="200%">
@@ -3173,6 +3179,25 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
             .ct-unit-static {
                 font-size: 12px; font-weight: 600;
                 color: var(--secondary-text-color, #999); padding: 4px 2px;
+            }
+            /* #277 Phase B.2 — Charge mode selector. Wider than ct-unit
+               (multi-word labels) and aligned right inside the row's
+               .ct-ctl cell. Same caret + chrome as ct-unit so the two
+               selectors visually rhyme. */
+            .ct-mode-select {
+                appearance: none; -webkit-appearance: none;
+                background-color: var(--secondary-background-color, rgba(255,255,255,0.07));
+                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23bbbbbb' d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+                background-repeat: no-repeat;
+                background-position: right 6px center;
+                background-size: 14px;
+                color: var(--primary-text-color, #e0e0e0);
+                border: 1px solid var(--divider-color, rgba(255,255,255,0.12));
+                border-radius: 8px;
+                padding: 4px 24px 4px 10px;
+                font-size: 12px; font-weight: 600;
+                cursor: pointer;
+                max-width: 200px;
             }
             .ct-sw {
                 width: 38px; height: 22px; border-radius: 12px;

--- a/dashboard/card/sem-localize.js
+++ b/dashboard/card/sem-localize.js
@@ -1,5 +1,5 @@
 // Auto-generated from translations.json — do not edit manually
-// Generated: 2026-05-30T03:29:22.219613+00:00
+// Generated: 2026-05-30T08:50:44.153139+00:00
 const _semTranslations = {
   "en": {
     "charging": "Charging",
@@ -810,7 +810,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Commanded current"
+    "commanded_current": "Commanded current",
+    "charge_mode": "Charge mode",
+    "charge_mode_solar_only": "Solar only",
+    "charge_mode_solar_plus_cheap": "Solar + cheapest hours",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Always (max)",
+    "charge_mode_off": "Off",
+    "charge_mode_hint_solar_only": "Surplus only — never imports from grid",
+    "charge_mode_hint_solar_plus_cheap": "Surplus by day, grid only in the cheapest hours",
+    "charge_mode_hint_min_plus_solar": "Guarantee Min from grid + solar up to Max",
+    "charge_mode_hint_always_max": "Charge at max regardless of source",
+    "charge_mode_hint_off": "No charging"
   },
   "de": {
     "charging": "Laden",
@@ -1621,7 +1632,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Befohlener Strom"
+    "commanded_current": "Befohlener Strom",
+    "charge_mode": "Lademodus",
+    "charge_mode_solar_only": "Nur Solar",
+    "charge_mode_solar_plus_cheap": "Solar + günstigste Stunden",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Immer (max)",
+    "charge_mode_off": "Aus",
+    "charge_mode_hint_solar_only": "Nur Überschuss — bezieht nie aus dem Netz",
+    "charge_mode_hint_solar_plus_cheap": "Tags Überschuss, nachts Netz nur zur günstigsten Stunde",
+    "charge_mode_hint_min_plus_solar": "Min aus dem Netz garantiert + Solar bis Max",
+    "charge_mode_hint_always_max": "Lädt mit max. Strom, unabhängig von der Quelle",
+    "charge_mode_hint_off": "Kein Laden"
   },
   "fr": {
     "charging": "En charge",
@@ -2432,7 +2454,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Courant commandé"
+    "commanded_current": "Courant commandé",
+    "charge_mode": "Mode de charge",
+    "charge_mode_solar_only": "Solaire seulement",
+    "charge_mode_solar_plus_cheap": "Solaire + heures les moins chères",
+    "charge_mode_min_plus_solar": "Min + Solaire",
+    "charge_mode_always_max": "Toujours (max)",
+    "charge_mode_off": "Arrêt",
+    "charge_mode_hint_solar_only": "Surplus seulement — jamais d'import du réseau",
+    "charge_mode_hint_solar_plus_cheap": "Surplus de jour, réseau uniquement aux heures les moins chères",
+    "charge_mode_hint_min_plus_solar": "Min garanti depuis le réseau + solaire jusqu'à Max",
+    "charge_mode_hint_always_max": "Charge au maximum, peu importe la source",
+    "charge_mode_hint_off": "Pas de charge"
   },
   "es": {
     "charging": "Cargando",
@@ -3243,7 +3276,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corriente solicitada"
+    "commanded_current": "Corriente solicitada",
+    "charge_mode": "Modo de carga",
+    "charge_mode_solar_only": "Solo solar",
+    "charge_mode_solar_plus_cheap": "Solar + horas más baratas",
+    "charge_mode_min_plus_solar": "Mín + Solar",
+    "charge_mode_always_max": "Siempre (máx)",
+    "charge_mode_off": "Apagado",
+    "charge_mode_hint_solar_only": "Solo excedente — nunca importa de la red",
+    "charge_mode_hint_solar_plus_cheap": "Excedente de día, red solo en las horas más baratas",
+    "charge_mode_hint_min_plus_solar": "Mín garantizado de la red + solar hasta Máx",
+    "charge_mode_hint_always_max": "Carga al máximo, sin importar la fuente",
+    "charge_mode_hint_off": "Sin carga"
   },
   "it": {
     "charging": "In carica",
@@ -4054,7 +4098,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corrente richiesta"
+    "commanded_current": "Corrente richiesta",
+    "charge_mode": "Modalità di ricarica",
+    "charge_mode_solar_only": "Solo solare",
+    "charge_mode_solar_plus_cheap": "Solare + ore più economiche",
+    "charge_mode_min_plus_solar": "Min + Solare",
+    "charge_mode_always_max": "Sempre (max)",
+    "charge_mode_off": "Spento",
+    "charge_mode_hint_solar_only": "Solo surplus — mai dalla rete",
+    "charge_mode_hint_solar_plus_cheap": "Surplus di giorno, rete solo nelle ore più economiche",
+    "charge_mode_hint_min_plus_solar": "Min garantito dalla rete + solare fino al Max",
+    "charge_mode_hint_always_max": "Carica al massimo, indipendentemente dalla fonte",
+    "charge_mode_hint_off": "Nessuna ricarica"
   },
   "nl": {
     "charging": "Laden",
@@ -4865,7 +4920,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Aangevraagde stroom"
+    "commanded_current": "Aangevraagde stroom",
+    "charge_mode": "Laadmodus",
+    "charge_mode_solar_only": "Alleen zon",
+    "charge_mode_solar_plus_cheap": "Zon + goedkoopste uren",
+    "charge_mode_min_plus_solar": "Min + Zon",
+    "charge_mode_always_max": "Altijd (max)",
+    "charge_mode_off": "Uit",
+    "charge_mode_hint_solar_only": "Alleen overschot — nooit van het net",
+    "charge_mode_hint_solar_plus_cheap": "Overdag overschot, 's nachts net alleen in de goedkoopste uren",
+    "charge_mode_hint_min_plus_solar": "Min van het net gegarandeerd + zon tot Max",
+    "charge_mode_hint_always_max": "Laadt op max, ongeacht de bron",
+    "charge_mode_hint_off": "Niet laden"
   },
   "cs": {
     "charging": "Nabíjení",
@@ -5676,7 +5742,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Požadovaný proud"
+    "commanded_current": "Požadovaný proud",
+    "charge_mode": "Režim nabíjení",
+    "charge_mode_solar_only": "Pouze solární",
+    "charge_mode_solar_plus_cheap": "Solární + nejlevnější hodiny",
+    "charge_mode_min_plus_solar": "Min + Solární",
+    "charge_mode_always_max": "Vždy (max)",
+    "charge_mode_off": "Vypnuto",
+    "charge_mode_hint_solar_only": "Pouze přebytek — nikdy ze sítě",
+    "charge_mode_hint_solar_plus_cheap": "Přes den přebytek, v noci síť jen v nejlevnějších hodinách",
+    "charge_mode_hint_min_plus_solar": "Min garantováno ze sítě + solární do Max",
+    "charge_mode_hint_always_max": "Nabíjí na max bez ohledu na zdroj",
+    "charge_mode_hint_off": "Bez nabíjení"
   },
   "da": {
     "charging": "Oplader",
@@ -6487,7 +6564,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Anmodet strøm"
+    "commanded_current": "Anmodet strøm",
+    "charge_mode": "Opladningstilstand",
+    "charge_mode_solar_only": "Kun sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigste timer",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Altid (max)",
+    "charge_mode_off": "Fra",
+    "charge_mode_hint_solar_only": "Kun overskud — aldrig fra nettet",
+    "charge_mode_hint_solar_plus_cheap": "Overskud om dagen, net kun i de billigste timer",
+    "charge_mode_hint_min_plus_solar": "Min garanteret fra nettet + sol op til Max",
+    "charge_mode_hint_always_max": "Oplader max uanset kilde",
+    "charge_mode_hint_off": "Ingen opladning"
   },
   "fi": {
     "charging": "Lataus",
@@ -7298,7 +7386,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Pyydetty virta"
+    "commanded_current": "Pyydetty virta",
+    "charge_mode": "Lataustila",
+    "charge_mode_solar_only": "Vain aurinko",
+    "charge_mode_solar_plus_cheap": "Aurinko + halvimmat tunnit",
+    "charge_mode_min_plus_solar": "Min + Aurinko",
+    "charge_mode_always_max": "Aina (max)",
+    "charge_mode_off": "Pois",
+    "charge_mode_hint_solar_only": "Vain ylijäämä — ei koskaan verkosta",
+    "charge_mode_hint_solar_plus_cheap": "Päivällä ylijäämä, yöllä verkko vain halvimpina tunteina",
+    "charge_mode_hint_min_plus_solar": "Min taataan verkosta + aurinko Max-asti",
+    "charge_mode_hint_always_max": "Lataa täydellä teholla lähteestä riippumatta",
+    "charge_mode_hint_off": "Ei latausta"
   },
   "hu": {
     "charging": "Töltés",
@@ -8109,7 +8208,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Kért áram"
+    "commanded_current": "Kért áram",
+    "charge_mode": "Töltési mód",
+    "charge_mode_solar_only": "Csak nap",
+    "charge_mode_solar_plus_cheap": "Nap + legolcsóbb órák",
+    "charge_mode_min_plus_solar": "Min + Nap",
+    "charge_mode_always_max": "Mindig (max)",
+    "charge_mode_off": "Ki",
+    "charge_mode_hint_solar_only": "Csak többlet — soha nem a hálózatról",
+    "charge_mode_hint_solar_plus_cheap": "Napközben többlet, éjjel hálózat csak a legolcsóbb órákban",
+    "charge_mode_hint_min_plus_solar": "Min garantált a hálózatról + nap Max-ig",
+    "charge_mode_hint_always_max": "Maximum tölt, forrástól függetlenül",
+    "charge_mode_hint_off": "Nincs töltés"
   },
   "no": {
     "charging": "Lader",
@@ -8920,7 +9030,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Forespurt strøm"
+    "commanded_current": "Forespurt strøm",
+    "charge_mode": "Lademodus",
+    "charge_mode_solar_only": "Kun sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigste timer",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Alltid (maks)",
+    "charge_mode_off": "Av",
+    "charge_mode_hint_solar_only": "Bare overskudd — aldri fra nettet",
+    "charge_mode_hint_solar_plus_cheap": "Overskudd på dagen, nett kun i de billigste timene",
+    "charge_mode_hint_min_plus_solar": "Min garantert fra nettet + sol opp til Maks",
+    "charge_mode_hint_always_max": "Lader maks uansett kilde",
+    "charge_mode_hint_off": "Ingen lading"
   },
   "pl": {
     "charging": "Ładowanie",
@@ -9731,7 +9852,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Zadany prąd"
+    "commanded_current": "Zadany prąd",
+    "charge_mode": "Tryb ładowania",
+    "charge_mode_solar_only": "Tylko słońce",
+    "charge_mode_solar_plus_cheap": "Słońce + najtańsze godziny",
+    "charge_mode_min_plus_solar": "Min + Słońce",
+    "charge_mode_always_max": "Zawsze (max)",
+    "charge_mode_off": "Wył",
+    "charge_mode_hint_solar_only": "Tylko nadwyżka — nigdy z sieci",
+    "charge_mode_hint_solar_plus_cheap": "W dzień nadwyżka, w nocy sieć tylko w najtańszych godzinach",
+    "charge_mode_hint_min_plus_solar": "Min gwarantowane z sieci + słońce do Max",
+    "charge_mode_hint_always_max": "Ładuje na max, niezależnie od źródła",
+    "charge_mode_hint_off": "Brak ładowania"
   },
   "pt": {
     "charging": "A carregar",
@@ -10542,7 +10674,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corrente solicitada"
+    "commanded_current": "Corrente solicitada",
+    "charge_mode": "Modo de carga",
+    "charge_mode_solar_only": "Apenas solar",
+    "charge_mode_solar_plus_cheap": "Solar + horas mais baratas",
+    "charge_mode_min_plus_solar": "Mín + Solar",
+    "charge_mode_always_max": "Sempre (máx)",
+    "charge_mode_off": "Desligado",
+    "charge_mode_hint_solar_only": "Apenas excedente — nunca importa da rede",
+    "charge_mode_hint_solar_plus_cheap": "Excedente de dia, rede só nas horas mais baratas",
+    "charge_mode_hint_min_plus_solar": "Mín garantido da rede + solar até o Máx",
+    "charge_mode_hint_always_max": "Carrega no máximo, independente da fonte",
+    "charge_mode_hint_off": "Sem carga"
   },
   "ro": {
     "charging": "Încărcare",
@@ -11353,7 +11496,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Curent solicitat"
+    "commanded_current": "Curent solicitat",
+    "charge_mode": "Mod de încărcare",
+    "charge_mode_solar_only": "Doar solar",
+    "charge_mode_solar_plus_cheap": "Solar + cele mai ieftine ore",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Întotdeauna (max)",
+    "charge_mode_off": "Oprit",
+    "charge_mode_hint_solar_only": "Doar surplus — niciodată din rețea",
+    "charge_mode_hint_solar_plus_cheap": "Surplus ziua, rețea doar în orele cele mai ieftine",
+    "charge_mode_hint_min_plus_solar": "Min garantat din rețea + solar până la Max",
+    "charge_mode_hint_always_max": "Încarcă la maxim, indiferent de sursă",
+    "charge_mode_hint_off": "Fără încărcare"
   },
   "sv": {
     "charging": "Laddar",
@@ -12164,7 +12318,18 @@ const _semTranslations = {
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Begärd ström"
+    "commanded_current": "Begärd ström",
+    "charge_mode": "Laddningsläge",
+    "charge_mode_solar_only": "Endast sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigaste timmar",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Alltid (max)",
+    "charge_mode_off": "Av",
+    "charge_mode_hint_solar_only": "Endast överskott — aldrig från elnätet",
+    "charge_mode_hint_solar_plus_cheap": "Överskott dagtid, elnät endast under de billigaste timmarna",
+    "charge_mode_hint_min_plus_solar": "Min garanterat från elnätet + sol upp till Max",
+    "charge_mode_hint_always_max": "Laddar max, oavsett källa",
+    "charge_mode_hint_off": "Ingen laddning"
   }
 };
 

--- a/dashboard/card/src/cards/sem-ev-status-card.js
+++ b/dashboard/card/src/cards/sem-ev-status-card.js
@@ -420,7 +420,33 @@ class SEMEVStatusCard extends SEMLitBase {
         const chargeColor = needsCharge ? '#f06292' : '#8DC892';
         const chargeText = needsCharge ? this._t('yes') : this._t('no');
 
-        const nightEntityId = `switch.sem_charger_${id}_night_charging`;
+        // Charge mode selector (#277 Phase B.2). Replaces the legacy
+        // four-toggle stack (ev_charging_mode select + night_charging +
+        // smart_night_charging + tariff_optimized switches) with one
+        // named per-charger select. Options + label come from the HA
+        // select entity itself — solar_plus_cheap is conditionally
+        // hidden by the entity's ``options`` property when no dynamic
+        // tariff is configured (Q1 resolution).
+        const chargeModeEntityId = `select.sem_charger_${id}_charge_mode`;
+        const chargeModeAttrs = this._stateAttrs(chargeModeEntityId);
+        const chargeMode = this._stateStr(chargeModeEntityId) || 'min_plus_solar';
+        const chargeModeOptions = chargeModeAttrs.options || [
+            'solar_only', 'min_plus_solar', 'always_max', 'off',
+        ];
+        const chargeModeLabels = {
+            solar_only:       this._t('charge_mode_solar_only'),
+            solar_plus_cheap: this._t('charge_mode_solar_plus_cheap'),
+            min_plus_solar:   this._t('charge_mode_min_plus_solar'),
+            always_max:       this._t('charge_mode_always_max'),
+            off:              this._t('charge_mode_off'),
+        };
+        const chargeModeHints = {
+            solar_only:       this._t('charge_mode_hint_solar_only'),
+            solar_plus_cheap: this._t('charge_mode_hint_solar_plus_cheap'),
+            min_plus_solar:   this._t('charge_mode_hint_min_plus_solar'),
+            always_max:       this._t('charge_mode_hint_always_max'),
+            off:              this._t('charge_mode_hint_off'),
+        };
 
         // Charge Target range (#245): Min (floor/night) + Max (solar ceiling) handles
         const targetTypeId = `select.sem_charger_${id}_ev_target_type`;
@@ -433,11 +459,9 @@ class SEMEVStatusCard extends SEMLitBase {
         const maxEntityId = isSoc
             ? `number.sem_charger_${id}_target_soc_max`
             : `number.sem_charger_${id}_daily_ev_target_max`;
-        const nightOnLive = this._stateStr(nightEntityId) === 'on';
 
-        // Deadline (#246) + tariff-optimized (#247)
-        const tariffEntityId = `switch.sem_charger_${id}_tariff_optimized`;
-        const tariffOnLive = this._stateStr(tariffEntityId) === 'on';
+        // Deadline (#246) — the tariff/grid toggles moved into the
+        // Charge mode selector above, but the deadline knob remains.
         const targetTimeId = `time.sem_charger_${id}_target_time`;
         const targetTimeRaw = this._stateStr(targetTimeId);  // "HH:MM:SS"
         const targetTimeLabel = targetTimeRaw ? targetTimeRaw.slice(0, 5) : '—';
@@ -454,6 +478,12 @@ class SEMEVStatusCard extends SEMLitBase {
                     { hour: '2-digit', minute: '2-digit' });
             } catch (e) { /* ignore */ }
         }
+        // Next cheap window only relevant when the mode actually uses
+        // tariff windows. Phase B.2 hides it for the other modes so
+        // users don't see a confusing "next cheap at HH:MM" line on a
+        // mode that ignores tariff entirely.
+        const showCheapHint = chargeMode === 'solar_plus_cheap'
+            && nextCheapLabel;
 
         // Range the charge will ADD to reach the Min (guaranteed) target, in km —
         // updates live as the Min handle moves. Solar may add more, up to Max. (#245)
@@ -462,12 +492,6 @@ class SEMEVStatusCard extends SEMLitBase {
             ? Math.max(0, (minTarget - soc) / 100 * capacityKwh)
             : Math.max(0, minTarget - dailyEnergy);
         const chargeKm = consumption > 0 ? Math.round(gapKwh / consumption * 100) : null;
-
-        const ctToggle = (on, entityId) => html`
-            <span class="ct-sw ${on ? 'on' : 'off'}"
-                @click=${(e) => { e.stopPropagation(); this._toggleSwitch(entityId); }}>
-                <span class="ct-knob"></span>
-            </span>`;
 
         const unitControl = ttOptions.length > 1
             ? html`<select class="ct-unit" .value=${targetType}
@@ -533,26 +557,34 @@ class SEMEVStatusCard extends SEMLitBase {
                         ${unitControl}
                     </div>
                     ${this._renderRangeSlider(minEntityId, maxEntityId, isSoc)}
+                    <!-- #277 Phase B.2: one named Charge mode selector
+                         replaces the legacy ev_grid_charging + nested
+                         ev_tariff_mode toggles. Options come from the HA
+                         entity itself (solar_plus_cheap is hidden when no
+                         dynamic tariff is configured, per Q1). The hint
+                         line under it explains what the selected mode
+                         actually does — cuts the toggle-soup mystery the
+                         #247 review flagged. -->
                     <div class="ct-row">
-                        <span class="ct-label">${this._t('ev_grid_charging')}</span>
-                        <span class="ct-ctl">${ctToggle(nightOnLive, nightEntityId)}</span>
+                        <span class="ct-label">${this._t('charge_mode')}</span>
+                        <span class="ct-ctl">
+                            <select class="ct-mode-select"
+                                    .value=${chargeMode}
+                                    @click=${(e) => e.stopPropagation()}
+                                    @change=${(e) => this._selectOption(chargeModeEntityId, e.target.value)}>
+                                ${chargeModeOptions.map(o => html`
+                                    <option value=${o} ?selected=${o === chargeMode}>
+                                        ${chargeModeLabels[o] || o}
+                                    </option>`)}
+                            </select>
+                        </span>
                     </div>
-                    <!-- Tariff is a refinement OF grid charging (when, not whether): nest it.
-                         Hidden when overnight grid charging is OFF so the hierarchy is enforced visually -
-                         the switch cannot be toggled in isolation (D2). -->
-                    ${nightOnLive ? html`
-                        <div class="ct-row ct-subrow">
-                            <span class="ct-label">${this._t('ev_tariff_mode')}</span>
-                            <span class="ct-ctl">${ctToggle(tariffOnLive, tariffEntityId)}</span>
-                        </div>
-                        ${tariffOnLive ? html`
-                            <div class="ct-subhint">
-                                ${this._t('ev_tariff_hint')}${nextCheapLabel
-                                    ? html` · ${this._t('ev_next_cheap')} <b style="color:#8DC892">${nextCheapLabel}</b>`
-                                    : nothing}
-                            </div>
+                    <div class="ct-subhint">
+                        ${chargeModeHints[chargeMode] || ''}
+                        ${showCheapHint ? html`
+                            · ${this._t('ev_next_cheap')} <b style="color:#8DC892">${nextCheapLabel}</b>
                         ` : nothing}
-                    ` : nothing}
+                    </div>
                     <div class="ct-row clickable"
                         @click=${() => this.dispatchEvent(new CustomEvent('hass-more-info',
                             { bubbles: true, composed: true, detail: { entityId: targetTimeId } }))}>
@@ -644,16 +676,10 @@ class SEMEVStatusCard extends SEMLitBase {
         const strategy = this._valStr('charging_state');
         const curr = semGetCurrency(this._hass);
 
-        // #255: charging mode is per-charger — resolve primary (fallback global).
-        const modeEntity = this._hass?.states[
-            this._pcEntity('select', 'ev_charging_mode', 'select.sem_ev_charging_mode')];
-        const mode = modeEntity?.state || 'auto';
-        const modeLabels = {
-            auto: this._t('mode_auto'),
-            minpv: this._t('mode_minpv'),
-            now: this._t('maximum'),
-            off: this._t('off'),
-        };
+        // (Dead ``modeLabels`` / ``modeEntity`` lookup of the legacy
+        // ``ev_charging_mode`` select removed in #277 Phase B.2 — the
+        // per-charger Charge mode selector lives inside
+        // ``_renderChargerSection`` now and consumes its own entity.)
 
         const wrapClass = charging ? 'wrap state-charging'
             : connected ? 'wrap state-connected'
@@ -1123,6 +1149,25 @@ class SEMEVStatusCard extends SEMLitBase {
             .ct-unit-static {
                 font-size: 12px; font-weight: 600;
                 color: var(--secondary-text-color, #999); padding: 4px 2px;
+            }
+            /* #277 Phase B.2 — Charge mode selector. Wider than ct-unit
+               (multi-word labels) and aligned right inside the row's
+               .ct-ctl cell. Same caret + chrome as ct-unit so the two
+               selectors visually rhyme. */
+            .ct-mode-select {
+                appearance: none; -webkit-appearance: none;
+                background-color: var(--secondary-background-color, rgba(255,255,255,0.07));
+                background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath fill='%23bbbbbb' d='M7 10l5 5 5-5z'/%3E%3C/svg%3E");
+                background-repeat: no-repeat;
+                background-position: right 6px center;
+                background-size: 14px;
+                color: var(--primary-text-color, #e0e0e0);
+                border: 1px solid var(--divider-color, rgba(255,255,255,0.12));
+                border-radius: 8px;
+                padding: 4px 24px 4px 10px;
+                font-size: 12px; font-weight: 600;
+                cursor: pointer;
+                max-width: 200px;
             }
             .ct-sw {
                 width: 38px; height: 22px; border-radius: 12px;

--- a/dashboard/translations.json
+++ b/dashboard/translations.json
@@ -808,7 +808,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Commanded current"
+    "commanded_current": "Commanded current",
+    "charge_mode": "Charge mode",
+    "charge_mode_solar_only": "Solar only",
+    "charge_mode_solar_plus_cheap": "Solar + cheapest hours",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Always (max)",
+    "charge_mode_off": "Off",
+    "charge_mode_hint_solar_only": "Surplus only — never imports from grid",
+    "charge_mode_hint_solar_plus_cheap": "Surplus by day, grid only in the cheapest hours",
+    "charge_mode_hint_min_plus_solar": "Guarantee Min from grid + solar up to Max",
+    "charge_mode_hint_always_max": "Charge at max regardless of source",
+    "charge_mode_hint_off": "No charging"
   },
   "de": {
     "charging": "Laden",
@@ -1619,7 +1630,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Befohlener Strom"
+    "commanded_current": "Befohlener Strom",
+    "charge_mode": "Lademodus",
+    "charge_mode_solar_only": "Nur Solar",
+    "charge_mode_solar_plus_cheap": "Solar + günstigste Stunden",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Immer (max)",
+    "charge_mode_off": "Aus",
+    "charge_mode_hint_solar_only": "Nur Überschuss — bezieht nie aus dem Netz",
+    "charge_mode_hint_solar_plus_cheap": "Tags Überschuss, nachts Netz nur zur günstigsten Stunde",
+    "charge_mode_hint_min_plus_solar": "Min aus dem Netz garantiert + Solar bis Max",
+    "charge_mode_hint_always_max": "Lädt mit max. Strom, unabhängig von der Quelle",
+    "charge_mode_hint_off": "Kein Laden"
   },
   "fr": {
     "charging": "En charge",
@@ -2430,7 +2452,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Courant commandé"
+    "commanded_current": "Courant commandé",
+    "charge_mode": "Mode de charge",
+    "charge_mode_solar_only": "Solaire seulement",
+    "charge_mode_solar_plus_cheap": "Solaire + heures les moins chères",
+    "charge_mode_min_plus_solar": "Min + Solaire",
+    "charge_mode_always_max": "Toujours (max)",
+    "charge_mode_off": "Arrêt",
+    "charge_mode_hint_solar_only": "Surplus seulement — jamais d'import du réseau",
+    "charge_mode_hint_solar_plus_cheap": "Surplus de jour, réseau uniquement aux heures les moins chères",
+    "charge_mode_hint_min_plus_solar": "Min garanti depuis le réseau + solaire jusqu'à Max",
+    "charge_mode_hint_always_max": "Charge au maximum, peu importe la source",
+    "charge_mode_hint_off": "Pas de charge"
   },
   "es": {
     "charging": "Cargando",
@@ -3241,7 +3274,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corriente solicitada"
+    "commanded_current": "Corriente solicitada",
+    "charge_mode": "Modo de carga",
+    "charge_mode_solar_only": "Solo solar",
+    "charge_mode_solar_plus_cheap": "Solar + horas más baratas",
+    "charge_mode_min_plus_solar": "Mín + Solar",
+    "charge_mode_always_max": "Siempre (máx)",
+    "charge_mode_off": "Apagado",
+    "charge_mode_hint_solar_only": "Solo excedente — nunca importa de la red",
+    "charge_mode_hint_solar_plus_cheap": "Excedente de día, red solo en las horas más baratas",
+    "charge_mode_hint_min_plus_solar": "Mín garantizado de la red + solar hasta Máx",
+    "charge_mode_hint_always_max": "Carga al máximo, sin importar la fuente",
+    "charge_mode_hint_off": "Sin carga"
   },
   "it": {
     "charging": "In carica",
@@ -4052,7 +4096,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corrente richiesta"
+    "commanded_current": "Corrente richiesta",
+    "charge_mode": "Modalità di ricarica",
+    "charge_mode_solar_only": "Solo solare",
+    "charge_mode_solar_plus_cheap": "Solare + ore più economiche",
+    "charge_mode_min_plus_solar": "Min + Solare",
+    "charge_mode_always_max": "Sempre (max)",
+    "charge_mode_off": "Spento",
+    "charge_mode_hint_solar_only": "Solo surplus — mai dalla rete",
+    "charge_mode_hint_solar_plus_cheap": "Surplus di giorno, rete solo nelle ore più economiche",
+    "charge_mode_hint_min_plus_solar": "Min garantito dalla rete + solare fino al Max",
+    "charge_mode_hint_always_max": "Carica al massimo, indipendentemente dalla fonte",
+    "charge_mode_hint_off": "Nessuna ricarica"
   },
   "nl": {
     "charging": "Laden",
@@ -4863,7 +4918,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Aangevraagde stroom"
+    "commanded_current": "Aangevraagde stroom",
+    "charge_mode": "Laadmodus",
+    "charge_mode_solar_only": "Alleen zon",
+    "charge_mode_solar_plus_cheap": "Zon + goedkoopste uren",
+    "charge_mode_min_plus_solar": "Min + Zon",
+    "charge_mode_always_max": "Altijd (max)",
+    "charge_mode_off": "Uit",
+    "charge_mode_hint_solar_only": "Alleen overschot — nooit van het net",
+    "charge_mode_hint_solar_plus_cheap": "Overdag overschot, 's nachts net alleen in de goedkoopste uren",
+    "charge_mode_hint_min_plus_solar": "Min van het net gegarandeerd + zon tot Max",
+    "charge_mode_hint_always_max": "Laadt op max, ongeacht de bron",
+    "charge_mode_hint_off": "Niet laden"
   },
   "cs": {
     "charging": "Nabíjení",
@@ -5674,7 +5740,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Požadovaný proud"
+    "commanded_current": "Požadovaný proud",
+    "charge_mode": "Režim nabíjení",
+    "charge_mode_solar_only": "Pouze solární",
+    "charge_mode_solar_plus_cheap": "Solární + nejlevnější hodiny",
+    "charge_mode_min_plus_solar": "Min + Solární",
+    "charge_mode_always_max": "Vždy (max)",
+    "charge_mode_off": "Vypnuto",
+    "charge_mode_hint_solar_only": "Pouze přebytek — nikdy ze sítě",
+    "charge_mode_hint_solar_plus_cheap": "Přes den přebytek, v noci síť jen v nejlevnějších hodinách",
+    "charge_mode_hint_min_plus_solar": "Min garantováno ze sítě + solární do Max",
+    "charge_mode_hint_always_max": "Nabíjí na max bez ohledu na zdroj",
+    "charge_mode_hint_off": "Bez nabíjení"
   },
   "da": {
     "charging": "Oplader",
@@ -6485,7 +6562,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Anmodet strøm"
+    "commanded_current": "Anmodet strøm",
+    "charge_mode": "Opladningstilstand",
+    "charge_mode_solar_only": "Kun sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigste timer",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Altid (max)",
+    "charge_mode_off": "Fra",
+    "charge_mode_hint_solar_only": "Kun overskud — aldrig fra nettet",
+    "charge_mode_hint_solar_plus_cheap": "Overskud om dagen, net kun i de billigste timer",
+    "charge_mode_hint_min_plus_solar": "Min garanteret fra nettet + sol op til Max",
+    "charge_mode_hint_always_max": "Oplader max uanset kilde",
+    "charge_mode_hint_off": "Ingen opladning"
   },
   "fi": {
     "charging": "Lataus",
@@ -7296,7 +7384,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Pyydetty virta"
+    "commanded_current": "Pyydetty virta",
+    "charge_mode": "Lataustila",
+    "charge_mode_solar_only": "Vain aurinko",
+    "charge_mode_solar_plus_cheap": "Aurinko + halvimmat tunnit",
+    "charge_mode_min_plus_solar": "Min + Aurinko",
+    "charge_mode_always_max": "Aina (max)",
+    "charge_mode_off": "Pois",
+    "charge_mode_hint_solar_only": "Vain ylijäämä — ei koskaan verkosta",
+    "charge_mode_hint_solar_plus_cheap": "Päivällä ylijäämä, yöllä verkko vain halvimpina tunteina",
+    "charge_mode_hint_min_plus_solar": "Min taataan verkosta + aurinko Max-asti",
+    "charge_mode_hint_always_max": "Lataa täydellä teholla lähteestä riippumatta",
+    "charge_mode_hint_off": "Ei latausta"
   },
   "hu": {
     "charging": "Töltés",
@@ -8107,7 +8206,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Kért áram"
+    "commanded_current": "Kért áram",
+    "charge_mode": "Töltési mód",
+    "charge_mode_solar_only": "Csak nap",
+    "charge_mode_solar_plus_cheap": "Nap + legolcsóbb órák",
+    "charge_mode_min_plus_solar": "Min + Nap",
+    "charge_mode_always_max": "Mindig (max)",
+    "charge_mode_off": "Ki",
+    "charge_mode_hint_solar_only": "Csak többlet — soha nem a hálózatról",
+    "charge_mode_hint_solar_plus_cheap": "Napközben többlet, éjjel hálózat csak a legolcsóbb órákban",
+    "charge_mode_hint_min_plus_solar": "Min garantált a hálózatról + nap Max-ig",
+    "charge_mode_hint_always_max": "Maximum tölt, forrástól függetlenül",
+    "charge_mode_hint_off": "Nincs töltés"
   },
   "no": {
     "charging": "Lader",
@@ -8918,7 +9028,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Forespurt strøm"
+    "commanded_current": "Forespurt strøm",
+    "charge_mode": "Lademodus",
+    "charge_mode_solar_only": "Kun sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigste timer",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Alltid (maks)",
+    "charge_mode_off": "Av",
+    "charge_mode_hint_solar_only": "Bare overskudd — aldri fra nettet",
+    "charge_mode_hint_solar_plus_cheap": "Overskudd på dagen, nett kun i de billigste timene",
+    "charge_mode_hint_min_plus_solar": "Min garantert fra nettet + sol opp til Maks",
+    "charge_mode_hint_always_max": "Lader maks uansett kilde",
+    "charge_mode_hint_off": "Ingen lading"
   },
   "pl": {
     "charging": "Ładowanie",
@@ -9729,7 +9850,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Zadany prąd"
+    "commanded_current": "Zadany prąd",
+    "charge_mode": "Tryb ładowania",
+    "charge_mode_solar_only": "Tylko słońce",
+    "charge_mode_solar_plus_cheap": "Słońce + najtańsze godziny",
+    "charge_mode_min_plus_solar": "Min + Słońce",
+    "charge_mode_always_max": "Zawsze (max)",
+    "charge_mode_off": "Wył",
+    "charge_mode_hint_solar_only": "Tylko nadwyżka — nigdy z sieci",
+    "charge_mode_hint_solar_plus_cheap": "W dzień nadwyżka, w nocy sieć tylko w najtańszych godzinach",
+    "charge_mode_hint_min_plus_solar": "Min gwarantowane z sieci + słońce do Max",
+    "charge_mode_hint_always_max": "Ładuje na max, niezależnie od źródła",
+    "charge_mode_hint_off": "Brak ładowania"
   },
   "pt": {
     "charging": "A carregar",
@@ -10540,7 +10672,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Corrente solicitada"
+    "commanded_current": "Corrente solicitada",
+    "charge_mode": "Modo de carga",
+    "charge_mode_solar_only": "Apenas solar",
+    "charge_mode_solar_plus_cheap": "Solar + horas mais baratas",
+    "charge_mode_min_plus_solar": "Mín + Solar",
+    "charge_mode_always_max": "Sempre (máx)",
+    "charge_mode_off": "Desligado",
+    "charge_mode_hint_solar_only": "Apenas excedente — nunca importa da rede",
+    "charge_mode_hint_solar_plus_cheap": "Excedente de dia, rede só nas horas mais baratas",
+    "charge_mode_hint_min_plus_solar": "Mín garantido da rede + solar até o Máx",
+    "charge_mode_hint_always_max": "Carrega no máximo, independente da fonte",
+    "charge_mode_hint_off": "Sem carga"
   },
   "ro": {
     "charging": "Încărcare",
@@ -11351,7 +11494,18 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Curent solicitat"
+    "commanded_current": "Curent solicitat",
+    "charge_mode": "Mod de încărcare",
+    "charge_mode_solar_only": "Doar solar",
+    "charge_mode_solar_plus_cheap": "Solar + cele mai ieftine ore",
+    "charge_mode_min_plus_solar": "Min + Solar",
+    "charge_mode_always_max": "Întotdeauna (max)",
+    "charge_mode_off": "Oprit",
+    "charge_mode_hint_solar_only": "Doar surplus — niciodată din rețea",
+    "charge_mode_hint_solar_plus_cheap": "Surplus ziua, rețea doar în orele cele mai ieftine",
+    "charge_mode_hint_min_plus_solar": "Min garantat din rețea + solar până la Max",
+    "charge_mode_hint_always_max": "Încarcă la maxim, indiferent de sursă",
+    "charge_mode_hint_off": "Fără încărcare"
   },
   "sv": {
     "charging": "Laddar",
@@ -12162,6 +12316,17 @@
     "plan_strip_wait": "waiting",
     "plan_strip_charging": "charging",
     "plan_strip_done": "done",
-    "commanded_current": "Begärd ström"
+    "commanded_current": "Begärd ström",
+    "charge_mode": "Laddningsläge",
+    "charge_mode_solar_only": "Endast sol",
+    "charge_mode_solar_plus_cheap": "Sol + billigaste timmar",
+    "charge_mode_min_plus_solar": "Min + Sol",
+    "charge_mode_always_max": "Alltid (max)",
+    "charge_mode_off": "Av",
+    "charge_mode_hint_solar_only": "Endast överskott — aldrig från elnätet",
+    "charge_mode_hint_solar_plus_cheap": "Överskott dagtid, elnät endast under de billigaste timmarna",
+    "charge_mode_hint_min_plus_solar": "Min garanterat från elnätet + sol upp till Max",
+    "charge_mode_hint_always_max": "Laddar max, oavsett källa",
+    "charge_mode_hint_off": "Ingen laddning"
   }
 }


### PR DESCRIPTION
## Summary

Phase B.2 of the EV charge UX consolidation arc (#277). Replaces the legacy four-toggle stack in the per-charger card section with a single named ``Charge mode`` selector + a per-mode help line. The user-visible payoff of the #277 arc.

The strategy machine still reads the legacy ``ev_charging_mode`` + ``_tariff_optimized_for`` switches under the hood — that's the deferred Phase C work per the Phase B PR narrative. Phase B.2's UI just exposes the named modes to the user.

## What changed

- **`dashboard/card/src/cards/sem-ev-status-card.js`** — `_renderChargerSection`:
  - Dropped the `ctToggle` helper + `nightOnLive` + `tariffOnLive` + the nested tariff sub-row.
  - Added the `Charge mode` selector with 5-mode labels + per-mode help lines.
  - Gated the "Next cheap window …" indicator on `chargeMode === 'solar_plus_cheap'` — was always shown when tariff was on, even in modes that ignore it.
  - `render`: removed the dead `modeLabels` / `modeEntity` lookup of the legacy `ev_charging_mode` select (its data was never rendered).
  - New `.ct-mode-select` CSS modeled on the existing `.ct-unit` select.
- **`dashboard/translations.json`** — 11 new keys × 15 languages: `charge_mode`, the 5 mode labels, the 5 per-mode hints.
- **`dashboard/card/sem-localize.js`** — regenerated.
- **`dashboard/card/dist/sem-cards.js`** — rebuilt bundle.

## Per-mode hint text (English)

| Mode | Hint |
|---|---|
| Solar only | Surplus only — never imports from grid |
| Solar + cheapest hours | Surplus by day, grid only in the cheapest hours |
| Min + Solar | Guarantee Min from grid + solar up to Max |
| Always (max) | Charge at max regardless of source |
| Off | No charging |

## Verified on HA-TEST

- Migration ran cleanly: ``charge_mode = "min_plus_solar"`` (derived from legacy ``pv + night=on + tariff=off``)
- Entity ``select.sem_charger_ev_charger_charge_mode`` registered with options ``["solar_only","min_plus_solar","always_max","off"]`` — ``solar_plus_cheap`` correctly hidden (no dynamic tariff configured)
- Schema bumped to v6
- Card bundle md5-verified on HA-TEST
- No regressions in suite: 2136 / 2136 tests pass (Phase B.2 is presentation-only, no test changes needed)

## Issues addressed
- Refs #277 (Phase B.2 of the consolidation arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)