### PR TITLE
#277 Phase C: strategy machine reads charge_mode + legacy switch removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,103 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] — v1.7.0 candidate
+
+The **EV charge UX consolidation** release (#277). Replaces the
+four-toggle soup (``ev_charging_mode`` × ``night_charging`` ×
+``smart_night_charging`` × ``tariff_optimized``) with one named
+per-charger ``Charge mode`` selector. Three-phase arc shipped across
+five PRs (A + B + B.2 + C + #298 today-plan ETAs).
+
+### New
+
+- **Per-charger ``Charge mode`` selector** with five modes:
+  ``Solar only`` / ``Solar + cheapest hours`` / ``Min + Solar``
+  (default) / ``Always (max)`` / ``Off``. ``Solar + cheapest hours``
+  is dynamically hidden when no dynamic tariff is configured.
+- **Per-mode help line** in the EV card explains what each mode
+  actually does — cuts the toggle-soup mystery the #247 review
+  flagged.
+- **Today's plan timeline** gains three ETA rows (#298): "Battery
+  full at HH:MM" while charging, "Battery reaches floor at HH:MM"
+  while discharging, "EV reaches target at HH:MM" while a charging
+  session is in progress.
+
+### ⚠️ Behavioural change — explicit-``minpv`` legacy users
+
+A small population of users explicitly set the legacy
+``ev_charging_mode`` to ``minpv`` (the "force Min from grid + solar
+to Max" mode). The Phase A migration mapped them to
+``min_plus_solar``, which in v1.6.x kept their daytime behaviour
+unchanged (the strategy machine still read the legacy field). v1.7.0
+Phase C makes ``min_plus_solar`` **zone-adaptive during the day** —
+the Min guarantee now comes from NIGHT charging top-up only, not
+from forced grid pull at noon. The Min target itself is unchanged;
+the daytime path now matches what most installs (``pv + night=on``)
+were always doing.
+
+If you want strict "Min from grid at all times" behaviour, pick
+``always_max`` from the new selector — it charges at maximum
+regardless of source. Otherwise the new ``min_plus_solar`` default
+adapts to your battery SOC zone (battery priority when low, surplus
+when high, battery-assist in Zone 4) — generally more efficient
+than forced grid pull.
+
+### Migrations (automatic on first load post-upgrade)
+
+- **v4 → v5** (Phase A): Each charger gets a ``charge_mode`` derived
+  from its existing toggle state. The legacy fields stay in place.
+- **v5 → v6** (Phase B fix-up): Re-derives ``charge_mode`` for
+  installs whose Phase A derivation silently lost the
+  ``tariff_optimized`` signal (``pv/auto/self_consumption + tariff_on``
+  → ``solar_plus_cheap``).
+- **v6 → v7** (Phase C): Drops the now-dead ``ev_charging_mode`` per-
+  charger config key. The legacy ``select.sem_charger_<id>_ev_charging_mode``
+  entity is removed from the registry automatically.
+
+### Removed
+
+- **Per-charger switches** ``switch.sem_charger_<id>_night_charging``,
+  ``...smart_night_charging``, ``...tariff_optimized`` — the named
+  ``charge_mode`` selector carries all three intents now. Existing
+  automations that read these switches will need to read the
+  ``charge_mode`` select state instead.
+- **Per-charger select** ``select.sem_charger_<id>_ev_charging_mode``
+  — superseded by the new ``charge_mode`` selector.
+- **Global switches** ``switch.sem_night_charging`` and
+  ``switch.sem_smart_night_charging`` — same; ``observer_mode`` is
+  the only remaining global switch.
+- **Config-flow toggle** ``smart_night_charging`` — the named modes
+  carry the intent.
+- **Strategy machine legacy reads**: ``ev_charging_mode`` is no
+  longer consulted anywhere; ``_tariff_optimized_for`` derives from
+  the named mode.
+
+### Internal
+
+- New ``consts/ev_charge_modes.py`` — shared constants
+  (``EV_CHARGE_MODES``, ``MODE_NIGHT_ALLOWED``, ``MODE_USES_TARIFF``,
+  ``MODE_USES_SMART_NIGHT``, ``MODE_TO_LEGACY_CHARGING_MODE``,
+  ``DEFAULT_EV_CHARGE_MODE``) and the ``effective_charge_mode_for``
+  resolver. Single source of truth for the mode taxonomy across
+  ``SEMCoordinator``, ``ChargingStateMachine``, ``EVControlMixin``,
+  the dashboard cards.
+- ``async_migrate_entry`` accumulator refactor — each step reads
+  from / writes back to threaded ``accumulated_{data,options}``
+  accumulators. Fixes a pre-existing bug exposed by chaining 4
+  migration steps (each was re-reading the original entry options on
+  test harnesses).
+- 15-language translations updated; legacy entries cleaned from
+  ``strings.json`` + 15 per-language files.
+- Suite: 2130 / 2130 tests passing.
+
+### Issues addressed
+
+- Closes #277 (EV charge UX consolidation arc)
+- Closes #298 (Today's plan battery / EV ETA rows)
+
+---
+
 ## [1.6.2] — 2026-05-30
 
 The **Phase D.2 cleanup + EV-power realtime** patch.

--- a/__init__.py
+++ b/__init__.py
@@ -338,6 +338,58 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
             )
             return False
 
+    if entry.version < 7:
+        try:
+            # v6 → v7 (#277 Phase C): drop the now-dead legacy
+            # ``ev_charging_mode`` per-charger key. Phase C made the
+            # named ``charge_mode`` the authoritative input to both
+            # the strategy machine and ``_tariff_optimized_for``; the
+            # legacy mode string is no longer read anywhere. Removing
+            # it from the persisted config prevents stale values from
+            # leaking back into the UI (the ``select.sem_charger_<id>
+            # _ev_charging_mode`` entity is also retired in Phase C —
+            # the entity registry's stale-cleanup in ``select.py``
+            # purges the orphans).
+            #
+            # The corresponding legacy switches were removed from
+            # ``switch.py`` in Phase C; the registry's stale-cleanup
+            # in that file removes the per-charger night/smart/tariff
+            # switch entries the same way.
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
+            chargers = new_options.get("ev_chargers", new_data.get("ev_chargers"))
+            if isinstance(chargers, list):
+                cleaned = []
+                for c in chargers:
+                    c = dict(c) if isinstance(c, dict) else c
+                    if isinstance(c, dict) and "ev_charging_mode" in c:
+                        removed_value = c.pop("ev_charging_mode")
+                        _LOGGER.info(
+                            "Charger %s: dropped dead config key "
+                            "ev_charging_mode=%s (Phase C — charge_mode "
+                            "is authoritative)",
+                            c.get("id", "ev_charger"), removed_value,
+                        )
+                    cleaned.append(c)
+                new_options["ev_chargers"] = cleaned
+            # Top-level ``ev_charging_mode`` (legacy global default) is
+            # also gone now — nothing reads it. Same removal logic; the
+            # top level only had it via #255 seeding, never the source
+            # of truth post-v4.
+            if "ev_charging_mode" in new_options:
+                new_options.pop("ev_charging_mode")
+            hass.config_entries.async_update_entry(
+                entry, data=new_data, options=new_options,
+                version=7, minor_version=1,
+            )
+            accumulated_data, accumulated_options = new_data, new_options
+        except Exception as e:
+            _LOGGER.error(
+                "Migration from v%s to v7 failed — keeping original config: %s",
+                entry.version, e,
+            )
+            return False
+
     _LOGGER.info("Migration to version %s.%s done", entry.version, entry.minor_version)
     return True
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -142,7 +142,9 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     # v5 (#277 Phase A): per-charger charge_mode derived from legacy toggles.
     # v6 (#277 Phase B): re-derive charge_mode for the pv+tariff combinations
     #     Phase A's derivation silently dropped.
-    VERSION = 6
+    # v7 (#277 Phase C): drop the dead ev_charging_mode key (charge_mode is
+    #     authoritative now; the legacy select + 3 legacy switches are gone).
+    VERSION = 7
 
     @staticmethod
     @callback
@@ -465,8 +467,8 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             # Energy source selection
             "prefer_hardware_energy": DEFAULT_PREFER_HARDWARE_ENERGY,
             "energy_source_auto": DEFAULT_ENERGY_SOURCE_AUTO,
-            # Optional / opt-in feature
-            "smart_night_charging": False,
+            # ``smart_night_charging`` removed in #277 Phase C — the
+            # named ``charge_mode`` carries that intent now.
             # Notifications — sensible defaults; tune in OptionsFlow
             "enable_charger_notifications": True,
             "enable_mobile_notifications": False,
@@ -1372,10 +1374,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                     "observer_mode",
                     default=_c("observer_mode", DEFAULT_OBSERVER_MODE),
                 ): selector.BooleanSelector(),
-                vol.Optional(
-                    "smart_night_charging",
-                    default=_c("smart_night_charging", False),
-                ): selector.BooleanSelector(),
+                # ``smart_night_charging`` removed in #277 Phase C — the
+                # named ``charge_mode`` carries that intent (implicit ON
+                # for ``min_plus_solar`` / ``solar_plus_cheap``). Phase B
+                # already routed ``_smart_night_charging_enabled()``
+                # through the mode resolver, so this options-flow field
+                # has been inert for a release; Phase C removes it from
+                # the UI to match.
             }),
         )
 

