### PR TITLE
fix: charge_mode=off now stops EV charging (v1.6.4 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] — 2026-05-31
+
+Hotfix on top of v1.6.3 plus the cleanup follow-ups #304/#305 that
+shipped to develop the same day.
+
+### Fixed
+
+- **`charge_mode=off` did not stop EV charging** — surfaced during the
+  v1.6.3 PROD soak. Setting the per-charger Charge mode to ``Off`` while
+  the EV was actively charging left the KEBA contactor closed; SEM
+  reported "Charging allowed" with budget 0 but the charger kept drawing
+  power, requiring a manual ``keba.disable`` call to stop. The state
+  machine fell through to ``SOLAR_CHARGING_ALLOWED`` instead of a
+  terminal stop, so ``stop_session()`` was never invoked.
+
+  Fix: introduce a distinct ``"disabled"`` strategy string for explicit-off
+  (separate from transient ``"idle"``). The state machine routes it to
+  ``SOLAR_IDLE``, which the actuator treats as terminal → calls
+  ``stop_session()`` → ``keba.disable``. The canonical EV budget enum
+  collapses ``"disabled"`` back to ``IDLE`` (same 0 W shape, distinct
+  upstream).
+
+  Multi-charger correctness: a static helper
+  ``_apply_per_charger_off_override`` runs in the dispatch loop so a
+  primary charger's ``off`` cannot bleed its terminate into siblings
+  with active ``solar_only``/``min_plus_solar`` modes.
+
+### Cleanup (from develop merge)
+
+- **#304** — ``select.py`` orphan removal now uses a registry-key sweep
+  matching ``switch.py``. Catches stale entries from previously-removed
+  chargers (rather than only those currently in the config).
+- **#305** — drop dead ``_auto_mode_strategy`` and the unreachable
+  ``min_pv`` branch in ``_canonical_strategy_from_legacy``. Both were
+  Phase C leftovers documented as deferred.
+
 ## [1.6.3] — 2026-05-30
 
 The **EV charge UX consolidation** release (#277). Replaces the

--- a/coordinator/charging_control.py
+++ b/coordinator/charging_control.py
@@ -53,9 +53,15 @@ class ChargingContext:
         daily_ev_energy_offset: EV energy from offset utility meter (kWh), 0 if unused.
         remaining_ev_energy: Remaining EV need (kWh), from vehicle SOC or daily target.
         charging_strategy: Strategy from SOC zone logic — one of:
-            "solar_only", "battery_assist", "night_grid", "idle". (The
-            legacy ``"min_pv"`` value was retired in #305 — no producer
-            remains and the consuming branch at line 208 is inert.)
+            "solar_only", "battery_assist", "night_grid", "idle",
+            "disabled". ``"disabled"`` is the explicit-off intent
+            (charge_mode=off) and routes the state machine to
+            SOLAR_IDLE → actuator stop_session(); ``"idle"`` is the
+            transient pause (Zone 1, solar<200W, target met) which
+            stays in CHARGING_ALLOWED (warm, waiting for surplus).
+            (The legacy ``"min_pv"`` value was retired in #305 — no
+            producer remains and the consuming branch at line 208 is
+            inert.)
         charging_strategy_reason: Human-readable explanation of strategy choice.
         night_target_kwh: Night charging target (kWh), may be forecast-adjusted if enabled.
             For night mode, remaining is derived from this field directly.
@@ -187,6 +193,22 @@ class ChargingStateMachine:
         """
         # Check EV connection first
         if not ctx.ev_connected:
+            self._battery_initial_check_done = False
+            self._ev_session_allowed = False
+            return ChargingState.SOLAR_IDLE
+
+        # Explicit-off intent (charge_mode=off → strategy="disabled")
+        # terminates the session rather than holding in CHARGING_ALLOWED
+        # with budget=0. Distinct from generic "idle" (which can be
+        # transient — Zone 1 battery priority, solar<200W, target met).
+        # Observed during the v1.6.3 PROD soak: KEBA's contactor stayed
+        # closed when only the setpoint was zeroed, because the actuator's
+        # CHARGING_ALLOWED path never calls stop_session(). SOLAR_IDLE
+        # routes through ev_control.py's TERMINAL STATES branch which
+        # invokes stop_session() → keba.disable. Matches the not-connected
+        # reset above so a later mode flip back to a charging mode replays
+        # the normal enable-delay warmup.
+        if ctx.charging_strategy == "disabled":
             self._battery_initial_check_done = False
             self._ev_session_allowed = False
             return ChargingState.SOLAR_IDLE

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -335,6 +335,32 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             if pc.get(key) is not None:
                 self.config[key] = pc[key]
 
+    @staticmethod
+    def _apply_per_charger_off_override(global_state: str, per_mode: str) -> str:
+        """Per-charger override of the global solar charging state (v1.6.3 hotfix).
+
+        The global ``charging_state`` is derived from the primary
+        charger's config only. Two correctness gaps in the multi-charger
+        loop need to be closed:
+
+        1. **This charger is off**: force ``SOLAR_IDLE`` so the actuator's
+           TERMINAL branch calls ``stop_session()`` regardless of what
+           the primary charger is doing. Without this, charger[1]=off
+           would never be stopped.
+        2. **Primary is off but this charger isn't**: don't propagate
+           the primary's terminate. Fall back to ``SOLAR_CHARGING_ALLOWED``
+           (warm-waiting) so this charger keeps participating in surplus
+           distribution.
+
+        Pure function — no side effects, no coordinator state read.
+        Directly unit-testable.
+        """
+        if per_mode == "off":
+            return ChargingState.SOLAR_IDLE
+        if global_state == ChargingState.SOLAR_IDLE:
+            return ChargingState.SOLAR_CHARGING_ALLOWED
+        return global_state
+
     def _effective_charge_mode_for(self, charger_cfg: dict) -> str:
         """Resolve the user-intent Charge mode for one charger (#277).
 
@@ -1164,6 +1190,16 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     charging_context.night_deadline_active = False
                     charging_context.night_tariff_wait = False
                     charging_context.night_deadline_reachable = True
+
+                    # Per-charger off-mode override (v1.6.3 hotfix follow-up).
+                    # The global ``charging_state`` is derived from the primary
+                    # charger only — the multi-charger loop needs to correct it
+                    # per charger so an OFF primary doesn't bleed its terminate
+                    # into the other chargers. See the helper for details.
+                    per_mode = self._effective_charge_mode_for(charger_cfg)
+                    effective_state = self._apply_per_charger_off_override(
+                        charging_state, per_mode
+                    )
                     if charging_state in (
                         ChargingState.NIGHT_CHARGING_ACTIVE,
                         ChargingState.TARIFF_WAITING_FOR_CHEAP,
@@ -2321,6 +2357,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
 
         if legacy_strategy == "idle":
             return EVBudgetStrategy.IDLE
+        if legacy_strategy == "disabled":
+            # User-disabled (charge_mode=off). Same budget shape as IDLE
+            # (zero watts). Distinct upstream so the state machine can
+            # route this to SOLAR_IDLE instead of CHARGING_ALLOWED.
+            return EVBudgetStrategy.IDLE
         if legacy_strategy == "now":
             return EVBudgetStrategy.NOW
         # ``min_pv`` removed in #305: post-#277 Phase C no charge mode
@@ -2447,7 +2488,13 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         if mode == "always_max":
             return ("now", "Always (max) mode — charge at max immediately")
         if mode == "off":
-            return ("idle", "Charging disabled (mode=off)")
+            # Distinct from generic "idle" (which can be transient — Zone 1
+            # battery priority, solar<200W, target met). "disabled" is the
+            # user's explicit OFF intent and routes the state machine to
+            # SOLAR_IDLE → actuator stop_session() → keba.disable. The
+            # canonical-budget mapper (`_canonical_strategy_from_legacy`)
+            # collapses it back to EVBudgetStrategy.IDLE so the budget is 0.
+            return ("disabled", "Charging disabled (mode=off)")
         if mode == "solar_only":
             # Strict surplus, never grid import. Self-consumption strategy
             # subtracts battery_charge below auto_start_soc so the home

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.3"
+  "version": "1.6.4"
 }

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -113,6 +113,123 @@ def test_solar_idle_when_ev_disconnected(sm):
     assert state == ChargingState.SOLAR_IDLE
 
 
+def test_off_mode_terminates_session(sm):
+    """charge_mode=off (strategy="disabled") with EV connected → SOLAR_IDLE.
+
+    Regression test for the v1.6.3 PROD soak bug: when the user sets
+    charge_mode=off mid-session, the strategy producer emits
+    ``("disabled", "Charging disabled (mode=off)")``. Pre-fix the state
+    machine fell through to SOLAR_CHARGING_ALLOWED with budget=0,
+    leaving the KEBA contactor closed because the actuator's
+    CHARGING_ALLOWED branch never calls stop_session(). The guard
+    routes the disabled strategy to SOLAR_IDLE which ev_control.py
+    treats as terminal → stop_session() → keba.disable.
+
+    Distinct from generic ``"idle"`` (Zone 1 battery priority,
+    solar<200W, target-met) which must still flow through the
+    surplus-tracking paths so charging resumes when conditions return.
+    """
+    # Pretend the session was active before the off-flip.
+    sm._battery_initial_check_done = True
+    sm._ev_session_allowed = True
+
+    ctx = _ctx(
+        ev_connected=True,
+        charging_strategy="disabled",
+        battery_soc=80.0,
+    )
+    state = sm.update_state(ctx)
+    assert state == ChargingState.SOLAR_IDLE
+    # Gates reset so a later mode flip back to a charging mode
+    # replays the normal enable-delay warmup (same as a fresh plug-in).
+    assert sm._ev_session_allowed is False
+    assert sm._battery_initial_check_done is False
+
+
+def test_off_mode_takes_priority_over_battery_too_low(sm):
+    """Explicit off intent beats battery-too-low pause — confirms guard ordering."""
+    sm._battery_initial_check_done = True
+    sm._ev_session_allowed = True
+
+    ctx = _ctx(
+        ev_connected=True,
+        charging_strategy="disabled",
+        battery_too_low=True,
+        battery_soc=20.0,
+    )
+    state = sm.update_state(ctx)
+    assert state == ChargingState.SOLAR_IDLE
+
+
+class TestPerChargerOffOverride:
+    """Multi-charger off-mode override (v1.6.3 hotfix).
+
+    The single-charger fix works because the strategy producer + state
+    machine see only one mode. In multi-charger setups the global state
+    is derived from the PRIMARY charger only, so an off primary would
+    bleed its SOLAR_IDLE into the other chargers and terminate them
+    too. The static helper ``_apply_per_charger_off_override`` fixes
+    this in the per-charger dispatch loop.
+    """
+
+    @staticmethod
+    def _override(global_state, per_mode):
+        from custom_components.solar_energy_management.coordinator import SEMCoordinator
+        return SEMCoordinator._apply_per_charger_off_override(global_state, per_mode)
+
+    def test_off_charger_forces_solar_idle(self):
+        """When this charger's mode is "off", force SOLAR_IDLE regardless of global."""
+        # Primary is normal-charging, this charger is off → terminate THIS.
+        assert self._override(ChargingState.SOLAR_CHARGING_ACTIVE, "off") == ChargingState.SOLAR_IDLE
+        assert self._override(ChargingState.SOLAR_CHARGING_ALLOWED, "off") == ChargingState.SOLAR_IDLE
+        assert self._override(ChargingState.SOLAR_MIN_PV, "off") == ChargingState.SOLAR_IDLE
+
+    def test_solar_charger_does_not_inherit_primary_off(self):
+        """When primary=off (global SOLAR_IDLE) but this charger=solar_only,
+        don't propagate the terminate — fall back to CHARGING_ALLOWED."""
+        assert self._override(ChargingState.SOLAR_IDLE, "solar_only") == ChargingState.SOLAR_CHARGING_ALLOWED
+        assert self._override(ChargingState.SOLAR_IDLE, "min_plus_solar") == ChargingState.SOLAR_CHARGING_ALLOWED
+        assert self._override(ChargingState.SOLAR_IDLE, "always_max") == ChargingState.SOLAR_CHARGING_ALLOWED
+
+    def test_normal_state_passes_through(self):
+        """When both global and per_mode are normal, no override."""
+        for state in (ChargingState.SOLAR_CHARGING_ACTIVE,
+                      ChargingState.SOLAR_CHARGING_ALLOWED,
+                      ChargingState.SOLAR_PAUSE_LOW_BATTERY,
+                      ChargingState.NIGHT_CHARGING_ACTIVE):
+            assert self._override(state, "solar_only") == state
+            assert self._override(state, "min_plus_solar") == state
+
+    def test_off_takes_priority_over_global_idle(self):
+        """Both global SOLAR_IDLE and per_mode=off → still SOLAR_IDLE
+        (the off-branch fires first; the result is the same either way
+        but the branch ordering matters for the next case)."""
+        assert self._override(ChargingState.SOLAR_IDLE, "off") == ChargingState.SOLAR_IDLE
+
+
+def test_generic_idle_strategy_does_not_terminate(sm):
+    """``"idle"`` is transient (Zone 1, solar<200W, target met) — NOT terminal.
+
+    Distinct from ``"disabled"`` (explicit user off). Generic idle should
+    keep the session warm so charging resumes when surplus reappears.
+    Pre-refinement my off-mode guard caught both; this test pins the
+    distinction so a future regression doesn't re-conflate them.
+    """
+    sm._battery_initial_check_done = True
+    sm._ev_session_allowed = True
+
+    ctx = _ctx(
+        ev_connected=True,
+        charging_strategy="idle",
+        battery_soc=80.0,
+    )
+    state = sm.update_state(ctx)
+    # Falls through to CHARGING_ALLOWED (session warm, waiting for surplus).
+    assert state == ChargingState.SOLAR_CHARGING_ALLOWED
+    # Gates kept — session remains allowed.
+    assert sm._ev_session_allowed is True
+
+
 def test_solar_waiting_battery_priority(sm):
     """Test waiting for battery priority when SOC is below threshold."""
     ctx = _ctx(

--- a/tests/test_soc_zone_strategy.py
+++ b/tests/test_soc_zone_strategy.py
@@ -229,10 +229,17 @@ class TestDetermineChargingStrategy:
         )
         assert strategy == "night_grid"
 
-    def test_charge_mode_off_returns_idle(self):
-        """Charge mode = 'off' → idle. Post-#277 Phase C the named
-        ``charge_mode`` is the dispatch authority; pre-C this was
-        ``ev_charging_mode=off``."""
+    def test_charge_mode_off_returns_disabled(self):
+        """Charge mode = 'off' → "disabled" (not generic "idle").
+
+        Post-v1.6.3 hotfix: explicit-off is a distinct strategy from
+        the transient "idle" producers (Zone 1, solar<200W, target met).
+        The state machine routes "disabled" to SOLAR_IDLE (terminal stop)
+        while "idle" stays in CHARGING_ALLOWED (warm, waiting). Same
+        canonical EVBudgetStrategy.IDLE downstream, distinct upstream.
+        Pre-C this was ``ev_charging_mode=off``; post-#277 Phase C the
+        named ``charge_mode`` is the dispatch authority.
+        """
         coord = _build_coordinator(config_overrides={
             "ev_chargers": [{"id": "ev_charger", "charge_mode": "off"}],
         })
@@ -240,7 +247,7 @@ class TestDetermineChargingStrategy:
             _make_power(battery_soc=95), _MockEnergy(),
             charger_cfg={"id": "ev_charger", "charge_mode": "off"},
         )
-        assert strategy == "idle"
+        assert strategy == "disabled"
 
     # ``test_charging_mode_minpv_returns_min_pv`` removed in #277 Phase C:
     # the ``minpv`` legacy mode no longer dispatches to ``("min_pv", …)``


### PR DESCRIPTION
## Summary

v1.6.3 PROD soak regression: setting per-charger ``Charge mode`` to ``Off`` while the EV was charging at ~9 kW did NOT stop the KEBA contactor. SEM correctly reported "Charging allowed" with budget 0, but the actuator never invoked ``stop_session()`` so ``keba.disable`` was never called. The user had to manually call ``keba.disable``.

## Root cause

``mode == "off"`` returned the generic ``("idle", ...)`` strategy. The state machine had no guard for ``charging_strategy == "idle"`` with ``ev_connected=True``, so dispatch fell through to ``SOLAR_CHARGING_ALLOWED``. The actuator's CHARGING_ALLOWED branch only zeroed the current setpoint (which KEBA treats as "minimum") and waited out the 300 s ``ev_disable_delay_seconds`` — it never called ``stop_session()``.

## Fix

- **Distinct ``"disabled"`` strategy** for explicit-off intent (separate from transient ``"idle"`` producers: Zone 1, solar<200W, target met). Same canonical ``EVBudgetStrategy.IDLE`` downstream (0 W budget shape), distinct upstream so the state machine can route it to the terminal stop.
- **State machine guard** in ``_solar_state_machine``: ``charging_strategy == "disabled"`` returns ``SOLAR_IDLE``, which the actuator's TERMINAL STATES branch treats as a session stop → ``stop_session()`` → ``keba.disable``.
- **Multi-charger correctness**: new static helper ``_apply_per_charger_off_override`` runs in the dispatch loop so a primary charger's ``off`` doesn't bleed its terminate into siblings with active ``solar_only``/``min_plus_solar`` modes.

## Tests

7 new tests, all passing. **2144 / 7 skipped** on Python 3.12 (was 2137 baseline + 7 new).

| Test | What it pins |
|---|---|
| ``test_off_mode_terminates_session`` | strategy="disabled" + EV connected → SOLAR_IDLE, gates reset |
| ``test_off_mode_takes_priority_over_battery_too_low`` | guard ordering (off beats battery-too-low) |
| ``test_generic_idle_strategy_does_not_terminate`` | regression pin: ``idle`` ≠ ``disabled`` |
| ``TestPerChargerOffOverride`` (4 tests) | pure-function unit tests on the per-charger override helper |
| ``test_charge_mode_off_returns_disabled`` | strategy producer emits ``"disabled"`` (was ``"idle"``) |

## Verification

- **2144 tests passed** on Python 3.12 (target file: 33/33 in test_charging_control.py).
- **HA-TEST clean install** with ``deploy-test.sh``: v1.6.4 reports, 250 entities, no SEM errors in logs, coordinator cycles green.
- **Reviewer (ruflo-core:reviewer)**: caught the multi-charger bleed BLOCK on the first pass — fix folded in. Second review pass returned OK-TO-SHIP.
- **End-to-end actuator behaviour cannot be verified on HA-TEST** (no real EV). The PROD soak that surfaced the bug will re-verify it post-merge: plug in EV, charge in ``solar_only``, flip to ``off``, confirm KEBA stops within ~10 s without manual ``keba.disable``.

## Risk + rollback

- Diff: 6 files, 239 ins, 10 del. No migrations, no schema changes, no entity additions.
- Rollback = ``git revert`` the merge. Falls back to manual ``keba.disable`` workaround the user was already using.

## Out of scope (filed for follow-up)

- **Surplus tracker spike fix** — pre-existing ``_apply_ramp_limit`` jump-from-0 bypass (``ev_control.py:855-856``). Surfaced by the same soak; separate issue (task #8).
- **PROD soak Sessions 2-4** (``min_plus_solar``, ``now``, ``off`` toggle test) resume after this hotfix lands (task #6).

## Test plan

- [x] Full test suite (2144 / 7 skipped)
- [x] HA-TEST clean install + validate-sem.sh
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] Post-merge: deploy to HA-PROD, resume soak Session 1: charge in ``solar_only``, flip ``off``, confirm KEBA stops without manual intervention