### PR TITLE
docs(#315): v1.6.4/v1.6.5 off-mode behaviour + KEBA self-resume

### DIFF
--- a/KNOWN_LIMITATIONS.md
+++ b/KNOWN_LIMITATIONS.md
@@ -101,6 +101,50 @@ is fully safe — if you DO unplug the car, both `ev_power` and
 `ev_charging` will drop and SEM will correctly transition to
 disconnected.
 
+## Charger self-resume on plug-in (KEBA P30 confirmed)
+
+KEBA P30 firmware remembers its last current setpoint across power
+cycles. When an EV plugs in — or after certain internal events SEM
+cannot observe — KEBA **self-starts** at the stored setpoint
+completely independently of SEM. This was confirmed on a 2026-05-31
+PROD soak where Charge mode was set to **Off** and the EV plugged in:
+KEBA pulled 4.1 kW on its own while SEM correctly reported
+"Solar mode - System ready" with 0 A commanded.
+
+Since v1.6.5, SEM **mitigates** this by re-asserting the per-brand
+disable service (e.g. `keba.disable`) every coordinator cycle (~10 s)
+whenever the user-intent strategy is `"disabled"` (mode=Off) AND THIS
+charger is drawing more than 500 W (handshake idle is 100–200 W; real
+charging starts at 4140 W). The mitigation is **per-charger correct**
+in multi-charger setups — only the off charger gets the disable
+re-asserted; sibling chargers with active modes are untouched.
+
+Worst-case unwanted draw is **bounded by the coordinator cycle period
+(~10 s)**: KEBA can self-start, ramp for one cycle, then SEM catches
+it on the next cycle and calls `keba.disable`. A WARNING line in the
+log records each self-resume episode so the upstream behaviour stays
+visible:
+
+```
+Charger <name> self-resumed while mode=off (drawing 4140W). Calling
+stop_session() — will re-assert every cycle until ev_power drops
+below 500W. (#315)
+```
+
+If you're concerned about even the bounded 10-s window — e.g. your
+electricity tariff penalises any grid draw — simply **unplug** the EV
+when not actively charging. Mitigation only fires when both Charge
+mode is Off and the charger is plugged in; unplugged cables can't
+self-start.
+
+Other chargers (Wallbox, Easee, go-eCharger, OpenEVSE, …) generally
+treat 0 A as "stop" rather than "minimum hold" and don't exhibit this
+behaviour; SEM's `_set_current(0)` call is sufficient on those.
+However, the v1.6.5 fix applies universally — if any charger
+integration reports power draw > 500 W with Charge mode = Off, the
+per-brand `stop_session()` mechanism fires regardless of firmware
+specifics.
+
 ## Battery-assist mode may transiently attribute a small grid flow to the EV
 
 When the EV is charging in `battery_assist` mode (Zone 4, home battery ≥ `battery_auto_start_soc`), SEM offers the EV a budget that includes the expected battery discharge contribution (up to `battery_assist_max_power`, default 4500 W). The EV's onboard charger ramps to that current effectively instantly, but the home battery — an LFP pack managed by the inverter's BMS — takes several seconds to ramp its discharge from 0 W to the requested level. During that ramp window, the grid backfills the gap.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -29,6 +29,49 @@
 
 ---
 
+## EV keeps charging when Charge mode is set to "Off"
+
+**Symptom:** You set `select.sem_charger_<id>_charge_mode` to **Off**, the SEM
+dashboard shows "Solar mode - System ready" with 0 A commanded, but the EV
+charger still draws power.
+
+**Cause (pre-v1.6.4):** A regression in the v1.6.3 consolidated Charge mode
+selector. The state machine fell through to `SOLAR_CHARGING_ALLOWED` instead
+of `SOLAR_IDLE`, and the actuator's stop path was never reached.
+
+**Cause (post-v1.6.4 on KEBA):** KEBA P30's firmware remembers its last
+current setpoint across power cycles. When an EV plugs in (or KEBA hits
+certain internal events), the charger **self-starts** at the stored
+setpoint independently of SEM. Because SEM never started an owned
+session, its `_session_active` flag was False and the disable path
+silently skipped.
+
+**Fix (v1.6.5+):** Upgrade to v1.6.5 or later. SEM now re-asserts the
+per-brand disable service (e.g. `keba.disable`) every coordinator cycle
+(~10 s) whenever Charge mode is **Off** and the charger is actually
+drawing power (> 500 W). Idempotent and KEBA-firmware-safe. Logs will
+show a one-time WARNING per self-resume episode:
+
+```
+Charger <name> self-resumed while mode=off (drawing 4140W). Calling
+stop_session() — will re-assert every cycle until ev_power drops
+below 500W. (#315)
+```
+
+**Workaround if you're on v1.6.4 or earlier:**
+
+1. Manually call the `keba.disable` service (or your charger's
+   equivalent) from **Developer Tools > Services**.
+2. Or simply **unplug** the EV — KEBA can't self-start on an unplugged
+   cable.
+
+The v1.6.5 fix has a worst-case 10-second window where KEBA can draw
+power before SEM catches the self-resume; if you observe sustained
+draw beyond that, file an issue with the SEM log line and the KEBA
+`max_current` setpoint reported at the moment of the resume.
+
+---
+
 ## Car charged overnight when I only wanted solar surplus
 
 **Cause:** Grid-assisted **night charging** is enabled, with a charge target (a daily kWh target or a target SOC %) the car hadn't reached, so SEM topped it up from the grid overnight. On fresh installs this is now off by default, but it stays enabled on upgraded systems that already had it on, and a multi-charger setup tracks an enable switch *per charger*.


### PR DESCRIPTION
## Summary

Doc updates surfacing what the v1.6.4 + v1.6.5 hotfixes mean for users. Per the docs-before-release policy in memory, lands ahead of the v1.6.5 HACS release.

## What's added

**TROUBLESHOOTING.md** — Q&A "EV keeps charging when Charge mode is set to Off"
- Pre-v1.6.4: state machine regression (cause + how to recognize)
- Post-v1.6.4 on KEBA: firmware self-resume gap (cause + recognition)
- v1.6.5+ mitigation: per-cycle stop_session, > 500 W threshold, log signature
- Manual workaround for users on v1.6.4 or earlier

**KNOWN_LIMITATIONS.md** — "Charger self-resume on plug-in (KEBA P30 confirmed)"
- Underlying KEBA firmware behaviour documented as upstream quirk
- v1.6.5 mitigation explained with worst-case 10-s window
- Unplug-to-be-safe fallback for tariff-sensitive users
- Generalisation: other chargers usually treat 0 A as stop

## Verification

No code changes. CI just confirms doc syntax.

## Test plan

- [x] Markdown renders correctly (preview)
- [ ] CI: Hassfest, HACS Validation (no functional impact)