### PR TITLE
cleanup(#304,#305): Phase C dead code + select.py orphan sweep

### DIFF
--- a/coordinator/charging_control.py
+++ b/coordinator/charging_control.py
@@ -53,7 +53,9 @@ class ChargingContext:
         daily_ev_energy_offset: EV energy from offset utility meter (kWh), 0 if unused.
         remaining_ev_energy: Remaining EV need (kWh), from vehicle SOC or daily target.
         charging_strategy: Strategy from SOC zone logic — one of:
-            "solar_only", "battery_assist", "night_grid", "min_pv", "idle".
+            "solar_only", "battery_assist", "night_grid", "idle". (The
+            legacy ``"min_pv"`` value was retired in #305 — no producer
+            remains and the consuming branch at line 208 is inert.)
         charging_strategy_reason: Human-readable explanation of strategy choice.
         night_target_kwh: Night charging target (kWh), may be forecast-adjusted if enabled.
             For night mode, remaining is derived from this field directly.

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2323,8 +2323,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             return EVBudgetStrategy.IDLE
         if legacy_strategy == "now":
             return EVBudgetStrategy.NOW
-        if legacy_strategy == "min_pv":
-            return EVBudgetStrategy.MIN_PV
+        # ``min_pv`` removed in #305: post-#277 Phase C no charge mode
+        # produces this tuple. ``_determine_charging_strategy`` only
+        # returns solar_only / battery_assist / night_grid / idle; the
+        # canonical ``MIN_PV`` is still reachable via the night_grid
+        # mapping below and is not retired.
         if legacy_strategy == "night_grid":
             # Night charging tops up to the Min floor using grid (#245
             # semantic). Canonical MIN_PV is the right shape — its formula
@@ -2501,12 +2504,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # ``_mode_allows_night_charging`` etc), so the daytime strategy
         # just runs the zone decision tree unchanged.
         #
-        # (Pre-Phase-C the legacy ``auto`` mode wrapped this branch in
-        # ``_auto_mode_strategy`` — forecast-aware self_consumption
-        # when ratio>2. That wrapper is still callable via
-        # ``_auto_mode_strategy`` but no charge mode dispatches to it
-        # in Phase C. v1.7.x or later can opt-in users who actually
-        # want forecast-aware switching, but it's not the default.)
+        # The legacy ``_auto_mode_strategy`` forecast-aware wrapper
+        # (self_consumption when ratio>2) was removed in #305 — no
+        # charge mode dispatched to it post-Phase-C. A future opt-in
+        # ``auto`` mode can re-introduce a forecast switcher; resurrect
+        # via git history rather than carrying dead code.
         # No-op — explicit fall-through.
 
         # No meaningful solar → wait
@@ -2608,45 +2610,6 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         available = max(0, available)
         zone = "Z4-redirect" if power.battery_soc >= auto_start_soc else f"Z{self._get_zone(power.battery_soc)}"
         return ("solar_only", f"self_consumption ({zone}): surplus={available:.0f}W, solar={power.solar_power:.0f}W")
-
-    def _auto_mode_strategy(self, power, energy, remaining_need: float) -> tuple:
-        """Auto mode: forecast-aware switching between self_consumption and pv (#67).
-
-        ratio = remaining_solar / remaining_ev_need
-        ratio > 2.0 → self_consumption (plenty of sun, no rush)
-        1.0-2.0     → pv with cap (tight, charge when available)
-        < 1.0       → pv aggressive (not enough, battery assist)
-        """
-        forecast = self._cycle_forecast
-        remaining_solar = 0
-        if forecast and forecast.available:
-            remaining_solar = forecast.forecast_remaining_today_kwh
-            try:
-                remaining_solar = self._forecast_tracker.apply_dampening(remaining_solar)
-            except (ValueError, AttributeError):
-                pass
-
-        if remaining_need < 0.5:
-            # Floor (Min) met — no forecast-based pacing needed. Solar surplus
-            # still continues up to the Max ceiling via the surplus path (#245).
-            return ("idle", "auto: min target met, solar continues to ceiling")
-
-        ratio = remaining_solar / remaining_need if remaining_need > 0 else 99
-
-        if ratio > 2.0:
-            # Plenty of sun → self_consumption
-            result = self._self_consumption_strategy(power, energy)
-            return (result[0], f"auto (ratio={ratio:.1f}→self_consumption): {result[1]}")
-        elif not forecast or not forecast.available:
-            # No forecast → default pv behavior (fall through to zone logic below)
-            pass
-        else:
-            # Tight or insufficient → pv with zones (fall through)
-            _LOGGER.debug("auto: ratio=%.1f → pv mode (zones active)", ratio)
-
-        # Fall through to normal zone-based pv logic
-        # (return None so caller continues to zone logic)
-        return None  # Signal: continue to zone logic
 
     def _raw_zone(self, soc: float, auto_start: float, buffer: float, priority: float) -> int:
         """Map SOC to a zone number using raw (un-debounced) thresholds."""

--- a/select.py
+++ b/select.py
@@ -90,31 +90,6 @@ async def async_setup_entry(
     except Exception as e:
         _LOGGER.debug("Global select removal skipped: %s", e)
 
-    # #277 Phase C — drop the per-charger ``ev_charging_mode`` selects
-    # the new ``charge_mode`` selector replaces. The v6→v7 migration
-    # already cleared the underlying config key; this purges the
-    # orphaned entity rows from the registry so the dashboard doesn't
-    # leak stale "EV Charging Mode" labels.
-    try:
-        registry = er.async_get(hass)
-        full_config_legacy = {**entry.data, **entry.options}
-        for charger_cfg in full_config_legacy.get("ev_chargers") or []:
-            cid = (
-                charger_cfg.get("id", "ev_charger")
-                if isinstance(charger_cfg, dict) else "ev_charger"
-            )
-            legacy_uid = f"{entry.entry_id}_charger_{cid}_ev_charging_mode"
-            legacy_eid = registry.async_get_entity_id("select", DOMAIN, legacy_uid)
-            if legacy_eid:
-                registry.async_remove(legacy_eid)
-                _LOGGER.info(
-                    "Removed legacy per-charger select %s "
-                    "(replaced by charge_mode selector, #277 Phase C)",
-                    legacy_eid,
-                )
-    except Exception as e:
-        _LOGGER.debug("Per-charger legacy select cleanup skipped: %s", e)
-
     entities = [
         SEMSelectEntity(coordinator, entry, description)
         for description in SELECT_TYPES
@@ -123,13 +98,17 @@ async def async_setup_entry(
     # Per-charger selects (#235, #255): target-type (kWh / SOC %) + charging mode.
     full_config = {**entry.data, **entry.options}
     ev_chargers = full_config.get("ev_chargers", [])
+    per_charger_keys: set[str] = set()
     if len(ev_chargers) >= 1:
         for charger_cfg in ev_chargers:
             cid = charger_cfg.get("id", "ev_charger")
+            target_key = f"charger_{cid}_ev_target_type"
+            mode_key = f"charger_{cid}_charge_mode"
+            per_charger_keys.update({target_key, mode_key})
             entities.append(SEMPerChargerSelect(
                 coordinator,
                 SelectEntityDescription(
-                    key=f"charger_{cid}_ev_target_type",
+                    key=target_key,
                     options=list(EV_TARGET_TYPES.keys()),
                     entity_category=EntityCategory.CONFIG,
                 ),
@@ -139,13 +118,12 @@ async def async_setup_entry(
             # The legacy ``ev_charging_mode`` per-charger select was
             # retired in #277 Phase C — the new ``charge_mode``
             # selector (registered below) is the only intent knob now.
-            # The entity registry's stale-cleanup at the top of this
-            # function removes orphaned ``charger_<id>_ev_charging_mode``
-            # entries on the next setup.
+            # The stale-key cleanup at the bottom of this function
+            # purges orphaned ``charger_<id>_ev_charging_mode`` rows.
             entities.append(SEMPerChargerSelect(
                 coordinator,
                 SelectEntityDescription(
-                    key=f"charger_{cid}_charge_mode",
+                    key=mode_key,
                     options=list(EV_CHARGE_MODES.keys()),
                     entity_category=EntityCategory.CONFIG,
                 ),
@@ -154,6 +132,34 @@ async def async_setup_entry(
             ))
 
     async_add_entities(entities)
+
+    # Stale-key cleanup (#304): scan the registry instead of iterating
+    # the current config so entries left behind by previously-removed
+    # chargers are caught. The per-config loop above only knew about
+    # currently-attached chargers, so a charger that was renamed or
+    # removed left its ``charger_<id>_ev_charging_mode`` (and any
+    # other retired per-charger select) in the registry indefinitely.
+    # Mirrors the pattern in ``switch.py`` (#277 Phase C cleanup).
+    try:
+        registry = er.async_get(hass)
+        valid_keys = {d.key for d in SELECT_TYPES} | per_charger_keys
+        for entity_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+            if entity_entry.domain != "select":
+                continue
+            unique_id = entity_entry.unique_id or ""
+            key: str | None = None
+            if unique_id.startswith("sem_"):
+                key = unique_id[4:]
+            elif unique_id.startswith(f"{entry.entry_id}_"):
+                key = unique_id[len(entry.entry_id) + 1:]
+            if key and key not in valid_keys:
+                _LOGGER.info(
+                    "Removing stale select entity %s (key '%s' no longer registered)",
+                    entity_entry.entity_id, key,
+                )
+                registry.async_remove(entity_entry.entity_id)
+    except Exception as e:
+        _LOGGER.debug("Stale select cleanup skipped: %s", e)
 
 
 class SEMSelectEntity(CoordinatorEntity, SelectEntity):

--- a/tests/scenario_harness.py
+++ b/tests/scenario_harness.py
@@ -267,9 +267,10 @@ def _build_coordinator(scenario: Dict[str, Any]):
     # config — we already populated config above, so no extra set needed.
     coord._forecast_tracker = MagicMock()
     coord._forecast_tracker.dampening_factor = 1.0
-    # apply_dampening is called by _auto_mode_strategy; default MagicMock
-    # would return a MagicMock that doesn't compare cleanly with floats →
-    # `ratio > 2.0` crashes. Make it a pass-through.
+    # apply_dampening is called from the night-charging top-up path
+    # (coordinator.py:2830). Default MagicMock returns something that
+    # doesn't compare cleanly with floats — make it a pass-through so
+    # downstream arithmetic doesn't crash inside the harness.
     coord._forecast_tracker.apply_dampening = lambda x: x
     # state machine + time manager — strategy doesn't need their behaviour,
     # only their presence. Mock at the attribute level so attr lookups succeed.
@@ -401,8 +402,9 @@ async def run_scenario(yaml_path: Path) -> ScenarioRun:
             canonical_strat = EVBudgetStrategy.IDLE
         elif strategy == "now":
             canonical_strat = EVBudgetStrategy.NOW
-        elif strategy == "min_pv":
-            canonical_strat = EVBudgetStrategy.MIN_PV
+        # ``min_pv`` mapping removed in #305 — production mapper no
+        # longer accepts the tuple either; the night_grid path is the
+        # only producer of canonical MIN_PV.
         elif strategy == "battery_assist":
             canonical_strat = EVBudgetStrategy.BATTERY_ASSIST
         elif strategy == "solar_only":

--- a/tests/scenarios/2026-05-29_budget_unify_battery_assist.yaml
+++ b/tests/scenarios/2026-05-29_budget_unify_battery_assist.yaml
@@ -27,11 +27,12 @@ config:
   battery_priority_soc: 30
   battery_assist_floor_soc: 60
   battery_assist_max_power: 4500
-  # Force pv mode so `_auto_mode_strategy` doesn't intercept. With the
-  # harness defaulting forecast to 25 kWh, auto-mode would take the
-  # ratio>2 path → self_consumption → strategy=solar_only, not
-  # battery_assist. PV mode goes directly to the main zone dispatch
-  # where Zone 4 returns battery_assist.
+  # Force pv mode so the zone dispatch picks battery_assist directly.
+  # (Pre-#305 the legacy ``auto`` mode wrapped this in
+  # ``_auto_mode_strategy`` and took the ratio>2 → self_consumption
+  # path under the harness's 25 kWh default forecast — that wrapper
+  # is now gone but the scenario still wants the deterministic
+  # Zone 4 → battery_assist outcome.)
   ev_charging_mode: "pv"
   ev_min_current: 6
   ev_max_current: 16

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -143,7 +143,16 @@ def test_solar_target_reached(sm):
 
 
 def test_min_pv_mode(sm):
-    """Test Min+PV mode returns SOLAR_MIN_PV state."""
+    """Pin the state-machine mapping for ``charging_strategy="min_pv"``.
+
+    Post-#305 the producer side (`_determine_charging_strategy` and
+    `_canonical_strategy_from_legacy`) no longer emits the legacy
+    ``"min_pv"`` string, so `charging_control.py:208` is unreachable
+    in production. This test still exercises that branch directly
+    via a synthetic context to keep the SOLAR_MIN_PV mapping pinned
+    in case a future producer is reintroduced. If both the producer
+    and the consumer are dropped together, delete this test too.
+    """
     ctx = _ctx(
         ev_connected=True,
         charging_strategy="min_pv",

--- a/tests/test_soc_zone_strategy.py
+++ b/tests/test_soc_zone_strategy.py
@@ -420,54 +420,11 @@ class TestZoneDebounce:
 # unit tests for the per-zone shape.
 
 
-class TestAutoMode:
-    """Tests for auto mode — forecast-aware self_consumption vs pv switching.
-
-    Post-#277 Phase C ``_auto_mode_strategy`` is no longer dispatched
-    to from any charge_mode (the maintainer chose pure zone logic for
-    ``min_plus_solar`` / ``solar_plus_cheap`` to preserve the legacy
-    ``pv + night=on`` factory default's behaviour). The helper is
-    still exercised here in case a future ``auto`` charge mode reuses
-    it; the previous ``test_auto_high_ratio_uses_self_consumption``
-    that drove the helper through ``_determine_charging_strategy``
-    was deleted in Phase C because the dispatch path is gone.
-    """
-
-    def test_auto_low_ratio_uses_pv(self):
-        """Not enough solar → fall through to pv/zone logic."""
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "auto"})
-        forecast = _MockForecast(available=True, remaining=5.0)
-        coord._cycle_forecast = forecast
-        coord._forecast_tracker.apply_dampening = MagicMock(return_value=5.0)
-
-        result = coord._auto_mode_strategy(
-            _make_power(solar=5000, battery_soc=50), _MockEnergy(daily_ev=0), 10
-        )
-        # ratio = 5/10 = 0.5 → None (fall through to zones)
-        assert result is None
-
-    def test_auto_no_forecast_uses_pv(self):
-        """No forecast → fall through to pv."""
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "auto"})
-        coord._cycle_forecast = _MockForecast(available=False)
-
-        result = coord._auto_mode_strategy(
-            _make_power(solar=5000, battery_soc=80), _MockEnergy(daily_ev=0), 10
-        )
-        assert result is None
-
-    def test_auto_target_reached_idle(self):
-        """Min floor met → auto returns idle (solar still continues to Max via surplus)."""
-        coord = _build_coordinator(config_overrides={"ev_charging_mode": "auto"})
-        coord._cycle_forecast = _MockForecast(available=True, remaining=20.0)
-        coord._forecast_tracker = MagicMock()
-        coord._forecast_tracker.apply_correction = MagicMock(return_value=20.0)
-
-        result = coord._auto_mode_strategy(
-            _make_power(solar=5000, battery_soc=80), _MockEnergy(daily_ev=10), 0.1
-        )
-        assert result[0] == "idle"
-        assert "min target met" in result[1]
+# TestAutoMode removed in #305: ``_auto_mode_strategy`` was deleted
+# as dead code (no charge mode dispatched to it post-#277 Phase C).
+# The previous 3 tests exercised the helper directly; if a future
+# opt-in ``auto`` mode resurrects the forecast-aware switcher, restore
+# both the method and its tests together from the #305 commit.
 
 
 class TestSelfConsumptionStrategy:


### PR DESCRIPTION
## Summary

Two cleanup items surfaced by the v1.6.3 release review (both pre-existing gaps, not v1.6.3 regressions). Pure dead-code/orphan removal; no semantic behaviour change for end users.

**Fixes #304** — registry-key sweep replaces the config-driven per-charger ``ev_charging_mode`` purge in ``select.py``. The old loop only iterated chargers currently in the config, leaving entities from renamed/removed chargers in the registry forever. The new sweep mirrors the long-standing pattern in ``switch.py:81-99`` and catches those orphans.

**Fixes #305** — drops two pieces of dead code:
- ``_auto_mode_strategy`` — no charge mode dispatches to it post-#277 Phase C.
- ``if legacy_strategy == "min_pv":`` branch in ``_canonical_strategy_from_legacy`` — ``_determine_charging_strategy`` only emits solar_only / battery_assist / night_grid / idle; the canonical ``EVBudgetStrategy.MIN_PV`` is still alive via the night_grid mapping.

## What's kept (still reachable)

- ``EVBudgetStrategy.MIN_PV`` — produced via ``night_grid`` → ``_canonical_strategy_from_legacy`` line 2340; consumed in ``flow_calculator.py:594``.
- ``ChargingState.SOLAR_MIN_PV`` — still reachable via the ``"now"`` strategy in ``charging_control.py:204``.
- ``test_min_pv_mode`` — annotated as a deliberate pin for the now-unreachable consumer branch in ``charging_control.py:208`` (full removal tracked as #308).

## Verification

- **2137 tests passed**, 7 skipped on Python 3.12 (same pre/post diff).
- Independent code-quality reviewer (``ruflo-core:reviewer``) returned OK-TO-SHIP with two NITs (both folded in: docstring fix at ``charging_control.py:56``, stale comment refresh).
- Independent audit pass on the full diff returned OK-TO-SHIP with one extra NIT (folded in: stale ``_auto_mode_strategy`` reference in ``tests/scenarios/2026-05-29_budget_unify_battery_assist.yaml``).
- HA-TEST full clean install verified: SEM v1.6.3 entities=250, coordinator cycles green, no SEM errors in logs, both per-charger selects (``charger_ev_charger_charge_mode`` + ``ev_target_type``) registered, no legacy ``_ev_charging_mode`` orphan.

## Follow-ups filed

- #308 — drop dead ``now``/``min_pv`` consumer branches in ``charging_control.py`` (depends on this PR landing)
- #309 — fold redundant global-select cleanup at ``select.py:80-91`` into the new sweep
- #310 — consolidate accumulated gravestone comments in ``test_soc_zone_strategy.py``

## Test plan

- [x] Full test suite — 2137 / 7 skipped
- [x] HA-TEST clean install + validate-sem.sh
- [ ] CI: Tests 3.12 + 3.13
- [ ] Post-merge: HA-PROD soak during a surplus-charge cycle (user's call)

## Diff stats

7 files changed, 77 insertions(+), 137 deletions(-)