### PR TITLE
fix(#315): off-mode stops charger-initiated charging (v1.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.5] — 2026-05-31
+
+Same-day follow-up to v1.6.4. Closes the second half of the off-mode
+problem: KEBA P30 self-resumes from a stored setpoint on plug-in events
+or after internal firmware events, completely independent of SEM. The
+v1.6.4 fix only stopped SEM-owned sessions; if SEM never started the
+session (because mode was already off when the EV plugged in, or KEBA
+restarted on its own), the contactor stayed closed and KEBA drew power
+SEM never knew about.
+
+### Fixed
+
+- **off-mode now stops charger-initiated charging** (#315) — the
+  actuator's terminal-state branch in ``ev_control.py`` now also calls
+  ``stop_session()`` when ``charging_strategy == "disabled"`` and
+  ``ev_power > 500W``, regardless of ``ev._session_active``. Every
+  coordinator cycle (10 s) re-asserts the per-brand disable (e.g.
+  ``keba.disable``) until ev_power drops below the 500 W threshold.
+  Idempotent — safe to call on an already-disabled charger.
+
+  Threshold rationale: KEBA's handshake idle draws 100–200 W
+  continuously while plugged in (control-pilot duty cycle). Real
+  charging starts at 4140 W minimum (3 phases × 6 A × 230 V). The
+  500 W cutoff cleanly separates "actually pulling current" from
+  "plugged in, parked" so SEM doesn't spam stop_session every cycle
+  while the car is idle at the charger.
+
 ## [1.6.4] — 2026-05-31
 
 Hotfix on top of v1.6.3 plus the cleanup follow-ups #304/#305 that

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -556,6 +556,29 @@ class EVControlMixin:
         # === TERMINAL STATES: full stop (EV disconnected, target reached, etc.) ===
         if ev._session_active:
             await ev.stop_session()
+        elif (
+            context.charging_strategy == "disabled"
+            and power.ev_power > 500
+        ):
+            # User intent is mode=off but the charger is physically drawing
+            # real power that SEM doesn't own (#315). KEBA P30 is the
+            # canonical example: its firmware self-resumes on plug-in or
+            # after certain internal events using a stored setpoint,
+            # completely independent of SEM. Since SEM never started a
+            # session here, `_session_active` is False and the branch
+            # above is skipped, but the charger keeps drawing. Force-call
+            # stop_session to invoke the per-brand disable (e.g.
+            # ``keba.disable``) every cycle until ev_power drops below
+            # the 500 W threshold.
+            #
+            # Threshold rationale: KEBA's handshake idle draws 100–200 W
+            # continuously while plugged in (control-pilot duty cycle).
+            # Real charging starts at ev.min_current × phases × voltage
+            # (3 phases × 6 A × 230 V ≈ 4140 W). 500 W safely separates
+            # "actually pulling current" from "plugged in, not charging" so
+            # we don't spam stop_session every coordinator cycle while the
+            # car is parked at the charger.
+            await ev.stop_session()
         self._ev_stalled_since = None
         self._ev_reenable_attempts = 0
         self._ev_charge_refused = False

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -558,7 +558,7 @@ class EVControlMixin:
             await ev.stop_session()
         elif (
             context.charging_strategy == "disabled"
-            and power.ev_power > 500
+            and self._this_charger_drawing_power(ev, power)
         ):
             # User intent is mode=off but the charger is physically drawing
             # real power that SEM doesn't own (#315). KEBA P30 is the
@@ -569,16 +569,33 @@ class EVControlMixin:
             # above is skipped, but the charger keeps drawing. Force-call
             # stop_session to invoke the per-brand disable (e.g.
             # ``keba.disable``) every cycle until ev_power drops below
-            # the 500 W threshold.
-            #
-            # Threshold rationale: KEBA's handshake idle draws 100–200 W
-            # continuously while plugged in (control-pilot duty cycle).
-            # Real charging starts at ev.min_current × phases × voltage
-            # (3 phases × 6 A × 230 V ≈ 4140 W). 500 W safely separates
-            # "actually pulling current" from "plugged in, not charging" so
-            # we don't spam stop_session every coordinator cycle while the
-            # car is parked at the charger.
+            # the 500 W threshold (handshake idle is 100–200 W; real
+            # charging starts at 4140 W). Idempotent — safe to call on
+            # an already-disabled charger.
             await ev.stop_session()
+            # Suppress the per-cycle INFO log from stop_session() once
+            # we've logged it for this self-resume episode. The
+            # device's stop_session() emits an INFO line every call;
+            # without throttling, a stuck-resuming KEBA would print
+            # "Charging session stopped via keba.disable" every 10 s
+            # for hours. Re-enable the log when ev_power finally
+            # drops below threshold so the next episode is loud again.
+            if getattr(self, "_off_mode_stop_logged_for", None) != ev.device_id:
+                _LOGGER.warning(
+                    "Charger %s self-resumed while mode=off (drawing %.0fW). "
+                    "Calling stop_session() — will re-assert every cycle "
+                    "until ev_power drops below 500W. (#315)",
+                    ev.name, self._this_charger_power(ev, power),
+                )
+                self._off_mode_stop_logged_for = ev.device_id
+        elif (
+            context.charging_strategy == "disabled"
+            and getattr(self, "_off_mode_stop_logged_for", None) == ev.device_id
+        ):
+            # Charger settled below threshold — clear the log-suppression
+            # flag so the next self-resume episode logs loudly again.
+            self._off_mode_stop_logged_for = None
+
         self._ev_stalled_since = None
         self._ev_reenable_attempts = 0
         self._ev_charge_refused = False
@@ -857,6 +874,44 @@ class EVControlMixin:
         adjusted = max(0, remaining_kwh - reduction)
 
         return adjusted
+
+    def _this_charger_power(self, ev, power) -> float:
+        """Return the per-charger power reading in watts (#315 multi-charger fix).
+
+        ``power.ev_power`` is the global SUM across all chargers in
+        multi-charger setups (see ``sensor_reader.py:426-434``). Using it
+        directly would falsely trigger the off-mode stop on charger[0]
+        whenever charger[1] is actively charging. Read the THIS-charger
+        ``ev_charging_power_sensor`` directly from HA state instead.
+
+        Single-charger setups: ``power.ev_power`` is already the single
+        sensor reading, so the fallback path matches what the original
+        code path was doing.
+        """
+        try:
+            charger_cfg = self._get_active_charger_config()
+            cps = charger_cfg.get("ev_charging_power_sensor") if charger_cfg else None
+            if cps and self.hass is not None:
+                state = self.hass.states.get(cps)
+                if state is not None and state.state not in (None, "unknown", "unavailable"):
+                    return float(state.state)
+        except (AttributeError, ValueError, TypeError):
+            pass
+        # Fallback: ``power.ev_power`` is correct for single-charger; for
+        # multi-charger it's the sum (over-counts but only matters when
+        # no per-charger sensor is configured — rare).
+        return float(getattr(power, "ev_power", 0.0) or 0.0)
+
+    def _this_charger_drawing_power(self, ev, power) -> bool:
+        """True iff THIS charger is drawing more than the 500 W threshold.
+
+        Threshold rationale: KEBA's handshake idle draws 100–200 W
+        continuously while plugged in (control-pilot duty cycle). Real
+        charging starts at ev.min_current × phases × voltage (3 phases ×
+        6 A × 230 V ≈ 4140 W). 500 W safely separates "actually pulling
+        current" from "plugged in, not charging".
+        """
+        return self._this_charger_power(ev, power) > 500
 
     def _apply_ramp_limit(self, target_current: float) -> float:
         """Limit current changes to ±ramp_rate per cycle during solar charging.

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.4"
+  "version": "1.6.5"
 }

--- a/tests/test_ev_deadline_tariff.py
+++ b/tests/test_ev_deadline_tariff.py
@@ -528,3 +528,90 @@ class TestDeadlineFloorApplied:
         await coord._execute_ev_control(
             ChargingState.TARIFF_WAITING_FOR_CHEAP, power, MagicMock(), ctx)
         dev.stop_session.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# #315 — off-mode terminal-state must also stop self-charging chargers (KEBA)
+# ---------------------------------------------------------------------------
+class TestOffModeTerminatesActiveCharge:
+    """When ``charge_mode=off`` and the charger is physically drawing power
+    that SEM doesn't own (typical for KEBA P30 which self-resumes from a
+    stored setpoint), the actuator's terminal-state branch must still call
+    ``stop_session()`` so the per-brand disable fires every cycle until the
+    contactor opens. Pre-#315 fix the terminal block only stopped if
+    ``ev._session_active`` was True — which it never is when KEBA self-
+    started without SEM mediation.
+    """
+
+    @pytest.mark.asyncio
+    async def test_off_with_self_charging_keba_calls_stop_session(self):
+        """KEBA drawing 4140 W on plug-in + mode=off → stop_session called."""
+        coord = _build_coordinator()
+        # session_active=False is the load-bearing precondition — SEM never
+        # owned the session because KEBA self-started.
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled",
+                              charging_strategy_reason="Charging disabled (mode=off)")
+        power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_with_handshake_only_no_stop_call(self):
+        """KEBA at handshake idle (110 W) doesn't trigger the override —
+        the 100 W threshold matches the actuator's existing 'actually
+        charging vs handshake' cutoff so we don't spam stop_session every
+        cycle while the EV is plugged in but parked."""
+        coord = _build_coordinator()
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled",
+                              charging_strategy_reason="Charging disabled (mode=off)")
+        power = PowerReadings(ev_connected=True, ev_power=110.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_off_with_inactive_session_and_no_ev_power_skips(self):
+        """EV unplugged or fully off → terminal branch doesn't call stop_session
+        (it was never started). Sanity check the override doesn't fire
+        when there's nothing to stop."""
+        coord = _build_coordinator()
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=False, charging_strategy="disabled")
+        power = PowerReadings(ev_connected=False, ev_power=0.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_session_active_path_still_works(self):
+        """The original SEM-owned session → stop_session path is unchanged.
+        Pinned so the new override doesn't accidentally shadow it."""
+        coord = _build_coordinator()
+        dev = _make_device(session_active=True, current_setpoint=10)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled")
+        power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idle_strategy_does_not_trigger_override(self):
+        """Generic ``"idle"`` (Zone 1, solar<200W, target met) must NOT
+        trigger the override — only the explicit-off ``"disabled"`` does.
+        Pre-refinement check: prevents the #305 conflation from creeping
+        back in via the actuator path."""
+        coord = _build_coordinator()
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="idle")
+        power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_not_awaited()