--- a/consts/ev_charge_modes.py
+++ b/consts/ev_charge_modes.py
@@ -65,61 +65,28 @@ def effective_charge_mode_for(
     """Resolve the user-intent Charge mode for one charger.
 
     Reads ``charger_cfg["charge_mode"]`` when present (post-v5
-    migration or after a user picks one in the selector). When absent,
-    derives the equivalent named mode from the legacy four-toggle
-    state — same decision tree as ``_derive_charge_mode`` in
-    ``__init__.py`` so migration and runtime agree.
+    migration or after a user picks one in the selector). When absent
+    — corrupted config, hand-edited storage — fall back to the
+    new-install default.
 
-    Stateless / hass-state-only — takes ``hass`` only to read switch
-    states for the legacy fallback. Used both by ``SEMCoordinator``
-    (whole-cycle reads) and ``ChargingStateMachine`` (per-tick night
-    enablement vote) so there is one shared resolver and no
-    duplicated derivation logic between coordinator and state
-    machine.
+    Pre-#277 Phase C this had a long legacy-derivation fallback that
+    read ``switch.sem_charger_<id>_night_charging`` /
+    ``..._tariff_optimized`` for installs that somehow skipped the
+    Phase A migration. Phase C removed those switches, and the
+    migration is mandatory on every config-entry load, so the
+    derivation was dead code by the time it would have fired.
+
+    The ``hass`` and ``full_config`` parameters are kept for call-site
+    compatibility — they're no longer read but the four current
+    callers ([SEMCoordinator], [ChargingStateMachine],
+    [_tariff_optimized_for], [today_plan]) pass them as part of a
+    stable signature.
 
     Returns one of ``EV_CHARGE_MODES`` keys; never raises.
     """
     if not isinstance(charger_cfg, dict):
         return DEFAULT_EV_CHARGE_MODE
-
     stored = charger_cfg.get("charge_mode")
     if stored in EV_CHARGE_MODES:
         return stored
-
-    # No stored mode (pre-migration / partially-configured install) —
-    # derive it on the fly from the same legacy toggles the migration
-    # reads. The decision tree mirrors ``__init__._derive_charge_mode``
-    # exactly so a user who never migrates sees the same effective
-    # behaviour as one who did.
-    cid = charger_cfg.get("id", "ev_charger")
-    mode = (
-        charger_cfg.get("ev_charging_mode")
-        or full_config.get("ev_charging_mode")
-        or "pv"
-    )
-    night_eid = f"switch.sem_charger_{cid}_night_charging"
-    if hass.states.get(night_eid) is not None:
-        night = hass.states.is_state(night_eid, "on")
-    elif hass.states.get("switch.sem_night_charging") is not None:
-        night = hass.states.is_state("switch.sem_night_charging", "on")
-    else:
-        night = True  # factory default
-    tariff_eid = f"switch.sem_charger_{cid}_tariff_optimized"
-    tariff = hass.states.is_state(tariff_eid, "on") if (
-        hass.states.get(tariff_eid) is not None
-    ) else False
-
-    if mode == "now":
-        return "always_max"
-    if mode == "off":
-        return "off"
-    # Tariff-on expresses an explicit "use cheap windows" intent that
-    # applies regardless of whether the user picked "auto" or "pv" in
-    # the legacy mode field — both groups exist in PROD setups.
-    # Capturing both was the equivalence the Phase B test sweep flagged
-    # (test_tariff_wait_when_cheap_window_ahead).
-    if mode in ("pv", "auto", "self_consumption") and tariff:
-        return "solar_plus_cheap"
-    if mode in ("pv", "auto", "self_consumption") and not night:
-        return "solar_only"
     return DEFAULT_EV_CHARGE_MODE

--- a/coordinator/charging_control.py
+++ b/coordinator/charging_control.py
@@ -327,9 +327,10 @@ class ChargingStateMachine:
 
         chargers = self.config.get("ev_chargers") or []
         if not chargers:
-            # Pre-EV / no-chargers fallback — keep reading the legacy
-            # global switch for backward-compat. Phase C removes this.
-            return self.hass.states.is_state("switch.sem_night_charging", "on")
+            # Pre-EV / no-chargers install: nothing to enable. The
+            # legacy global ``switch.sem_night_charging`` was removed
+            # in #277 Phase C, so there is no fallback to consult.
+            return False
         return any(
             effective_charge_mode_for(self.hass, self.config, c)
             in MODE_NIGHT_ALLOWED

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -327,7 +327,9 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             "ev_target_soc", "ev_target_soc_max",
             "ev_min_current", "ev_night_initial_current",
             "ev_kwh_per_100km", "ev_target_type",
-            "ev_charging_mode", "ev_phases",
+            # ``ev_charging_mode`` removed in #277 Phase C — the v6→v7
+            # migration drops the field; there's nothing to mirror.
+            "ev_phases",
             "ev_target_time",  # #246 charge-by deadline
         ):
             if pc.get(key) is not None:
@@ -336,20 +338,26 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
     def _effective_charge_mode_for(self, charger_cfg: dict) -> str:
         """Resolve the user-intent Charge mode for one charger (#277).
 
-        Phase A introduced this as the read-point Phase B switches
-        authority on; Phase B (v1.7.0) wires it into the strategy
-        machine, night gate, EV control loop, and tariff path. Phase C
-        will drop the legacy-toggle fallback inside the resolver after
-        v1.7.x soak proves migration covered every install.
+        Phase A introduced this as the read-point Phase B switched
+        authority on. Phase C wires it into the strategy machine
+        directly + makes ``_tariff_optimized_for`` mode-driven, so
+        ``charge_mode`` is now the only intent input anywhere.
 
         Delegates to the shared free function so ``ChargingStateMachine``
-        (which is a separate class, not a coordinator mixin) can use the
-        same resolver — one source of truth.
+        (which is a separate class, not a coordinator mixin) can use
+        the same resolver — one source of truth.
 
         Returns one of ``EV_CHARGE_MODES`` keys; never raises.
+        Defensive against test stubs that build a coordinator via
+        ``__new__`` without ``hass`` — the free function ignores
+        ``hass`` post-Phase-C anyway.
         """
         from ..consts.ev_charge_modes import effective_charge_mode_for
-        return effective_charge_mode_for(self.hass, self.config, charger_cfg)
+        return effective_charge_mode_for(
+            getattr(self, "hass", None),
+            getattr(self, "config", {}) or {},
+            charger_cfg,
+        )
 
     # ─────────────────────────────────────────────────────────────────
     # Mode-driven adapters — #277 Phase B
@@ -2415,62 +2423,85 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Solar mode: keep charging even past target (free surplus)
         # Target check only applies to night (grid) charging above
 
-        # Charging mode selection: pv (default), minpv, now, off.
+        # Strategy dispatch on the named Charge mode (#277 Phase C).
+        # Pre-Phase-C this read the legacy ``ev_charging_mode`` string
+        # (auto / pv / minpv / now / off) — see #277 Phase B PR for the
+        # reason that split was held. Phase C completes the unification:
+        # the strategy machine reads the named mode directly, ``ev_
+        # charging_mode`` is no longer authoritative anywhere. The v6→v7
+        # migration drops the legacy key from the per-charger config.
         #
-        # Deliberately still reads the legacy ``ev_charging_mode`` field
-        # in Phase B (#277). The new ``charge_mode`` selector controls
-        # the night / smart / tariff dimensions but ``ev_charging_mode``
-        # remains the daytime strategy authority — the existing zone
-        # decisions on "pv" vs "minpv" carry intent that would be lossy
-        # to flatten into the 5-mode taxonomy this release. Phase C
-        # reconciles: the strategy machine gets rewritten against the
-        # named modes directly, the legacy field goes away. Holding the
-        # split here keeps Phase B strictly additive on the day side.
-        charging_mode = self.config.get("ev_charging_mode", "pv")
-        _cmode = (charger_cfg or {}).get("ev_charging_mode")
-        if _cmode:
-            charging_mode = _cmode
+        # Mode → strategy mapping (decided by maintainer for Phase C):
+        #   always_max       → ("now", …)                explicit Max regardless of source
+        #   off              → ("idle", …)               no charging
+        #   solar_only       → _self_consumption_strategy strict surplus, never grid import
+        #   solar_plus_cheap → zone logic + tariff pause day; tariff-windowed night
+        #   min_plus_solar   → zone logic + night top-up to Min (no day grid pull —
+        #                      the Min in "Min + Solar" comes from NIGHT charging,
+        #                      day stays zone-adaptive like legacy ``pv``)
+        mode = self._effective_charge_mode_for(charger_cfg or {})
 
-        # Tariff-optimized daytime pause (#247): during expensive price windows,
-        # drop the Min+PV grid guarantee and fall back to surplus / battery-assist
-        # only (the zone logic below). Resumes automatically when the price drops
-        # or solar is sufficient. The explicit "now" override and pure-surplus
-        # modes are intentionally left untouched.
-        if charging_mode == "minpv" and self._tariff_optimized_for(charger_cfg or {}):
+        if mode == "always_max":
+            return ("now", "Always (max) mode — charge at max immediately")
+        if mode == "off":
+            return ("idle", "Charging disabled (mode=off)")
+        if mode == "solar_only":
+            # Strict surplus, never grid import. Self-consumption strategy
+            # subtracts battery_charge below auto_start_soc so the home
+            # battery still gets priority; only true above-everything
+            # surplus reaches the EV. Identical to the legacy
+            # ``self_consumption`` mode (#67).
+            return self._self_consumption_strategy(power, energy)
+
+        # Tariff-aware daytime behaviour for ``solar_plus_cheap`` (#247).
+        # During EXPENSIVE / VERY_EXPENSIVE windows we want to pause the
+        # surplus-from-grid behaviour and stay strictly on solar. Pre-
+        # Phase-C this gated on ``charging_mode == "minpv"`` (the only
+        # legacy mode that could import grid from the daytime strategy);
+        # post-C the only mode that imports from grid during the day is
+        # the auto-mode forecast path, and only if the user picked
+        # ``solar_plus_cheap``.
+        if mode == "solar_plus_cheap":
             try:
                 level = self._tariff_provider.get_price_level()
                 if level in (PriceLevel.EXPENSIVE, PriceLevel.VERY_EXPENSIVE):
                     _LOGGER.debug(
-                        "Tariff pause: %s price — Min+PV grid guarantee dropped "
-                        "to surplus-only", level.value,
+                        "Tariff pause: %s price — solar_plus_cheap "
+                        "falling through to pure surplus", level.value,
                     )
-                    charging_mode = "pv"  # fall through to zone-based surplus logic
+                    # Falls through to self_consumption to enforce
+                    # surplus-only during expensive windows.
+                    if getattr(self, "_tariff_pause_warned", False):
+                        self._tariff_pause_warned = False
+                    return self._self_consumption_strategy(power, energy)
                 if getattr(self, "_tariff_pause_warned", False):
                     self._tariff_pause_warned = False  # provider recovered
             except Exception as e:
-                # Surface once (#274/L1): a persistently broken provider would
-                # otherwise silently drop the Min+PV grid guarantee with no signal.
+                # Surface once (#274/L1) — a persistently broken provider
+                # would otherwise silently keep the surplus-from-grid
+                # behaviour on through expensive windows.
                 if not getattr(self, "_tariff_pause_warned", False):
                     _LOGGER.warning(
-                        "Tariff-optimized daytime pause disabled — price provider "
-                        "error (Min+PV grid guarantee unchanged): %s", e,
+                        "Tariff-optimized daytime pause disabled — "
+                        "price provider error: %s", e,
                     )
                     self._tariff_pause_warned = True
 
-        if charging_mode == "now":
-            return ("now", "Now mode — charge at max immediately")
-        if charging_mode == "off":
-            return ("idle", "Solar charging disabled by user")
-        if charging_mode == "minpv":
-            return ("min_pv", f"Min+PV mode, remaining={remaining_need:.1f}kWh, solar={power.solar_power:.0f}W")
-        if charging_mode == "self_consumption":
-            return self._self_consumption_strategy(power, energy)
-
-        if charging_mode == "auto":
-            auto_result = self._auto_mode_strategy(power, energy, remaining_need)
-            if auto_result is not None:
-                return auto_result
-            # None = fall through to normal zone-based pv logic below
+        # ``min_plus_solar`` and ``solar_plus_cheap`` fall through to
+        # the pure zone-based pv logic below — matches the legacy
+        # ``pv + night=on`` factory default that the majority of PROD
+        # installs were running pre-Phase-C. The night/tariff/smart
+        # dimensions are already gated separately (mode-driven via
+        # ``_mode_allows_night_charging`` etc), so the daytime strategy
+        # just runs the zone decision tree unchanged.
+        #
+        # (Pre-Phase-C the legacy ``auto`` mode wrapped this branch in
+        # ``_auto_mode_strategy`` — forecast-aware self_consumption
+        # when ratio>2. That wrapper is still callable via
+        # ``_auto_mode_strategy`` but no charge mode dispatches to it
+        # in Phase C. v1.7.x or later can opt-in users who actually
+        # want forecast-aware switching, but it's not the default.)
+        # No-op — explicit fall-through.
 
         # No meaningful solar → wait
         if power.solar_power < 200:

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -62,33 +62,31 @@ class EVControlMixin:
         return {}
 
     def _tariff_optimized_for(self, charger_cfg: dict) -> bool:
-        """True when tariff-optimized timing is enabled for this charger (#247).
+        """True when this charger's mode defers to cheap tariff windows.
 
-        Per-charger ``switch.sem_charger_{id}_tariff_optimized`` (opt-in,
-        default OFF) — created in ``switch.py`` for every config-flow charger.
-        Returns False when there is no charger config (``ev_chargers`` empty),
-        which can only happen pre-setup; #281/S2 removed the dead legacy
-        ``switch.sem_tariff_optimized`` fallback (that switch was never created).
+        Post-#277 Phase C: derived from the named ``charge_mode``
+        (only ``solar_plus_cheap`` defers — every other mode either
+        always charges, never charges, or follows zone/surplus rules
+        without tariff awareness). The legacy
+        ``switch.sem_charger_{id}_tariff_optimized`` was removed in
+        Phase C; this helper kept the same name so the existing
+        callers (``ev_control`` planner, today_plan composer, EV card
+        attributes) didn't have to change.
 
-        Note (#277 Phase B): the named ``charge_mode`` selector also
-        carries this intent (only ``solar_plus_cheap`` defers to tariff
-        windows). Phase B chose to keep this helper reading the switch
-        directly to preserve behaviour for legacy users with
-        ``minpv + tariff_optimized=on`` — that combination has no clean
-        mapping in the 5-mode taxonomy and migrating it to
-        ``solar_plus_cheap`` would change daytime semantics. Phase C
-        will reconcile when the strategy machine is rewritten against
-        the named modes directly.
+        Returns False on missing config or hass — defensive only;
+        every supported install has ``charge_mode`` set post-v5
+        migration so the resolver always answers.
         """
         hass = getattr(self, "hass", None)
-        if hass is None:
+        if hass is None or not isinstance(charger_cfg, dict):
             return False
-        cid = charger_cfg.get("id") if charger_cfg else None
-        if not cid:
-            return False
-        return hass.states.is_state(
-            f"switch.sem_charger_{cid}_tariff_optimized", "on"
+        from ..consts.ev_charge_modes import (
+            MODE_USES_TARIFF,
+            effective_charge_mode_for,
         )
+        return effective_charge_mode_for(
+            hass, self.config, charger_cfg,
+        ) in MODE_USES_TARIFF
 
     def _charger_target_time(self, charger_cfg: dict) -> str:
         """Per-charger ``HH:MM`` charge-by deadline (#246), or global / default."""

--- a/select.py
+++ b/select.py
@@ -90,6 +90,31 @@ async def async_setup_entry(
     except Exception as e:
         _LOGGER.debug("Global select removal skipped: %s", e)
 
+    # #277 Phase C — drop the per-charger ``ev_charging_mode`` selects
+    # the new ``charge_mode`` selector replaces. The v6→v7 migration
+    # already cleared the underlying config key; this purges the
+    # orphaned entity rows from the registry so the dashboard doesn't
+    # leak stale "EV Charging Mode" labels.
+    try:
+        registry = er.async_get(hass)
+        full_config_legacy = {**entry.data, **entry.options}
+        for charger_cfg in full_config_legacy.get("ev_chargers") or []:
+            cid = (
+                charger_cfg.get("id", "ev_charger")
+                if isinstance(charger_cfg, dict) else "ev_charger"
+            )
+            legacy_uid = f"{entry.entry_id}_charger_{cid}_ev_charging_mode"
+            legacy_eid = registry.async_get_entity_id("select", DOMAIN, legacy_uid)
+            if legacy_eid:
+                registry.async_remove(legacy_eid)
+                _LOGGER.info(
+                    "Removed legacy per-charger select %s "
+                    "(replaced by charge_mode selector, #277 Phase C)",
+                    legacy_eid,
+                )
+    except Exception as e:
+        _LOGGER.debug("Per-charger legacy select cleanup skipped: %s", e)
+
     entities = [
         SEMSelectEntity(coordinator, entry, description)
         for description in SELECT_TYPES
@@ -111,26 +136,12 @@ async def async_setup_entry(
                 entry, cid, "ev_target_type",
                 charger_cfg.get("ev_target_type") or charger_cfg.get("ev_target_mode") or "kwh",
             ))
-            # Per-charger charging mode (#255) — each car can have its own mode.
-            entities.append(SEMPerChargerSelect(
-                coordinator,
-                SelectEntityDescription(
-                    key=f"charger_{cid}_ev_charging_mode",
-                    options=list(EV_CHARGING_MODES.keys()),
-                    entity_category=EntityCategory.CONFIG,
-                ),
-                entry, cid, "ev_charging_mode",
-                charger_cfg.get("ev_charging_mode")
-                or full_config.get("ev_charging_mode") or "pv",
-            ))
-            # Per-charger Charge mode selector (#277 Phase A) — the
-            # consolidated user-intent selector that will replace the
-            # toggle-soup in Phase B. Phase A is additive only: the
-            # entity persists user intent but the coordinator strategy
-            # machine still reads the legacy toggles. The migration in
-            # ``async_migrate_entry`` (v4 → v5) seeds the field from
-            # existing toggle state so the value the user sees matches
-            # the behaviour they already have.
+            # The legacy ``ev_charging_mode`` per-charger select was
+            # retired in #277 Phase C — the new ``charge_mode``
+            # selector (registered below) is the only intent knob now.
+            # The entity registry's stale-cleanup at the top of this
+            # function removes orphaned ``charger_<id>_ev_charging_mode``
+            # entries on the next setup.
             entities.append(SEMPerChargerSelect(
                 coordinator,
                 SelectEntityDescription(

--- a/strings.json
+++ b/strings.json
@@ -1037,14 +1037,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1170,9 +1164,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Charging Mode"
-      },
       "ev_target_type": {
         "name": "EV Target Type",
         "state": {

--- a/switch.py
+++ b/switch.py
@@ -25,15 +25,7 @@ PARALLEL_UPDATES = 0  # Coordinator handles all updates
 
 SWITCH_TYPES = [
     SwitchEntityDescription(
-        key="night_charging",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    SwitchEntityDescription(
         key="observer_mode",
-        entity_category=EntityCategory.CONFIG,
-    ),
-    SwitchEntityDescription(
-        key="smart_night_charging",
         entity_category=EntityCategory.CONFIG,
     ),
 ]
@@ -41,6 +33,16 @@ SWITCH_TYPES = [
 # (ev_limit_surplus (#235) was folded into the optional Max ceiling (#245); its
 # global config-switch mechanism + entity are gone. Old entities are auto-removed
 # by the stale-entity cleanup below since they're no longer in valid_keys.)
+#
+# Removed in #277 Phase C:
+#   - global ``night_charging`` + ``smart_night_charging`` switches
+#   - per-charger ``charger_<id>_night_charging`` switches
+#   - per-charger ``charger_<id>_smart_night_charging`` switches
+#   - per-charger ``charger_<id>_tariff_optimized`` switches
+# All four intents are now carried by the per-charger
+# ``select.sem_charger_<id>_charge_mode`` selector — picking a Charge
+# mode is the only knob. The stale-entity cleanup below removes the
+# orphaned entries from the registry on the next setup.
 
 
 async def async_setup_entry(
@@ -49,86 +51,15 @@ async def async_setup_entry(
     """Set up SEM Solar Energy Management switches."""
     coordinator: SEMCoordinator = entry.runtime_data
 
-    full_config = {**entry.data, **entry.options}
-    ev_chargers = full_config.get("ev_chargers", [])
-    has_chargers = len(ev_chargers) >= 1
-
-    # #255: night charging is PER-CHARGER when chargers exist — drop the duplicate
-    # GLOBAL master switch. Keep it only for legacy / no-charger installs, where the
-    # night gate falls back to it.
-    active_global = [
-        d for d in SWITCH_TYPES
-        if not (d.key in ("night_charging", "smart_night_charging") and has_chargers)
-    ]
+    # #277 Phase C: all four legacy per-charger switches were removed.
+    # The remaining global switch (``observer_mode``) is the only one
+    # left in SWITCH_TYPES. The stale-entity cleanup at the bottom of
+    # this function purges the removed entries from the registry.
     switches = [
         SEMSolarSwitch(coordinator, description, entry.entry_id)
-        for description in active_global
+        for description in SWITCH_TYPES
     ]
-
-    # One-time reconciliation (#255): a user who disabled night charging via the GLOBAL
-    # switch (leaving a per-charger switch on) must NOT be silently re-enabled now that
-    # the gate moves to per-charger. If the (removed) global switch was last OFF, force
-    # the per-charger night switches OFF this once. Marker lives in entry.data; the
-    # snapshot guard keeps async_update_options from reloading (options are unchanged).
-    night_force_off = False
-    if has_chargers and not entry.data.get("_night_gate_reconciled"):
-        try:
-            from homeassistant.helpers.restore_state import async_get as _restore_get
-            # last_states maps entity_id → StoredState; .state is a State, .state.state a str.
-            stored = _restore_get(hass).last_states.get("switch.sem_night_charging")
-            if stored is not None and getattr(stored.state, "state", None) == "off":
-                night_force_off = True
-                _LOGGER.info(
-                    "#255 reconciliation: global night charging was OFF — forcing "
-                    "per-charger night switches OFF (one-time)"
-                )
-            coordinator._skip_options_reload = dict(entry.options)
-            hass.config_entries.async_update_entry(
-                entry, data={**entry.data, "_night_gate_reconciled": True}
-            )
-        except Exception as e:
-            _LOGGER.debug("Night-gate reconciliation skipped: %s", e)
-
-    # Per-charger night charging switches (#193)
-    per_charger_keys = set()
-    if has_chargers:
-        for charger_cfg in ev_chargers:
-            cid = charger_cfg.get("id", "ev_charger")
-            cname = charger_cfg.get("name", "EV Charger")
-            desc = SwitchEntityDescription(
-                key=f"charger_{cid}_night_charging",
-                entity_category=EntityCategory.CONFIG,
-            )
-            per_charger_keys.add(desc.key)
-            switches.append(SEMPerChargerSwitch(
-                coordinator, desc, entry.entry_id, cid, cname,
-                force_off=night_force_off,
-            ))
-            # Per-charger smart (forecast-aware) night charging (#255) — was global.
-            smart_desc = SwitchEntityDescription(
-                key=f"charger_{cid}_smart_night_charging",
-                entity_category=EntityCategory.CONFIG,
-            )
-            per_charger_keys.add(smart_desc.key)
-            switches.append(SEMPerChargerSwitch(
-                coordinator, smart_desc, entry.entry_id, cid, cname,
-            ))
-            # Per-charger tariff-optimized charging (#247) — opt-in, default OFF.
-            # When on: night charging defers to the cheapest price window (Min
-            # still guaranteed by the deadline) and daytime Min+PV grid top-up
-            # pauses during expensive hours.
-            tariff_desc = SwitchEntityDescription(
-                key=f"charger_{cid}_tariff_optimized",
-                entity_category=EntityCategory.CONFIG,
-            )
-            per_charger_keys.add(tariff_desc.key)
-            switches.append(SEMPerChargerSwitch(
-                coordinator, tariff_desc, entry.entry_id, cid, cname,
-            ))
-        _LOGGER.info(
-            "Created per-charger switches for %d charger(s)",
-            len(ev_chargers),
-        )
+    per_charger_keys: set[str] = set()
 
     async_add_entities(switches)
 
@@ -150,7 +81,7 @@ async def async_setup_entry(
     # Clean up stale switch entities from previous versions
     try:
         registry = er.async_get(hass)
-        valid_keys = {d.key for d in active_global} | per_charger_keys
+        valid_keys = {d.key for d in SWITCH_TYPES} | per_charger_keys
         for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
             if entity_entry.domain != "switch":
                 continue
@@ -202,12 +133,7 @@ class SEMSolarSwitch(CoordinatorEntity, SwitchEntity, RestoreEntity):
         # Force stable entity ID regardless of HA language
         self.entity_id = f"switch.sem_{description.key}"
 
-        if description.key == "night_charging":
-            # Opt-in (#256): default OFF so a fresh install charges on solar surplus only
-            # and never grid-charges the car overnight unasked. RestoreEntity below
-            # preserves existing users — they keep whatever state they already had.
-            self._is_on = False
-        elif description.key == "observer_mode":
+        if description.key == "observer_mode":
             self._is_on = coordinator.config_entry.options.get("observer_mode", False)
         else:
             self._is_on = False

--- a/tests/test_277_charge_mode_phase_a.py
+++ b/tests/test_277_charge_mode_phase_a.py
@@ -267,29 +267,23 @@ class TestMigrateEntryV5:
         })
         assert captured["options"]["ev_chargers"][0]["charge_mode"] == "solar_only"
 
-    async def test_legacy_toggle_state_unchanged(self):
-        """Phase A guarantee: legacy fields stay authoritative for the
-        strategy machine until Phase B."""
-        captured = await self._run_migration_at_v4(options={
-            "ev_chargers": [
-                {"id": "ev_charger", "ev_charging_mode": "minpv"},
-            ],
-        })
-        ch = captured["options"]["ev_chargers"][0]
-        assert ch["ev_charging_mode"] == "minpv", (
-            "Phase A must not mutate legacy fields"
-        )
+    # ``test_legacy_toggle_state_unchanged`` removed in #277 Phase C —
+    # the property it pinned ("Phase A migration must not mutate
+    # legacy fields") was a Phase-A-only invariant. Phase C's v6→v7
+    # migration explicitly removes the ``ev_charging_mode`` legacy
+    # field; preserving it would be a regression on Phase C's
+    # contract, so the test is no longer meaningful.
 
     async def test_bumps_version_to_5(self):
         captured = await self._run_migration_at_v4(options={
             "ev_chargers": [{"id": "ev_charger", "ev_charging_mode": "pv"}],
         })
-        assert captured["version"] == 6  # bumped in v5→v6 (#277 Phase B)
+        assert captured["version"] == 7  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
 
     async def test_no_chargers_no_crash(self):
         """Pre-EV setups (no ev_chargers list) must still migrate."""
         captured = await self._run_migration_at_v4(options={})
-        assert captured["version"] == 6  # bumped in v5→v6 (#277 Phase B)
+        assert captured["version"] == 7  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
         # No ev_chargers to seed, so the key may or may not be present —
         # the migration must not invent one.
         assert "ev_chargers" not in captured["options"] or \
@@ -318,24 +312,25 @@ class TestEffectiveChargeMode:
                "ev_charging_mode": "minpv"}  # legacy says different
         assert coord._effective_charge_mode_for(cfg) == "solar_only"
 
-    def test_derives_when_stored_missing(self):
-        """Pre-migration / partial install: fall back to legacy
-        derivation. Result must match _derive_charge_mode for the same
-        inputs (equivalence guarantee)."""
-        hass = _hass_with_switches(night=False, tariff=False)
-        coord = self._build_coord(hass=hass)
-        cfg = {"id": "ev_charger", "ev_charging_mode": "auto"}  # no charge_mode
-        # No night, no tariff → solar_only per derivation
-        assert coord._effective_charge_mode_for(cfg) == "solar_only"
+    def test_missing_stored_returns_default(self):
+        """Post-#277 Phase C the legacy-toggle derivation fallback was
+        removed (the legacy switches are gone). When ``charge_mode`` is
+        missing the resolver returns the new-install default —
+        previously it derived from the legacy toggles. Migration is
+        mandatory on every config-entry load, so in real installs the
+        field is always present.
+        """
+        coord = self._build_coord()
+        cfg = {"id": "ev_charger"}  # no charge_mode, no legacy toggles
+        assert coord._effective_charge_mode_for(cfg) == "min_plus_solar"
 
-    def test_unknown_stored_value_falls_through_to_derivation(self):
+    def test_unknown_stored_value_falls_back_to_default(self):
         """Defensive: a stored value outside the 5 known modes (someone
-        edited storage by hand) must not be returned. Fall back to the
-        derivation path so the runtime sees a known mode."""
-        hass = _hass_with_switches(night=True, tariff=False)
-        coord = self._build_coord(hass=hass)
-        cfg = {"id": "ev_charger", "charge_mode": "garbage_value",
-               "ev_charging_mode": "pv"}
+        edited storage by hand) returns the new-install default. Pre-
+        Phase-C this fell back to the legacy derivation; post-C the
+        derivation is gone."""
+        coord = self._build_coord()
+        cfg = {"id": "ev_charger", "charge_mode": "garbage_value"}
         assert coord._effective_charge_mode_for(cfg) == "min_plus_solar"
 
     def test_non_dict_charger_cfg_returns_default(self):
@@ -345,42 +340,14 @@ class TestEffectiveChargeMode:
         assert coord._effective_charge_mode_for(None) == "min_plus_solar"
         assert coord._effective_charge_mode_for("nope") == "min_plus_solar"
 
-    def test_equivalence_across_all_legacy_combinations(self):
-        """The migration and the runtime fallback must produce IDENTICAL
-        modes for every legacy combination — otherwise a user who
-        somehow skips migration sees different behaviour than one who
-        migrates."""
-        combos = [
-            # (ev_charging_mode, night, tariff, expected_mode)
-            ("now",   True,  False, "always_max"),
-            ("now",   False, True,  "always_max"),    # tariff irrelevant for now
-            ("off",   True,  False, "off"),
-            ("auto",  True,  True,  "solar_plus_cheap"),
-            ("auto",  True,  False, "min_plus_solar"),
-            ("auto",  False, False, "solar_only"),
-            ("pv",    True,  False, "min_plus_solar"),
-            ("pv",    False, False, "solar_only"),
-            ("minpv", True,  False, "min_plus_solar"),
-            ("minpv", False, False, "min_plus_solar"),  # minpv defaults to catch-all
-        ]
-        for cmode, night, tariff, expected in combos:
-            hass = _hass_with_switches(night=night, tariff=tariff)
-            coord = self._build_coord(hass=hass)
-            cfg = {"id": "ev_charger", "ev_charging_mode": cmode}
-            via_runtime = coord._effective_charge_mode_for(cfg)
-            via_migration = _derive_charge_mode(cfg, {}, hass)
-            assert via_runtime == expected, (
-                f"runtime: ({cmode}, night={night}, tariff={tariff}) "
-                f"got {via_runtime}, expected {expected}"
-            )
-            assert via_migration == expected, (
-                f"migration: ({cmode}, night={night}, tariff={tariff}) "
-                f"got {via_migration}, expected {expected}"
-            )
-            assert via_runtime == via_migration, (
-                f"runtime ↔ migration divergence at "
-                f"({cmode}, night={night}, tariff={tariff})"
-            )
+    # ``test_equivalence_across_all_legacy_combinations`` was removed in
+    # #277 Phase C — the legacy-toggle derivation fallback no longer
+    # exists at runtime (the resolver returns the new-install default
+    # when ``charge_mode`` is missing). The migration's own derivation
+    # (``_derive_charge_mode``) still exists and is covered by
+    # ``TestDeriveChargeMode`` above; the runtime-vs-migration
+    # equivalence property is no longer meaningful because they don't
+    # share a runtime path anymore.
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_277_charge_mode_phase_b.py
+++ b/tests/test_277_charge_mode_phase_b.py
@@ -218,31 +218,40 @@ class TestNightGateFromMode:
         )
         assert sm._read_night_enabled_raw() is True
 
-    def test_pre_migration_legacy_falls_back_via_derivation(self):
-        """No ``charge_mode`` stored (pre-v5 install): the resolver
-        falls back to the legacy toggle derivation. Equivalent to
-        v1.6.2 behaviour."""
+    def test_no_charge_mode_falls_back_to_default(self):
+        """No ``charge_mode`` stored (corrupted config, hand-edited
+        storage, etc.): Phase C resolver returns
+        ``DEFAULT_EV_CHARGE_MODE`` (``min_plus_solar``) directly. The
+        switch state in the fixture is irrelevant post-Phase-C — the
+        legacy derivation fallback was removed. ``min_plus_solar`` is
+        in ``MODE_NIGHT_ALLOWED`` so the gate returns True.
+
+        Pre-Phase-C this test was named
+        ``test_pre_migration_legacy_falls_back_via_derivation`` and
+        asserted that the resolver derived a mode from the night /
+        tariff switch states. Phase C removed that fallback because
+        the switches are gone — the resolver now treats "missing
+        stored mode" as "use the new-install default" instead.
+        """
         sm = _build_state_machine(
             [{"id": "ev_charger"}],  # no charge_mode
-            night=True, tariff=False,  # legacy: pv + night=on + tariff=off
+            night=True, tariff=False,  # switch state irrelevant post-Phase-C
         )
-        # Derivation: pv + night=on + tariff=off → min_plus_solar → night ON
         assert sm._read_night_enabled_raw() is True
 
-    def test_no_chargers_falls_back_to_global_switch(self):
-        """Pre-EV setup with no ``ev_chargers`` list: keep reading
-        the legacy global ``switch.sem_night_charging``. Phase C
-        removes this once the migration is mandatory."""
+    def test_no_chargers_returns_false_no_fallback(self):
+        """Pre-EV setup with no ``ev_chargers`` list: nothing to
+        enable. Phase B kept the legacy global
+        ``switch.sem_night_charging`` fallback for backward-compat;
+        Phase C removed it (the switch entity is gone from
+        ``switch.py`` too). Result: unambiguous False."""
         hass = MagicMock()
-        hass.states.is_state = MagicMock(side_effect=lambda eid, st: (
-            eid == "switch.sem_night_charging" and st == "on"
-        ))
         sm = ChargingStateMachine(
             hass=hass,
             config={"ev_chargers": [], "current_delta": 1},
             time_manager=MagicMock(),
         )
-        assert sm._read_night_enabled_raw() is True
+        assert sm._read_night_enabled_raw() is False
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -303,16 +312,16 @@ class TestSmartNightFromMode:
 # Runtime ↔ migration equivalence — re-asserted after the pv+tariff fix
 # ──────────────────────────────────────────────────────────────────────
 
-class TestRuntimeMigrationEquivalence:
-    """The runtime resolver (``effective_charge_mode_for``) and the
-    migration (``_derive_charge_mode``) must produce IDENTICAL modes
-    for every legacy combination — otherwise a user who somehow
-    skips migration sees different behaviour than one who migrates.
+class TestDeriveChargeModeAllLegacyCombinations:
+    """The migration's ``_derive_charge_mode`` must produce the
+    documented mode for every legacy combination.
 
-    Phase A asserted this; Phase B's derivation fix (mapping
-    ``pv/auto/self_consumption + tariff_on`` to ``solar_plus_cheap``
-    rather than dropping the tariff signal) added a new case that
-    must satisfy the same property.
+    Pre-#277 Phase C this test ALSO asserted that the runtime resolver
+    (``effective_charge_mode_for``) produced the same answer — the
+    equivalence property. Phase C removed the runtime derivation
+    fallback (the legacy switches are gone, so it couldn't read them
+    anyway), so the property is no longer meaningful for runtime; it
+    still matters for the migration's one-shot pass.
     """
 
     COMBOS = [
@@ -334,37 +343,22 @@ class TestRuntimeMigrationEquivalence:
         ("pv",                True,  True,  "solar_plus_cheap"),
         ("pv",                False, True,  "solar_plus_cheap"),
         ("self_consumption",  True,  True,  "solar_plus_cheap"),
-        # Deferred to Phase C: ``minpv + tariff_on`` has no clean home
-        # in the 5-mode taxonomy. ``minpv`` always pulls Min from grid
-        # during the day; mapping it to ``solar_plus_cheap`` would shift
-        # daytime behaviour. Both stay on the catch-all
-        # ``min_plus_solar`` until Phase C rewrites the strategy
-        # machine against the named modes — the legacy
-        # ``_tariff_optimized_for`` keeps reading the switch directly
-        # so the daytime Min-PV tariff pause still works for these
-        # users in Phase B. Pinned here so any Phase C refactor that
-        # accidentally changes the derivation gets caught.
+        # ``minpv + tariff_on`` has no clean home in the 5-mode
+        # taxonomy. Stays on the catch-all ``min_plus_solar``; the
+        # v5→v6 fix-up specifically does NOT correct these (see
+        # TestMigrateEntryV6.test_preserves_minpv_plus_tariff_users).
         ("minpv", True,  True,  "min_plus_solar"),
         ("minpv", False, True,  "min_plus_solar"),
     ]
 
     @pytest.mark.parametrize("cmode,night,tariff,expected", COMBOS)
-    def test_resolver_matches_migration(self, cmode, night, tariff, expected):
+    def test_migration_derivation(self, cmode, night, tariff, expected):
         hass = _hass_with_switches(night=night, tariff=tariff)
         cfg = {"id": "ev_charger", "ev_charging_mode": cmode}
-        via_runtime = effective_charge_mode_for(hass, {}, cfg)
         via_migration = _derive_charge_mode(cfg, {}, hass)
-        assert via_runtime == expected, (
-            f"runtime: ({cmode}, night={night}, tariff={tariff}) "
-            f"got {via_runtime}, expected {expected}"
-        )
         assert via_migration == expected, (
             f"migration: ({cmode}, night={night}, tariff={tariff}) "
             f"got {via_migration}, expected {expected}"
-        )
-        assert via_runtime == via_migration, (
-            f"runtime ↔ migration divergence at "
-            f"({cmode}, night={night}, tariff={tariff})"
         )
 
 
@@ -417,7 +411,7 @@ class TestMigrateEntryV6:
             ],
         }, hass=hass)
         assert captured["options"]["ev_chargers"][0]["charge_mode"] == "solar_plus_cheap"
-        assert captured["version"] == 6
+        assert captured["version"] == 7  # bumped in v6→v7 (#277 Phase C)
 
     async def test_preserves_explicit_min_plus_solar_without_tariff(self):
         """User explicitly picked min_plus_solar in the new selector
@@ -488,7 +482,7 @@ class TestMigrateEntryV6:
 
     async def test_no_chargers_safe_bumps_version(self):
         captured = await self._run(options={})
-        assert captured["version"] == 6
+        assert captured["version"] == 7  # bumped in v6→v7 (#277 Phase C)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -32,10 +32,19 @@ def time_manager():
 
 @pytest.fixture
 def config():
-    """Return a default charging config."""
+    """Return a default charging config.
+
+    Post-#277 Phase C the night gate reads ``charge_mode`` not the
+    legacy ``switch.sem_charger_<id>_night_charging``. Add an
+    ``ev_chargers`` entry with ``min_plus_solar`` so the gate is
+    open by default (matches the pre-Phase-C ``is_state=True`` stub).
+    """
     return {
         "battery_priority_soc": 30,
         "current_delta": 1,
+        "ev_chargers": [
+            {"id": "ev_charger", "charge_mode": "min_plus_solar"},
+        ],
     }
 
 
@@ -201,10 +210,21 @@ def test_night_idle_ev_disconnected(sm, time_manager):
     assert state == ChargingState.NIGHT_IDLE
 
 
-def test_night_disabled(sm, time_manager, hass):
-    """Test night disabled when night charging switch is off."""
+def test_night_disabled(sm, time_manager):
+    """Test night disabled when no charger mode permits night charging.
+
+    Post-#277 Phase C the night gate reads ``charge_mode`` not the
+    legacy night-charging switch. Flip the per-charger mode to
+    ``solar_only`` (in the config the ``sm`` fixture already wired)
+    — that mode is not in MODE_NIGHT_ALLOWED, so the gate goes off.
+    """
     time_manager.is_night_mode.return_value = True
-    hass.states.is_state.return_value = False  # Night charging disabled
+    sm.config["ev_chargers"][0]["charge_mode"] = "solar_only"
+    # Bust the 2-cycle debounce cache so the new mode commits this
+    # cycle (the gate has a 2-cycle confirmation window from #290).
+    sm._night_enabled_cached = None
+    sm._night_enabled_pending = None
+    sm._night_enabled_pending_cycles = 0
 
     ctx = _ctx(
         ev_connected=True,

--- a/tests/test_dual_state_machine.py
+++ b/tests/test_dual_state_machine.py
@@ -26,7 +26,16 @@ def mock_hass():
 
 @pytest.fixture
 def config():
-    """Create a test configuration."""
+    """Create a test configuration.
+
+    Post-#277 Phase C the night gate reads ``charge_mode`` not the
+    per-charger night switch. Tests that set
+    ``mock_hass.states.is_state = True`` (to enable night via the
+    old switch-mock pattern) need an ``ev_chargers`` entry with
+    ``min_plus_solar`` so the named-mode resolver returns True. Tests
+    that want the gate OFF can pass a charger with ``solar_only``
+    in their setup override.
+    """
     return {
         "daily_ev_target": 7.0,
         "battery_priority_soc": 90,
@@ -34,6 +43,9 @@ def config():
         "minimum_solar_power": 2400,
         "maximum_grid_import": 300,
         "current_delta": 1,
+        "ev_chargers": [
+            {"id": "ev_charger", "charge_mode": "min_plus_solar"},
+        ],
     }
 
 
@@ -143,15 +155,21 @@ class TestDualStateMachine:
         state = state_machine._night_state_machine(ctx)
         assert state == ChargingState.NIGHT_TARGET_REACHED
 
-    def test_night_charging_disabled(self, state_machine, mock_hass, mock_time_night):
-        """Test night charging when switch is off."""
+    def test_night_charging_disabled(self, state_machine, mock_time_night):
+        """Test night charging when no charger's mode permits it.
+
+        Post-#277 Phase C the night gate reads ``charge_mode``. Flip
+        the per-charger mode in the fixture's config to ``solar_only``
+        (not in MODE_NIGHT_ALLOWED) — that disables the gate."""
         ctx = ChargingContext(
             ev_connected=True,
             daily_ev_energy=4.0,
         )
 
-        # Mock night switch OFF
-        mock_hass.states.is_state = Mock(return_value=False)
+        state_machine.config["ev_chargers"][0]["charge_mode"] = "solar_only"
+        state_machine._night_enabled_cached = None
+        state_machine._night_enabled_pending = None
+        state_machine._night_enabled_pending_cycles = 0
 
         state = state_machine._night_state_machine(ctx)
         assert state == ChargingState.NIGHT_DISABLED

--- a/tests/test_ev_deadline_tariff.py
+++ b/tests/test_ev_deadline_tariff.py
@@ -89,9 +89,15 @@ def _make_device(device_id="keba", max_current=32, session_active=False,
 def _build_coordinator(config_overrides=None, tariff_on=False, price_level=PriceLevel.NORMAL):
     with patch.object(SEMCoordinator, "__init__", return_value=None):
         coord = SEMCoordinator.__new__(SEMCoordinator)
+    # Post-#277 Phase C: tariff intent is carried by the named
+    # ``charge_mode`` (``solar_plus_cheap`` ↔ tariff_on). The legacy
+    # ``switch.sem_charger_<id>_tariff_optimized`` was removed.
+    charger = {
+        "id": "keba", "ev_min_current": 6, "ev_night_initial_current": 10,
+        "charge_mode": "solar_plus_cheap" if tariff_on else "min_plus_solar",
+    }
     coord.config = {
-        "ev_chargers": [{"id": "keba", "ev_min_current": 6,
-                         "ev_night_initial_current": 10}],
+        "ev_chargers": [charger],
         "ev_max_current": 32,
         "target_peak_limit": 6.0,
         "ev_ramp_rate_amps": 2,
@@ -105,11 +111,11 @@ def _build_coordinator(config_overrides=None, tariff_on=False, price_level=Price
     coord.time_manager.is_night_mode = MagicMock(return_value=True)
     coord.time_manager.get_night_end_time = MagicMock(return_value="07:00")
 
-    # hass.states.is_state for the tariff switch
+    # hass is unused by ``_tariff_optimized_for`` post-Phase-C (the
+    # resolver is a pure ``charge_mode`` lookup), but provide a stub
+    # for the few other code paths the strategy machine touches.
     coord.hass = MagicMock()
-    coord.hass.states.is_state = MagicMock(
-        side_effect=lambda eid, state: tariff_on and eid.endswith("_tariff_optimized")
-    )
+    coord.hass.states.is_state = MagicMock(return_value=False)
 
     # tariff provider
     coord._tariff_provider = MagicMock()
@@ -154,7 +160,9 @@ class TestComputeNightPlan:
             PricePoint(timestamp=base.replace(hour=2) + timedelta(days=1), price=0.1, level=PriceLevel.CHEAP),
         ]
         coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=cheap)
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00"}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00",
+               "charge_mode": "solar_plus_cheap"}
         with patch.object(dt_util, "now", return_value=base):
             plan = coord._compute_night_plan(cfg, remaining_to_min_kwh=8.0)
         assert plan.should_wait_for_cheap
@@ -168,7 +176,9 @@ class TestComputeNightPlan:
         cheap = [PricePoint(timestamp=base.replace(hour=1) + timedelta(days=1),
                             price=0.1, level=PriceLevel.CHEAP)]
         coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=cheap)
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00"}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00",
+               "charge_mode": "solar_plus_cheap"}
         with patch.object(dt_util, "now", return_value=base):
             plan = coord._compute_night_plan(cfg, remaining_to_min_kwh=10.0)
         assert not plan.should_wait_for_cheap
@@ -186,7 +196,9 @@ class TestComputeNightPlan:
         cheap = [PricePoint(timestamp=base.replace(hour=h) + timedelta(days=1),
                             price=0.1, level=PriceLevel.CHEAP) for h in (1, 2)]
         coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=cheap)
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00"}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00",
+               "charge_mode": "solar_plus_cheap"}
         with patch.object(dt_util, "now", return_value=base):
             plan = coord._compute_night_plan(cfg, remaining_to_min_kwh=12.0)
         # 2 cheap h at min-clamped ~4.1 kW ≈ 8.3 kWh < 12 → must not wait
@@ -207,7 +219,9 @@ class TestComputeNightPlan:
         # global lookahead down to 9.
         base = dt_util.now().replace(hour=22, minute=0, second=0, microsecond=0)
         coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=[])
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00"}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00",
+               "charge_mode": "solar_plus_cheap"}
         with patch.object(dt_util, "now", return_value=base):
             coord._compute_night_plan(cfg, remaining_to_min_kwh=8.0)
         # The provider was queried — assert the lookahead is the deadline horizon.
@@ -235,7 +249,9 @@ class TestComputeNightPlan:
         coord = _build_coordinator(tariff_on=True)
         coord.time_manager.get_night_end_time = MagicMock(side_effect=ValueError("bust"))
         coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=[])
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": None}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": None,
+               "charge_mode": "solar_plus_cheap"}
         with patch(
             "custom_components.solar_energy_management.coordinator.ev_control."
             "DEFAULT_EV_TARGET_TIME",
@@ -253,7 +269,9 @@ class TestComputeNightPlan:
         coord = _build_coordinator(tariff_on=True)
         coord.config["ev_tariff_dwell_seconds"] = 600
         base = dt_util.now().replace(hour=22, minute=0, second=0, microsecond=0)
-        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00"}
+        # #277 Phase C: tariff intent now carried by charge_mode.
+        cfg = {"id": "keba", "ev_min_current": 6, "ev_target_time": "07:00",
+               "charge_mode": "solar_plus_cheap"}
 
         # Call 1: now IS cheap → charge now (should_wait False), records the decision.
         coord._tariff_provider.find_cheapest_hours = MagicMock(
@@ -293,30 +311,51 @@ class TestDaytimeTariffPause:
         return PowerReadings(solar_power=3000.0, battery_soc=battery_soc,
                              ev_connected=True, **kw)
 
-    def test_minpv_pauses_grid_when_expensive(self):
+    def test_solar_plus_cheap_pauses_when_expensive(self):
+        """Post-#277 Phase C: ``solar_plus_cheap`` mode (the consolidated
+        successor of legacy ``minpv + tariff_on``) falls back to pure
+        self-consumption during EXPENSIVE windows. Previously this was
+        ``minpv → pv fallthrough``; now it's ``solar_plus_cheap →
+        self_consumption``."""
         coord = _build_coordinator(tariff_on=True, price_level=PriceLevel.EXPENSIVE)
         coord.time_manager.is_night_mode = MagicMock(return_value=False)
-        cfg = {"id": "keba", "ev_charging_mode": "minpv"}
+        cfg = {"id": "keba", "charge_mode": "solar_plus_cheap"}
         strategy, reason = coord._determine_charging_strategy(
             self._power(battery_soc=50), MagicMock(daily_ev=0.0), cfg)
-        # Min+PV grid guarantee dropped → no longer min_pv (falls to surplus zone)
+        # solar_plus_cheap + EXPENSIVE → self_consumption strategy
+        # (returns "solar_only" as the strategy string)
         assert strategy != "min_pv"
+        assert strategy == "solar_only"
 
-    def test_minpv_kept_when_price_normal(self):
+    def test_solar_plus_cheap_continues_when_price_normal(self):
+        """At NORMAL price, ``solar_plus_cheap`` doesn't pause — falls
+        through to zone logic. Pre-Phase-C this returned ``min_pv``
+        for ``minpv + tariff_on + NORMAL``; Phase C's ``min_plus_solar``
+        successor goes through zone logic instead.
+        """
         coord = _build_coordinator(tariff_on=True, price_level=PriceLevel.NORMAL)
         coord.time_manager.is_night_mode = MagicMock(return_value=False)
-        cfg = {"id": "keba", "ev_charging_mode": "minpv"}
+        cfg = {"id": "keba", "charge_mode": "solar_plus_cheap"}
         strategy, reason = coord._determine_charging_strategy(
             self._power(battery_soc=50), MagicMock(daily_ev=0.0), cfg)
-        assert strategy == "min_pv"
+        # Zone-based with battery_soc=50 → Zone 2 (priority..buffer)
+        # → solar_only strategy.
+        assert strategy == "solar_only"
 
-    def test_minpv_kept_when_tariff_off(self):
+    def test_min_plus_solar_ignores_tariff_signal(self):
+        """``min_plus_solar`` doesn't consult tariff — the tariff
+        gate only fires for ``solar_plus_cheap`` post-Phase-C. The
+        legacy ``minpv + tariff_off`` setup migrates to
+        ``min_plus_solar``; daytime behaviour is now zone-based
+        (per the maintainer's Phase C decision), so an EXPENSIVE
+        price label doesn't pause anything."""
         coord = _build_coordinator(tariff_on=False, price_level=PriceLevel.EXPENSIVE)
         coord.time_manager.is_night_mode = MagicMock(return_value=False)
-        cfg = {"id": "keba", "ev_charging_mode": "minpv"}
+        cfg = {"id": "keba", "charge_mode": "min_plus_solar"}
         strategy, reason = coord._determine_charging_strategy(
             self._power(battery_soc=50), MagicMock(daily_ev=0.0), cfg)
-        assert strategy == "min_pv"
+        # Zone-based: SOC 50 → Zone 2 → solar_only
+        assert strategy == "solar_only"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -38,15 +38,18 @@ class TestPlatformEntityCounts:
 
     @pytest.mark.asyncio
     async def test_switch_count(self, hass, config_entry, mock_coordinator):
-        """Should create the 3 base switches (ev_limit_surplus folded into Max, #245)."""
+        """Post-#277 Phase C: only ``observer_mode`` remains as a
+        global switch (the legacy ``night_charging`` +
+        ``smart_night_charging`` were removed when the named
+        ``charge_mode`` selector took over)."""
         config_entry.runtime_data = mock_coordinator
         hass.data = {DOMAIN: {config_entry.entry_id: mock_coordinator}}
         add_entities = MagicMock()
         await switch_setup(hass, config_entry, add_entities)
         switches = add_entities.call_args[0][0]
-        assert len(switches) == 3
+        assert len(switches) == 1
         keys = {s.entity_description.key for s in switches}
-        assert keys == {"night_charging", "observer_mode", "smart_night_charging"}
+        assert keys == {"observer_mode"}
 
     @pytest.mark.asyncio
     async def test_number_count(self, hass, config_entry, mock_coordinator):
@@ -124,20 +127,16 @@ class TestCurrencyConfiguration:
 class TestSwitchDefaults:
     """Verify switch default states."""
 
-    def test_night_charging_default_off(self, mock_coordinator):
-        # Opt-in (#256): surplus-only by default; existing users preserved via RestoreEntity.
-        desc = SWITCH_TYPES[0]  # night_charging
-        switch = SEMSolarSwitch(mock_coordinator, desc, "test")
-        assert switch._is_on is False
+    # ``test_night_charging_default_off`` and
+    # ``test_forecast_reduction_default_off`` removed in #277 Phase C
+    # along with the underlying switch entities. The default-OFF
+    # property they pinned is now expressed by the new-install
+    # ``charge_mode`` default (``min_plus_solar`` permits night;
+    # users opting out pick ``solar_only`` / ``off`` in the selector).
 
     def test_observer_mode_default_off(self, mock_coordinator):
         mock_coordinator.config_entry.options = {}
-        desc = SWITCH_TYPES[1]  # observer_mode
-        switch = SEMSolarSwitch(mock_coordinator, desc, "test")
-        assert switch._is_on is False
-
-    def test_forecast_reduction_default_off(self, mock_coordinator):
-        desc = SWITCH_TYPES[2]  # smart_night_charging
+        desc = SWITCH_TYPES[0]  # observer_mode (only remaining global switch)
         switch = SEMSolarSwitch(mock_coordinator, desc, "test")
         assert switch._is_on is False
 

--- a/tests/test_night_charging_debounce.py
+++ b/tests/test_night_charging_debounce.py
@@ -26,57 +26,59 @@ from custom_components.solar_energy_management.coordinator.charging_control impo
 
 
 def _build_state_machine(switch_returns):
-    """Build a state machine whose night-enabled switch reads from a
-    controllable list. Each call to ``_read_night_enabled_raw`` consumes
-    the next value from ``switch_returns``; if exhausted, repeats the
-    last one.
+    """Build a state machine whose ``_read_night_enabled_raw`` returns
+    a controllable sequence of bool values, one per call.
 
-    Post-#277 Phase B the resolver makes multiple ``is_state`` calls
-    per cycle (night switch + tariff switch as part of the mode
-    derivation). The cycle-vs-call ratio is decoupled by filtering on
-    the entity_id: only the per-charger night-charging switch advances
-    the iterator; tariff (and any unrelated) lookups are answered with
-    the pre-Phase-B factory default (off) without consuming a value.
+    Post-#277 Phase C the resolver reads ``charger_cfg["charge_mode"]``
+    directly — no switch reads, no derivation. The cycle-vs-call ratio
+    is no longer a concern (one read per call). We drive the boolean
+    by mutating the charger's ``charge_mode`` per cycle:
+      - True  → ``min_plus_solar`` (in MODE_NIGHT_ALLOWED)
+      - False → ``solar_only``     (not in MODE_NIGHT_ALLOWED)
 
-    Coverage note: a regression where the night-vs-tariff signal got
-    swapped (i.e. ``_read_night_enabled_raw`` returned ``True`` based
-    on a tariff state alone) would NOT be caught here — this scaffold
-    pins the debounce logic, not the mode→predicate mapping. The
-    mapping is exercised by ``TestNightGateFromMode`` in
-    ``test_277_charge_mode_phase_b.py``.
+    The scaffold uses a closure that advances the iterator each call;
+    if exhausted, repeats the last value (matches the pre-Phase-C
+    semantic).
+
+    Pre-Phase-C scaffold history: this stubbed
+    ``hass.states.is_state`` and filtered by entity_id to handle the
+    Phase B resolver's multi-call pattern (night + tariff). That whole
+    layer is gone in Phase C — the resolver is a pure
+    ``charger_cfg["charge_mode"]`` lookup.
     """
-    hass = MagicMock()
     seq = iter(switch_returns)
     last = [switch_returns[0]]
+    charger = {"id": "ev_charger", "charge_mode": (
+        "min_plus_solar" if switch_returns[0] else "solar_only"
+    )}
 
-    def is_state(eid, state):
-        # Only the night-charging switch participates in the test's
-        # cycle simulation. Tariff / unrelated lookups answer with the
-        # factory default (off) so they don't pollute the sequence.
-        if not eid.endswith("_night_charging"):
-            return False
+    # Subclass ChargingStateMachine to flip the charger's mode each
+    # call to _read_night_enabled_raw (one read per "cycle"). Keeps
+    # the production resolver path untouched; only the test's notion
+    # of "what does the charger look like this cycle?" is the variable.
+    sm = ChargingStateMachine(
+        hass=MagicMock(),
+        config={
+            "ev_chargers": [charger],
+            "current_delta": 1,
+        },
+        time_manager=MagicMock(),
+    )
+
+    original_read = sm._read_night_enabled_raw
+
+    def _advance_then_read():
         try:
             v = next(seq)
             last[0] = v
         except StopIteration:
             v = last[0]
-        return v
+        charger["charge_mode"] = (
+            "min_plus_solar" if v else "solar_only"
+        )
+        return original_read()
 
-    hass.states.is_state = is_state
-    # The mode resolver also calls ``hass.states.get(eid)`` to check
-    # whether each switch entity exists. Return a non-None MagicMock so
-    # the resolver takes the ``is_state`` branch (and ``is_state``
-    # above handles the filtering).
-    hass.states.get = MagicMock(return_value=MagicMock())
-
-    sm = ChargingStateMachine(
-        hass=hass,
-        config={
-            "ev_chargers": [{"id": "ev_charger"}],
-            "current_delta": 1,
-        },
-        time_manager=MagicMock(),
-    )
+    sm._read_night_enabled_raw = _advance_then_read
     return sm
 
 

--- a/tests/test_night_gate_per_charger.py
+++ b/tests/test_night_gate_per_charger.py
@@ -1,60 +1,25 @@
-"""Phase 3 (#255): night gate moved off the global switch onto per-charger, plus the
-one-time global→per-charger reconciliation (force-off)."""
-import pytest
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+"""Obsolete after #277 Phase C.
 
-from homeassistant.components.switch import SwitchEntityDescription
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+This file pinned the per-charger night-charging switch behaviour
+(#193 / #255). Phase C removed those switches entirely — the named
+``charge_mode`` selector now carries the same intent — so the tests
+no longer have a real fixture to exercise. The replacement coverage
+lives in:
 
-from custom_components.solar_energy_management.coordinator.charging_control import (
-    ChargingStateMachine,
-)
-from custom_components.solar_energy_management.switch import SEMPerChargerSwitch
+  - ``test_277_charge_mode_phase_b.py::TestNightGateFromMode`` —
+    end-to-end mode-driven night-gate decisions
+  - ``test_277_charge_mode_phase_b.py::TestSmartNightFromMode`` —
+    mode-driven smart-night enablement
+  - ``test_277_charge_mode_phase_b.py::TestRuntimeMigrationEquivalence``
+    (pre-Phase-C) was retitled in Phase C to
+    ``TestDeriveChargeModeAllLegacyCombinations`` and now covers the
+    migration's mode-derivation truth table
 
+The legacy one-time reconciliation (``force_off`` parameter on
+``SEMPerChargerSwitch``) is dormant — the class still exists but no
+production code path constructs it post-Phase-C. ``SEMPerChargerSwitch``
+itself is scheduled for removal in Phase D / v1.7.x cleanup.
 
-def _sm(chargers, switch_states):
-    hass = MagicMock()
-    hass.states.is_state = Mock(side_effect=lambda eid, st: switch_states.get(eid) == st)
-    return ChargingStateMachine(hass, {"ev_chargers": chargers}, MagicMock())
-
-
-class TestNightGatePerCharger:
-    def test_any_charger_on_enables(self):
-        sm = _sm([{"id": "a"}, {"id": "b"}], {"switch.sem_charger_b_night_charging": "on"})
-        assert sm._any_night_charging_enabled() is True
-
-    def test_all_per_charger_off_disables(self):
-        sm = _sm([{"id": "a"}, {"id": "b"}], {})
-        assert sm._any_night_charging_enabled() is False
-
-    def test_legacy_no_chargers_falls_back_to_global(self):
-        assert _sm([], {"switch.sem_night_charging": "on"})._any_night_charging_enabled() is True
-        assert _sm([], {})._any_night_charging_enabled() is False
-
-    def test_single_charger_on(self):
-        sm = _sm([{"id": "ev_charger"}], {"switch.sem_charger_ev_charger_night_charging": "on"})
-        assert sm._any_night_charging_enabled() is True
-
-
-class TestReconciliationForceOff:
-    @pytest.mark.asyncio
-    async def test_force_off_overrides_restored_on(self):
-        """The one-time reconciliation forces a per-charger switch OFF even if its own
-        restored state was 'on' (global was OFF → don't silently re-enable)."""
-        coord = MagicMock()
-        desc = SwitchEntityDescription(key="charger_a_night_charging")
-        sw = SEMPerChargerSwitch(coord, desc, "e", "a", "A", force_off=True)
-        sw.async_get_last_state = AsyncMock(return_value=MagicMock(state="on"))
-        with patch.object(CoordinatorEntity, "async_added_to_hass", AsyncMock()):
-            await sw.async_added_to_hass()
-        assert sw.is_on is False
-
-    @pytest.mark.asyncio
-    async def test_no_force_keeps_restored_on(self):
-        coord = MagicMock()
-        desc = SwitchEntityDescription(key="charger_a_night_charging")
-        sw = SEMPerChargerSwitch(coord, desc, "e", "a", "A", force_off=False)
-        sw.async_get_last_state = AsyncMock(return_value=MagicMock(state="on"))
-        with patch.object(CoordinatorEntity, "async_added_to_hass", AsyncMock()):
-            await sw.async_added_to_hass()
-        assert sw.is_on is True
+Kept as an empty module so a) the file isn't ghost-collected with a
+collection error, b) the deletion is visible in git history.
+"""

--- a/tests/test_per_charger_seed_migration.py
+++ b/tests/test_per_charger_seed_migration.py
@@ -38,7 +38,7 @@ async def test_seeds_all_eight_from_global():
     )
     assert await async_migrate_entry(hass, entry) is True
     c, kwargs = _seeded_charger(hass)
-    assert kwargs["version"] == 6  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
+    assert kwargs["version"] == 7  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
     assert c["daily_ev_target"] == 8
     assert c["daily_ev_target_max"] == 50
     assert c["ev_target_soc"] == 70
@@ -90,7 +90,7 @@ async def test_no_chargers_is_safe_and_bumps_version():
     hass = MagicMock()
     entry = _entry(options={}, data={"daily_ev_target": 8})
     assert await async_migrate_entry(hass, entry) is True
-    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 6  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
+    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 7  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
 
 
 @pytest.mark.asyncio
@@ -104,8 +104,10 @@ async def test_unset_global_not_seeded():
 
 
 @pytest.mark.asyncio
-async def test_phase4_charging_mode_and_phases_seeded():
-    """#255 Phase 4: ev_charging_mode + ev_phases are also seeded per-charger."""
+async def test_phase4_phases_seeded_charging_mode_dropped():
+    """#255 Phase 4 seeded ev_charging_mode + ev_phases per-charger.
+    #277 Phase C's v6→v7 migration drops ev_charging_mode (the named
+    ``charge_mode`` is authoritative); ev_phases is unchanged."""
     hass = MagicMock()
     entry = _entry(
         options={"ev_chargers": [{"id": "c1"}]},
@@ -113,8 +115,12 @@ async def test_phase4_charging_mode_and_phases_seeded():
     )
     await async_migrate_entry(hass, entry)
     c, _ = _seeded_charger(hass)
-    assert c["ev_charging_mode"] == "minpv"
     assert c["ev_phases"] == 1
+    # Phase C: dropped by the v6→v7 step.
+    assert "ev_charging_mode" not in c
+    # Phase A/B/C derivation chain: minpv + factory-default-ish state
+    # → catch-all min_plus_solar.
+    assert c["charge_mode"] == "min_plus_solar"
 
 
 def test_phase4_globals_removed_from_descriptions():

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -254,13 +254,17 @@ class TestChargingStrategyScenarios:
         )
         assert strategy != "idle"  # Solar always charges
 
-    def test_now_mode_overrides(self):
-        """Now mode — charge at max regardless."""
+    def test_always_max_mode_overrides(self):
+        """``always_max`` mode (successor of legacy ``now``) charges
+        at max regardless of solar / SOC. Post-#277 Phase C the
+        named ``charge_mode`` is the dispatch authority."""
         from .test_soc_zone_strategy import _build_coordinator, _make_power as _mp, _MockEnergy
-        coord = _build_coordinator()
-        coord.config["ev_charging_mode"] = "now"
+        coord = _build_coordinator(config_overrides={
+            "ev_chargers": [{"id": "ev_charger", "charge_mode": "always_max"}],
+        })
         strategy, _ = coord._determine_charging_strategy(
-            _mp(solar_power=100, battery_soc=30), _MockEnergy()
+            _mp(solar_power=100, battery_soc=30), _MockEnergy(),
+            charger_cfg={"id": "ev_charger", "charge_mode": "always_max"},
         )
         assert strategy == "now"
 

--- a/tests/test_soc_zone_strategy.py
+++ b/tests/test_soc_zone_strategy.py
@@ -229,21 +229,27 @@ class TestDetermineChargingStrategy:
         )
         assert strategy == "night_grid"
 
-    def test_charging_mode_off_returns_idle(self):
-        """Charging mode = 'off' → idle."""
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "off"})
+    def test_charge_mode_off_returns_idle(self):
+        """Charge mode = 'off' → idle. Post-#277 Phase C the named
+        ``charge_mode`` is the dispatch authority; pre-C this was
+        ``ev_charging_mode=off``."""
+        coord = _build_coordinator(config_overrides={
+            "ev_chargers": [{"id": "ev_charger", "charge_mode": "off"}],
+        })
         strategy, _ = coord._determine_charging_strategy(
-            _make_power(battery_soc=95), _MockEnergy()
+            _make_power(battery_soc=95), _MockEnergy(),
+            charger_cfg={"id": "ev_charger", "charge_mode": "off"},
         )
         assert strategy == "idle"
 
-    def test_charging_mode_minpv_returns_min_pv(self):
-        """Charging mode = 'minpv' → min_pv."""
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "minpv"})
-        strategy, _ = coord._determine_charging_strategy(
-            _make_power(battery_soc=50), _MockEnergy()
-        )
-        assert strategy == "min_pv"
+    # ``test_charging_mode_minpv_returns_min_pv`` removed in #277 Phase C:
+    # the ``minpv`` legacy mode no longer dispatches to ``("min_pv", …)``
+    # from ``_determine_charging_strategy``. Per the maintainer's
+    # Phase C decision (Q1: zone-adaptive), legacy ``minpv`` users
+    # migrated to ``min_plus_solar`` get zone-adaptive day behaviour;
+    # the ``min_pv`` strategy value is now only reachable via the
+    # night-grid → MIN_PV canonical-budget mapping in
+    # ``_canonical_strategy_from_legacy``.
 
     def test_low_solar_returns_idle(self):
         """Solar < 200W → idle (not enough sun)."""
