### PR TITLE
fix(#301): content-hash cache-bust for Lovelace card resources

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -39,6 +39,31 @@ from .coordinator import SEMCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+def _content_hash_cache_bust(card_root: str, base_url: str, version: str) -> str:
+    """Compute ``{version}-{sha1(content)[:8]}`` for a dashboard card asset.
+
+    Used by every Lovelace-resource registration path so the ``?v=`` query
+    follows file content. A bare timestamp (the previous behaviour) stayed
+    constant across rsync deploys and let browsers serve a stale cached
+    ``sem-localize.js`` even after the on-disk file was updated — surfacing
+    as raw translation keys on the EV charge-mode selector (#301).
+
+    ``base_url`` is the ``/local/custom_components/.../card/<path>`` URL;
+    the trailing relative path is resolved against ``card_root`` (the
+    deployed copy under ``/config/www/...``). Falls back to a bare
+    ``version`` if the file can't be read so a transient disk error still
+    busts the cache once and never deregisters a resource.
+    """
+    import hashlib
+
+    rel = base_url.split("/dashboard/card/", 1)[-1]
+    try:
+        with open(os.path.join(card_root, rel), "rb") as f:
+            return f"{version}-{hashlib.sha1(f.read()).hexdigest()[:8]}"
+    except OSError:
+        return version
+
+
 class _SEMYAMLModeSkip(Exception):
     """Sentinel: bail out of the Lovelace resource registration block
     when the user is running YAML-mode Lovelace (#283). YAML-mode
@@ -1162,10 +1187,19 @@ async def _async_register_services(
                     stale_count,
                 )
 
-            # Cache-busting: use timestamp so every generate_dashboard
-            # call forces browsers to reload card JS files.
-            import time as _time
-            cache_bust = str(int(_time.time()))
+            # Cache-busting: per-file content hash + manifest version (#301).
+            # See _content_hash_cache_bust at module level. Inlined into a
+            # closure here so the resolved card_www_dir + manifest version
+            # are captured once per service call.
+            manifest_path_l = os.path.join(component_dir, "manifest.json")
+            try:
+                with open(manifest_path_l) as f:
+                    _mver = json.load(f).get("version", "0")
+            except Exception:
+                _mver = "0"
+
+            def _cache_bust_for(base_url: str) -> str:
+                return _content_hash_cache_bust(card_www_dir, base_url, _mver)
 
             existing_bases = {item.get("url", "").split("?")[0] for item in resources_data["items"]}
             added_resources = []
@@ -1176,7 +1210,7 @@ async def _async_register_services(
                     import uuid as _uuid
                     resources_data["items"].append({
                         "id": _uuid.uuid4().hex,
-                        "url": f"{base_url}?v={cache_bust}",
+                        "url": f"{base_url}?v={_cache_bust_for(base_url)}",
                         "type": "module",
                     })
                     added_resources.append(base_url)
@@ -1202,7 +1236,7 @@ async def _async_register_services(
                         # Card file no longer exists — remove orphaned resource
                         cleaned.append(base)
                         continue
-                    new_url = f"{base}?v={cache_bust}"
+                    new_url = f"{base}?v={_cache_bust_for(base)}"
                     if item["url"] != new_url:
                         item["url"] = new_url
                         updated_resources += 1
@@ -1216,7 +1250,7 @@ async def _async_register_services(
                 if added_resources:
                     _LOGGER.info("Registered %d new Lovelace resource(s): %s", len(added_resources), added_resources)
                 if updated_resources:
-                    _LOGGER.info("Updated cache-bust on %d Lovelace resource(s) to v=%s", updated_resources, cache_bust)
+                    _LOGGER.info("Updated cache-bust on %d Lovelace resource(s) (content-hash)", updated_resources)
 
             # Step 2: Generate dashboard config
             generator = DashboardGenerator(hass)

--- a/tests/test_dashboard_generator.py
+++ b/tests/test_dashboard_generator.py
@@ -109,6 +109,113 @@ class TestDashboardTemplate:
             assert os.path.exists(os.path.join(card_dir, card)), f"Missing: {card}"
 
 
+class TestContentHashCacheBust:
+    """Regression tests for the Lovelace cache-bust helper (#301).
+
+    The legacy cache-bust used ``int(time.time())`` which stayed constant
+    between ``generate_dashboard`` service calls — so an rsync deploy that
+    rewrote ``sem-localize.js`` left the registered URL's ``?v=`` unchanged
+    and browsers happily served the old cached copy. Newly-added translation
+    keys (e.g. ``charge_mode_*``) then rendered as raw key text on the EV
+    card. The fix is to hash the file content so any real change flips the
+    URL automatically.
+    """
+
+    def _bust(self, *args, **kwargs):
+        # Imported lazily so the test module remains importable when the
+        # parent package's optional deps are missing in some test envs.
+        from custom_components.solar_energy_management import (
+            _content_hash_cache_bust,
+        )
+        return _content_hash_cache_bust(*args, **kwargs)
+
+    def test_url_includes_version_and_short_hash(self, tmp_path):
+        card_root = tmp_path
+        (card_root / "sem-localize.js").write_bytes(b"const x = 1;")
+        base = "/local/custom_components/solar_energy_management/dashboard/card/sem-localize.js"
+
+        bust = self._bust(str(card_root), base, "1.7.0")
+
+        # Format must be ``{version}-{8-hex-char hash}`` — matches the
+        # _async_register_frontend_resources bundle path so both registration
+        # paths produce identical URLs for the same file content.
+        assert "-" in bust
+        version, short = bust.split("-", 1)
+        assert version == "1.7.0"
+        assert len(short) == 8
+        assert all(c in "0123456789abcdef" for c in short)
+
+    def test_url_changes_when_content_changes(self, tmp_path):
+        """A file edit must flip the URL — the property the bug violated."""
+        card_root = tmp_path
+        f = card_root / "sem-localize.js"
+        base = "/local/custom_components/solar_energy_management/dashboard/card/sem-localize.js"
+
+        f.write_bytes(b'{"charge_mode": "Charge mode"}')
+        before = self._bust(str(card_root), base, "1.7.0")
+
+        f.write_bytes(b'{"charge_mode": "Charge mode", "charge_mode_min_plus_solar": "Min + Solar"}')
+        after = self._bust(str(card_root), base, "1.7.0")
+
+        assert before != after, (
+            "cache-bust must track file content — adding a new translation key "
+            "must change the ?v= URL or the browser will serve the stale cached "
+            "file (the #301 regression)."
+        )
+
+    def test_url_stable_across_calls_when_content_unchanged(self, tmp_path):
+        """No URL churn on each restart — only file content drives changes."""
+        card_root = tmp_path
+        (card_root / "sem-localize.js").write_bytes(b"const x = 1;")
+        base = "/local/custom_components/solar_energy_management/dashboard/card/sem-localize.js"
+
+        first = self._bust(str(card_root), base, "1.7.0")
+        second = self._bust(str(card_root), base, "1.7.0")
+
+        assert first == second
+
+    def test_url_for_nested_bundle_path(self, tmp_path):
+        """Bundle lives under ``dist/`` — the URL splitter must handle it."""
+        card_root = tmp_path
+        (card_root / "dist").mkdir()
+        (card_root / "dist" / "sem-cards.js").write_bytes(b"// bundle")
+        base = "/local/custom_components/solar_energy_management/dashboard/card/dist/sem-cards.js"
+
+        bust = self._bust(str(card_root), base, "1.7.0")
+
+        version, short = bust.split("-", 1)
+        assert version == "1.7.0"
+        assert len(short) == 8
+
+    def test_missing_file_falls_back_to_bare_version(self, tmp_path):
+        """If the asset can't be read, return bare version — don't crash or
+        return an empty bust that could collide with another resource."""
+        card_root = tmp_path
+        base = "/local/custom_components/solar_energy_management/dashboard/card/sem-localize.js"
+
+        bust = self._bust(str(card_root), base, "1.7.0")
+
+        assert bust == "1.7.0"
+
+    def test_no_timestamp_anti_pattern_in_service_path(self):
+        """Guard the regression: the legacy ``int(time.time())`` cache-bust
+        must not reappear in the generate_dashboard service path. If a future
+        edit reverts to a timestamp, the symptom returns silently — no test
+        catches it because the URL is still ``valid``, just stale."""
+        init_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            "__init__.py",
+        )
+        src = open(init_path).read()
+        # The legacy pattern. We pick the exact construction that produced
+        # the bug so this test stays sharp and doesn't false-positive on
+        # unrelated timestamp usage elsewhere in the file.
+        assert 'cache_bust = str(int(_time.time()))' not in src, (
+            "Reintroduced the time-based cache-bust that caused #301. Use "
+            "_content_hash_cache_bust so ?v= follows file content."
+        )
+
+
 class TestWeatherSubstitution:
     """Test weather entity substitution in the dashboard generator."""
 


### PR DESCRIPTION
Closes #301.

## Problem

After v1.7.0 deploy, the new EV charge-mode selector rendered **raw translation keys** instead of localized labels:

- Label: `charge_mode`
- Selected value: `charge_mode_min_plus_so…`
- Hint: `charge_mode_hint_min_plus_solar`

Other strings on the same card (`power`, `today`, `ev_charge_by`) rendered correctly, so `semLocalize()` itself worked — the dictionary loaded into the browser just didn't contain any `charge_mode_*` keys yet.

## Root cause

Two registration paths exist for `sem-localize.js`:

| Path | Cache-bust | Updates when |
|---|---|---|
| `_async_register_frontend_resources` (every restart) | content hash | restart after file change |
| `async_generate_dashboard_service` (legacy `.storage/lovelace_resources`) | `int(time.time())` | only on `generate_dashboard` service call |

The legacy path's timestamp never moved on plain rsync deploys, so the registered URL stayed `?v=1779975126` while the file on disk was the fresh v1.7.0 copy. The browser cache served the pre-Phase-B.2 file, which lacked the new translation keys.

## Fix

Replace the timestamp with the existing `{manifest_version}-{sha1(content)[:8]}` format already used by `_async_register_frontend_resources` for the Lit bundle. Both registration paths now produce identical URLs for the same file content; any deploy that changes file content auto-flips the URL on the next `generate_dashboard` call and the browser cache-misses through to the fresh copy.

Extracted as the module-level `_content_hash_cache_bust` helper so the behaviour is directly testable instead of buried in a closure.

## Verification

On HA-PROD after deploy + one `generate_dashboard` call:

```
disk: sem-localize.js  sha1[:8]=b59bd587
disk: dist/sem-cards.js sha1[:8]=732be796
disk: sem-system-diagram-card.js sha1[:8]=4f031688
disk: sem-reactive-base.js sha1[:8]=b92b1fcf
disk: sem-shared.js  sha1[:8]=ee04c640

regd: sem-localize.js?v=1.7.0-b59bd587  ← was ?v=1779975126
regd: dist/sem-cards.js?v=1.7.0-732be796
regd: sem-system-diagram-card.js?v=1.7.0-4f031688
regd: sem-reactive-base.js?v=1.7.0-b92b1fcf
regd: sem-shared.js?v=1.7.0-ee04c640
```

Every registered URL now matches the on-disk content hash.

## Tests

6 new regression tests in `TestContentHashCacheBust`:

- URL format is `{version}-{8 hex chars}`
- Editing the file changes the URL (the property the bug violated)
- URL is stable across calls when content doesn't change (no churn)
- Nested bundle path under `dist/` is handled
- Missing-file fallback returns bare version (no crash, no empty bust)
- Source guard rejects the `int(time.time())` anti-pattern from being silently reintroduced

Full suite: **2136 passed, 7 skipped, 0 failed**.

## Already deployed

The patch is already live on HA-PROD (md5 `a68ef0ef…` matches the local pre-refactor version; the post-refactor module-level helper is behaviour-equivalent). User confirmed the charge-mode card recovered after a single `generate_dashboard` call refreshed the URL.

## Test plan
- [x] All 6 new regression tests pass
- [x] Full local test suite green (2136 passed)
- [x] Deployed to HA-TEST — clean startup, no SEM errors
- [x] Deployed to HA-PROD — md5 verified, `generate_dashboard` call refreshed every registered URL to content-hash format
- [ ] CI green