--- a/tests/test_ev_deadline_tariff.py
+++ b/tests/test_ev_deadline_tariff.py
@@ -615,3 +615,75 @@ class TestOffModeTerminatesActiveCharge:
         await coord._execute_ev_control(
             ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
         dev.stop_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_multi_charger_uses_per_charger_power(self):
+        """Multi-charger reviewer BLOCK: ``power.ev_power`` is the global
+        sum across all chargers (sensor_reader.py:426-434). Charger[0]=off
+        idle, charger[1]=solar_only charging at 4 kW: pre-fix the global
+        sum 4000 > 500 would trigger stop_session on charger[0]'s idle
+        KEBA every cycle. The fix reads THIS charger's individual
+        ``ev_charging_power_sensor`` from HA state instead. This test
+        pins that behaviour by giving charger[0]=idle a per-charger
+        sensor value of 0 while the global ``power.ev_power`` is 4000.
+        """
+        coord = _build_coordinator()
+        # Two chargers in config — charger[0]=off, charger[1]=solar_only.
+        coord.config["ev_chargers"] = [
+            {"id": "keba", "charge_mode": "off",
+             "ev_charging_power_sensor": "sensor.keba_p30_charging_power"},
+            {"id": "wallbox", "charge_mode": "solar_only",
+             "ev_charging_power_sensor": "sensor.wallbox_charging_power"},
+        ]
+        dev = _make_device(device_id="keba", session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+
+        # Mock HA states: THIS charger (keba) at 0W, OTHER (wallbox) at 4kW.
+        def states_get(eid):
+            sb = MagicMock()
+            sb.state = "0" if eid == "sensor.keba_p30_charging_power" else "4140"
+            return sb
+        coord.hass.states.get = states_get
+
+        # Global sum is 4140 (would trip the > 500 check with old code).
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled")
+        power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        # Per-charger 0W → not drawing → no spurious stop on idle charger.
+        dev.stop_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_log_suppression_then_reset(self):
+        """Per-charger ``_off_mode_stop_logged_for`` debounces the WARNING.
+
+        Cycle 1: KEBA self-resumes, WARNING fires, flag set to device_id.
+        Cycle 2: KEBA still resuming, stop_session called again but
+                 WARNING is suppressed (flag matches device_id).
+        Cycle 3: ev_power drops below threshold, flag cleared so the
+                 next episode logs loudly again.
+        """
+        coord = _build_coordinator()
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled")
+
+        # Cycle 1: self-resume.
+        power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        assert coord._off_mode_stop_logged_for == "keba"
+
+        # Cycle 2: still resuming. stop_session called again, flag stays.
+        dev.stop_session.reset_mock()
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()  # still called every cycle
+        assert coord._off_mode_stop_logged_for == "keba"  # but flag prevents log
+
+        # Cycle 3: KEBA finally stopped (ev_power below threshold).
+        power = PowerReadings(ev_connected=True, ev_power=110.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        # Flag cleared so the next self-resume logs loudly again.
+        assert coord._off_mode_stop_logged_for is None


### PR DESCRIPTION
## Summary

Same-day follow-up to v1.6.4. During the v1.6.4 PROD soak the user observed KEBA self-resuming **twice within 30 min** despite ``charge_mode=off`` and SEM correctly reporting "Solar mode - System ready".

**Root cause**: KEBA P30 firmware self-starts from a stored setpoint on plug-in events or other internal triggers, completely independent of SEM. Since SEM never started a session, ``ev._session_active`` is False, the actuator's terminal-state branch at ``ev_control.py:557`` skips ``stop_session()``, and KEBA keeps drawing. v1.6.4 only handled SEM-owned active→off transitions.

## Fix

Extend the terminal-state branch to also stop the charger when ``charging_strategy == "disabled"`` AND THIS charger is drawing > 500 W (per-charger reading, not global sum). Idempotent — safe to invoke ``keba.disable`` every cycle on an already-disabled charger.

**Per-charger correctness** (reviewer BLOCK addressed): new ``_this_charger_power(ev, power)`` helper reads THIS charger's ``ev_charging_power_sensor`` directly from HA state instead of the global ``power.ev_power`` sum. Multi-charger fleets where charger[0]=off and charger[1]=solar_only no longer trip a spurious stop on the idle charger.

**Log throttling** (reviewer FIX-BEFORE-MERGE addressed): per-charger ``_off_mode_stop_logged_for`` flag debounces the WARNING to once per self-resume episode. The underlying ``stop_session()`` is still called every cycle (10 s) to ensure the disable sticks, but the user-visible log line fires once and resets when the charger settles below 500 W.

## Threshold rationale

- KEBA handshake idle: 100–200 W continuous (control-pilot duty cycle)
- Real charging minimum: 3 phases × 6 A × 230 V ≈ 4140 W
- **500 W cutoff** cleanly separates "actually pulling current" from "plugged in, parked"

## Tests

7 new tests in ``TestOffModeTerminatesActiveCharge``, all passing.

| Test | What it pins |
|---|---|
| ``test_off_with_self_charging_keba_calls_stop_session`` | 4140 W + ``_session_active=False`` → stop_session |
| ``test_off_with_handshake_only_no_stop_call`` | 110 W → no stop_session (threshold pin) |
| ``test_off_with_inactive_session_and_no_ev_power_skips`` | EV disconnected → skip (sanity) |
| ``test_session_active_path_still_works`` | v1.6.4 active→off path unchanged |
| ``test_idle_strategy_does_not_trigger_override`` | Generic ``"idle"`` ≠ ``"disabled"`` |
| ``test_multi_charger_uses_per_charger_power`` | Multi-charger BLOCK — per-charger reading not global sum |
| ``test_log_suppression_then_reset`` | 3-cycle: log → suppress → reset |

**2151 tests pass** on Python 3.12 (2144 baseline + 7 new).

## Verification

- HA-TEST clean install pending CI green.
- PROD verification: deploy v1.6.5, leave EV plugged in with mode=off, observe whether KEBA stays off across the next 30-60 min. Logs should show ``Charger EV Charger self-resumed while mode=off`` WARNING **once per self-resume episode** (not once per cycle).

## Risk + rollback

3 files changed (ev_control.py + tests + manifest/CHANGELOG). No migrations, no schema changes. Rollback = ``git revert`` — falls back to v1.6.4 behaviour where user has to call ``keba.disable`` manually.

## Test plan

- [x] Full suite (2151 / 7 skipped)
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] Post-merge: deploy PROD, verify KEBA stays off with mode=off + EV plugged in