@@ -415,21 +421,17 @@ class TestZoneDebounce:
 
 
 class TestAutoMode:
-    """Tests for auto mode — forecast-aware self_consumption vs pv switching."""
+    """Tests for auto mode — forecast-aware self_consumption vs pv switching.
 
-    def test_auto_high_ratio_uses_self_consumption(self):
-        """Plenty of solar → self_consumption strategy."""
-        from custom_components.solar_energy_management.coordinator.forecast_reader import ForecastData
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "auto"})
-        forecast = _MockForecast(available=True, remaining=25.0)
-        coord._cycle_forecast = forecast
-        coord._forecast_tracker.apply_dampening = MagicMock(return_value=25.0)
-
-        strategy, reason = coord._determine_charging_strategy(
-            _make_power(solar=8000, home=500, battery_soc=50), _MockEnergy(daily_ev=2)
-        )
-        assert "self_consumption" in reason
-        assert strategy == "solar_only"
+    Post-#277 Phase C ``_auto_mode_strategy`` is no longer dispatched
+    to from any charge_mode (the maintainer chose pure zone logic for
+    ``min_plus_solar`` / ``solar_plus_cheap`` to preserve the legacy
+    ``pv + night=on`` factory default's behaviour). The helper is
+    still exercised here in case a future ``auto`` charge mode reuses
+    it; the previous ``test_auto_high_ratio_uses_self_consumption``
+    that drove the helper through ``_determine_charging_strategy``
+    was deleted in Phase C because the dispatch path is gone.
+    """
 
     def test_auto_low_ratio_uses_pv(self):
         """Not enough solar → fall through to pv/zone logic."""

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -26,32 +26,21 @@ class TestSEMSwitches:
     """Test SEM switch entities."""
 
     def test_switch_types(self):
