### PR TITLE
observability: log which stop_session mechanism fired

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -740,7 +740,14 @@ class CurrentControlDevice(ControllableDevice):
         """Stop the charging session.
 
         Uses the charger profile to determine the correct stop method (#82).
+
+        Logs which mechanism fired and warns if none did (which means we're
+        relying on ``_set_current(0)`` alone to stop charging — that works
+        on chargers where 0 A == pause, but NOT on KEBA where 0 A is
+        documented as "minimum" and the contactor stays closed without an
+        explicit ``keba.disable`` call (v1.6.3 PROD soak regression).
         """
+        stop_method = None
         try:
             if self.stop_service:
                 domain, service = self.stop_service.split(".", 1)
@@ -748,12 +755,14 @@ class CurrentControlDevice(ControllableDevice):
                 if self.service_device_id:
                     data["device_id"] = self.service_device_id
                 await self.hass.services.async_call(domain, service, data, blocking=True)
+                stop_method = f"stop_service={self.stop_service}"
             elif self.charge_mode_entity and self.charge_mode_stop:
                 await self.hass.services.async_call(
                     "select", "select_option",
                     {"entity_id": self.charge_mode_entity, "option": self.charge_mode_stop},
                     blocking=True,
                 )
+                stop_method = f"charge_mode={self.charge_mode_stop}"
             elif self.start_stop_entity:
                 domain = self.start_stop_entity.split(".")[0]
                 if domain == "switch":
@@ -761,6 +770,7 @@ class CurrentControlDevice(ControllableDevice):
                         "switch", "turn_off",
                         {"entity_id": self.start_stop_entity}, blocking=True,
                     )
+                    stop_method = f"switch.turn_off={self.start_stop_entity}"
                 elif domain == "button":
                     # Stop buttons have different entity_ids than start buttons
                     # The stop entity is typically named *_stop_charging*
@@ -771,18 +781,47 @@ class CurrentControlDevice(ControllableDevice):
                         "button", "press",
                         {"entity_id": stop_entity}, blocking=True,
                     )
+                    stop_method = f"button.press={stop_entity}"
             elif self.charger_service:
                 # KEBA-style fallback
                 domain = self.charger_service.split(".", 1)[0]
                 if self.hass.services.has_service(domain, "disable"):
                     await self.hass.services.async_call(domain, "disable", {}, blocking=True)
+                    stop_method = f"{domain}.disable"
+                else:
+                    _LOGGER.warning(
+                        "stop_session(%s): charger_service=%s configured but "
+                        "%s.disable service is not registered — falling back to "
+                        "_set_current(0) which does NOT stop KEBA-style contactors. "
+                        "Check that the underlying charger integration is loaded.",
+                        self.name, self.charger_service, domain,
+                    )
 
             await self._set_current(0)
             self._session_active = False
             self._status.state = DeviceState.IDLE
             self._status.current_consumption_w = 0.0
             self._current_setpoint = 0.0
-            _LOGGER.info("Charging session stopped for %s", self.name)
+
+            if stop_method is None:
+                # No brand-specific stop fired — relying on _set_current(0) alone.
+                # That works on Wallbox / Easee / go-e / OpenEVSE (firmware treats
+                # 0 A as pause) but NOT on KEBA (0 A is "minimum", contactor stays
+                # closed; needs keba.disable). Warning so this case is visible in
+                # PROD logs the next time the bug class re-emerges.
+                _LOGGER.warning(
+                    "stop_session(%s): no brand-specific stop mechanism "
+                    "configured (stop_service=None, charge_mode_entity=None, "
+                    "start_stop_entity=None, charger_service=None). Relying on "
+                    "_set_current(0) alone — confirm your charger firmware "
+                    "treats 0 A as a stop signal, not as a minimum hold.",
+                    self.name,
+                )
+            else:
+                _LOGGER.info(
+                    "Charging session stopped for %s via %s",
+                    self.name, stop_method,
+                )
         except Exception as e:
             _LOGGER.error("Failed to stop session on %s: %s", self.name, e)
 


### PR DESCRIPTION
## Summary

Follow-up to v1.6.4 (off-mode hotfix). Pure observability — no behavioural change.

The v1.6.3 off-mode bug took longer to trace than it should have because PROD logs only said ``Charging session stopped for SEM EV Charger`` without identifying WHICH disable mechanism was used. On KEBA the real answer was "none — ``stop_session`` was never called" but that wasn't visible without re-reading the strategy → state-machine → actuator chain end-to-end.

## What this adds

In ``devices/base.py::stop_session()``:

1. **``stop_method`` tracking** through every branch. The success log now reads ``"Charging session stopped for <name> via <method>"`` (e.g. ``via keba.disable``, ``via switch.turn_off=switch.wallbox_pause``, ``via button.press=button.openevse_stop_charging``).

2. **WARNING** when ``charger_service`` is configured but the matching ``.disable`` service isn't registered (charger integration not loaded). Pre-fix this fell through silently to ``_set_current(0)``.

3. **WARNING** when ``stop_session`` is called but NONE of the brand-specific branches fire — relying on ``_set_current(0)`` alone, which works on Wallbox/Easee/go-e/OpenEVSE (firmware treats 0 A as pause) but NOT on KEBA (0 A is "minimum hold"). This is the exact bug class v1.6.4 fixed.

## Why now

User asked for this as a defensive observability addition during the v1.6.3 → v1.6.4 retro: "Please do so it will show us later in prod if it does all work." Lands ahead of the resumed PROD soak so the next charge cycle's stop transitions are visible from logs.

## Verification

- 2144 tests pass on Python 3.12 (same as baseline).
- HA-TEST clean install pending CI green.
- PROD verification: after deploy, the next charge stop will emit a ``stop_method=...`` log line. Either branch identification (good) or the new WARNING (the bug class is back).

## Risk + rollback

Single file, 40 lines added. No new tests required (pure log addition). Rollback = ``git revert``.

## Test plan

- [x] Full test suite (2144 / 7 skipped)
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] Post-merge: deploy to PROD, plug in EV, charge, stop, confirm PROD log shows ``via keba.disable`` for KEBA stops