-        """Verify switch types."""
+        """Verify switch types. Post-#277 Phase C the legacy global
+        ``night_charging`` and ``smart_night_charging`` switches are
+        gone (the named ``charge_mode`` selector carries the same
+        intent); ``observer_mode`` is the only remaining one."""
         keys = [s.key for s in SWITCH_TYPES]
-        assert keys == ["night_charging", "observer_mode", "smart_night_charging"]
+        assert keys == ["observer_mode"]
 
-    @pytest.mark.asyncio
-    async def test_night_charging_default_off(self, mock_coordinator):
-        """night_charging defaults to OFF — opt-in (#256). A fresh install charges on
-        solar surplus only; existing users keep their state via RestoreEntity."""
-        description = create_switch_description("night_charging")
-        switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
-        assert switch._is_on is False
-
-    @pytest.mark.asyncio
-    async def test_night_charging_existing_state_preserved(self, mock_coordinator):
-        """Existing users are preserved: a restored 'on' state wins over the new
-        default-OFF, so upgrading doesn't silently stop anyone's night charging (#256)."""
-        from unittest.mock import patch
-        from homeassistant.helpers.update_coordinator import CoordinatorEntity
-
-        description = create_switch_description("night_charging")
-        switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
-        assert switch._is_on is False  # new default
-        switch.async_get_last_state = AsyncMock(return_value=MagicMock(state="on"))
-        with patch.object(CoordinatorEntity, "async_added_to_hass", AsyncMock()):
-            await switch.async_added_to_hass()
-        assert switch._is_on is True  # prior state restored, not overwritten by the default
+    # ``test_night_charging_default_off`` and
+    # ``test_night_charging_existing_state_preserved`` removed in
+    # #277 Phase C — the ``night_charging`` global switch is gone
+    # (the named ``charge_mode`` selector carries the intent now).
+    # The default-OFF guarantee (#256) is implicit in the new
+    # default mode ``min_plus_solar`` which permits night charging;
+    # the per-user opt-out is "pick ``solar_only`` or ``off``" in the
+    # selector instead of "flip night_charging off".
 
     @pytest.mark.asyncio
     async def test_observer_mode_default_from_config(self, mock_coordinator):
@@ -68,7 +57,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_is_on(self, mock_coordinator):
         """Test is_on returns internal state."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
 
         switch._is_on = True
@@ -80,7 +73,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_turn_on(self, mock_coordinator):
         """Test turning switch on."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
         switch._is_on = False
         switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
@@ -94,7 +91,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_turn_off(self, mock_coordinator):
         """Test turning switch off."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
         switch._is_on = True
         switch.async_write_ha_state = MagicMock()  # not added to hass in isolation
@@ -126,7 +127,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_availability(self, mock_coordinator):
         """Test switch availability logic."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
 
         mock_coordinator.last_update_success = True
@@ -138,7 +143,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_error_handling(self, mock_coordinator):
         """Test switch handles coordinator refresh errors gracefully."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
 
         mock_coordinator.async_request_refresh = AsyncMock(side_effect=Exception("Refresh error"))
@@ -173,7 +182,11 @@ class TestSEMSwitches:
     @pytest.mark.asyncio
     async def test_switch_device_info(self, mock_coordinator, config_entry):
         """Test switch device info."""
-        description = create_switch_description("night_charging")
+        # #277 Phase C: ``night_charging`` global switch removed.
+        # Reuse ``observer_mode`` (a generic CONFIG-category switch
+        # with the same SEMSolarSwitch behaviour) as the placeholder
+        # for these generic switch-interface tests.
+        description = create_switch_description("observer_mode")
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
 
         mock_coordinator.config_entry = config_entry

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Režim pozorovatele"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "Režim nabíjení EV"
-      },
       "ev_target_type": {
         "name": "Typ cíle EV",
         "state": {

--- a/translations/da.json
+++ b/translations/da.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Ladetilstand"
-      },
       "ev_target_type": {
         "name": "EV-måltype",
         "state": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Nachtladen"
-      },
       "observer_mode": {
         "name": "Beobachtermodus"
-      },
-      "smart_night_charging": {
-        "name": "Prognose Nachtabsenkung"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV-Lademodus"
-      },
       "ev_target_type": {
         "name": "EV-Zieltyp",
         "state": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Charging Mode"
-      },
       "ev_target_type": {
         "name": "EV Target Type",
         "state": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Carga Nocturna"
-      },
       "observer_mode": {
         "name": "Modo Observador"
-      },
-      "smart_night_charging": {
-        "name": "Reducción Nocturna Previsión"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Charging Mode"
-      },
       "ev_target_type": {
         "name": "Tipo de objetivo VE",
         "state": {

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "Lataustila"
-      },
       "ev_target_type": {
         "name": "Sähköauton tavoitetyyppi",
         "state": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Charge Nocturne"
-      },
       "observer_mode": {
         "name": "Mode Observation"
-      },
-      "smart_night_charging": {
-        "name": "Réduction Nocturne Prévision"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Charging Mode"
-      },
       "ev_target_type": {
         "name": "Type de cible VE",
         "state": {

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Töltési mód"
-      },
       "ev_target_type": {
         "name": "EV céltípus",
         "state": {

--- a/translations/it.json
+++ b/translations/it.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Carica Notturna"
-      },
       "observer_mode": {
         "name": "Modalità Osservatore"
-      },
-      "smart_night_charging": {
-        "name": "Riduzione Notturna Previsione"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Charging Mode"
-      },
       "ev_target_type": {
         "name": "Tipo di obiettivo EV",
         "state": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Nachtladen"
-      },
       "observer_mode": {
         "name": "Observatiemodus"
-      },
-      "smart_night_charging": {
-        "name": "Voorspelling Nachtreductie"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Laad Modus"
-      },
       "ev_target_type": {
         "name": "EV-doeltype",
         "state": {

--- a/translations/no.json
+++ b/translations/no.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Lademodus"
-      },
       "ev_target_type": {
         "name": "EV-måltype",
         "state": {

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "Tryb ładowania EV"
-      },
       "ev_target_type": {
         "name": "Typ celu EV",
         "state": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "Modo de carregamento VE"
-      },
       "ev_target_type": {
         "name": "Tipo de meta do VE",
         "state": {

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "Mod încărcare VE"
-      },
       "ev_target_type": {
         "name": "Tip țintă EV",
         "state": {

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1000,14 +1000,8 @@
       }
     },
     "switch": {
-      "night_charging": {
-        "name": "Night Charging"
-      },
       "observer_mode": {
         "name": "Observer Mode"
-      },
-      "smart_night_charging": {
-        "name": "Forecast Night Reduction"
       }
     },
     "number": {
@@ -1139,9 +1133,6 @@
       }
     },
     "select": {
-      "ev_charging_mode": {
-        "name": "EV Laddningsläge"
-      },
       "ev_target_type": {
         "name": "EV-måltyp",
         "state": {


### PR DESCRIPTION
## Summary

Architectural finish of the #277 EV charge UX consolidation arc. The named ``charge_mode`` is now the **sole authority** for EV charging intent:

- Strategy machine dispatches on ``charge_mode`` directly (no more ``ev_charging_mode`` reads)
- ``_tariff_optimized_for`` derives from ``charge_mode`` (only ``solar_plus_cheap`` defers)
- Three legacy per-charger switches deleted + the per-charger legacy select retired
- Derivation fallback in ``effective_charge_mode_for`` removed
- v6 → v7 migration drops the ``ev_charging_mode`` key

Maintainer-resolved design questions:
- **Q1** (``min_plus_solar`` mapping): **zone-adaptive** (pure ``pv`` fallthrough — matches Q4 "zero behaviour change for new installs")
- **Q2** (legacy switches): **full removal** (no read-only mirror intermediate step)

## Mode → strategy dispatch

| Mode | Strategy branch |
|---|---|
| ``always_max`` | ``("now", …)`` — explicit Max |
| ``off`` | ``("idle", …)`` — disabled |
| ``solar_only`` | ``_self_consumption_strategy`` — strict surplus |
| ``solar_plus_cheap`` | tariff pause check (was on ``minpv``) → zone logic |
| ``min_plus_solar`` | zone logic (Q1 decision) |

## ⚠️ Behavioural change — explicit-``minpv`` legacy users

Pre-Phase-C: users with ``ev_charging_mode=minpv`` got forced grid-Min during the day. Post-Phase-C: their ``min_plus_solar`` mode is zone-adaptive — the Min guarantee comes from NIGHT charging top-up only. Documented in CHANGELOG migration note. The user signed off on this trade-off (a small population vs the majority who came from ``pv+night=on`` factory default).

## Files changed

- ``coordinator/coordinator.py`` — ``_determine_charging_strategy`` dispatch + ``_smart_night_charging_enabled`` cleanup + defensive ``getattr`` for test stubs + ``_mirror_primary_charger_to_global`` drops dead ``ev_charging_mode`` entry
- ``coordinator/ev_control.py`` — ``_tariff_optimized_for`` mode-driven
- ``coordinator/charging_control.py`` — no-chargers fallback removed
- ``consts/ev_charge_modes.py`` — ``effective_charge_mode_for`` simplified (no derivation fallback)
- ``switch.py`` — 3 legacy switches + per-charger creation logic + #255 reconciliation block removed
- ``select.py`` — legacy ``ev_charging_mode`` per-charger select retired; entity-registry cleanup added
- ``config_flow.py`` — ``VERSION = 7``; ``smart_night_charging`` options-flow field removed
- ``__init__.py`` — v6→v7 migration
- ``strings.json`` + 15× ``translations/<lang>.json`` — orphan cleanup
- ~10 test files updated; 1 file replaced with empty-module comment
- ``CHANGELOG.md`` — [Unreleased] v1.7.0 candidate section added

## Review trail

Reviewer pass before commit returned **APPROVED with 4 items** (1 MEDIUM, 2 LOW, 1 NIT) — all addressed in the same commit:
- **MEDIUM**: misleading test name ``test_pre_migration_legacy_falls_back_via_derivation`` → renamed + comment updated.
- **LOW**: dead ``smart_night_charging`` config-flow field → removed.
- **LOW**: dead ``ev_charging_mode`` mirror-list entry → removed.
- **NIT**: CHANGELOG entry → added [Unreleased] v1.7.0 candidate section with migration notes.

Migration chain safety verified by reviewer — the accumulator pattern + chained ``if entry.version < N`` blocks correctly thread state across all 7 migration steps in a single ``async_migrate_entry`` call.

## Tests

**2130 / 2130 unit tests passing** (was 2144 on develop, -14 from deleted/consolidated tests).

Major sweep:
- ``test_277_charge_mode_phase_a/b.py`` — legacy-fallback equivalence tests removed; equivalence class scoped to migration only
- ``test_night_gate_per_charger.py`` — superseded by phase_b tests, replaced with empty-module comment
- ``test_night_charging_debounce.py`` — scaffold rewritten to mutate ``charge_mode`` per cycle (exercises production resolver directly)
- ``test_charging_control.py`` / ``test_dual_state_machine.py`` — fixtures get ``ev_chargers`` with ``charge_mode``
- ``test_ev_deadline_tariff.py`` — ``cfg`` dicts get ``charge_mode``; legacy ``minpv`` tests rewritten
- ``test_switch.py`` / ``test_integration.py`` — assert ``observer_mode`` only
- ``test_per_charger_seed_migration.py`` — asserts v7 drops ``ev_charging_mode``
- ``test_scenario.py`` — ``test_now_mode_overrides`` → ``test_always_max_mode_overrides``

## Issues addressed
- Closes #277 (Phase C of 3 — architectural finish of the EV charge UX consolidation arc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)