### PR TITLE
fix: v1.6.6 — kW unit conversion (#315) + per-charger SOC isolation (#318)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.6] — 2026-05-31
+
+Same-day hotfix for v1.6.5 — the per-charger power read at
+``_this_charger_power`` did a unit-naive ``float(state.state)`` and
+compared a kW value to a 500 W threshold. KEBA's native
+``sensor.keba_p30_charging_power`` reports in kW; the comparison
+``4.14 < 500`` was always False so the v1.6.5 off-mode stop never
+fired on KEBA, even when the firmware self-resumed. Confirmed live
+on PROD 2026-05-31 15:26 — KEBA self-resumed and ran uncontrolled
+for ~2 min until a manual ``keba.disable`` stopped it.
+
+### Fixed
+
+- **Unit-aware per-charger power reading** — ``_this_charger_power``
+  now reads the sensor's ``unit_of_measurement`` attribute and
+  converts kW → W before the 500 W threshold check. Tests pin both
+  KEBA-style (kW) and Wallbox-style (W) sensors so the next charger
+  integration doesn't introduce the same trap.
+
+- **Per-charger SOC isolation in multi-charger setups** (#318) —
+  ``_update_ev_intelligence`` was only calling ``update_energy()`` on
+  the PRIMARY taper detector at line ~3326; every per-charger detector
+  in ``_ev_taper_detectors`` stayed at ``_energy_since_full=0``,
+  giving every charger the same default SOC. Confirmed by @RienduPre
+  on a multi-charger Wallbox Pulsar + Growatt setup. Fix: also call
+  ``update_energy(per_increment, per_hw_total)`` inside the
+  per-charger loop, using each charger's own ``ev_total_energy_sensor``
+  hardware counter for drift-free tracking when configured.
+
 ## [1.6.5] — 2026-05-31
 
 Same-day follow-up to v1.6.4. Closes the second half of the off-mode

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -3206,6 +3206,47 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             })
         return payload
 
+    def _update_per_charger_detector_energy(
+        self, cid: str, charger_power: float, interval_hours: float,
+    ) -> None:
+        """Feed the per-charger taper detector its own energy increment (#318).
+
+        Mirrors what ``self._ev_taper_detector.update_energy(...)`` does
+        for the primary detector — but per-charger, so each charger's
+        ``_energy_since_full`` tracks its own session. Without this,
+        every per-charger detector stays at 0 → ``get_virtual_soc()``
+        returns the same default (100 %) for every charger → dashboard
+        shows identical SOC across the fleet.
+
+        Uses each charger's own ``ev_total_energy_sensor`` HW counter
+        when configured (drift-free); falls back to incremental-only
+        tracking when not (same behaviour the primary detector had for
+        installs without a hardware counter).
+
+        No-op when ``charger_power <= 0`` (idle) — matches the legacy
+        per-charger ``update()`` gating at the call site.
+        """
+        if charger_power <= 0:
+            return
+        detector = self._ev_taper_detectors.get(cid)
+        if detector is None:
+            return
+        per_charger_cfg = next(
+            (c for c in (self.config.get("ev_chargers") or [])
+             if c.get("id") == cid), {}
+        ) or {}
+        per_increment = charger_power * interval_hours / 1000
+        per_hw_total = None
+        per_hw_entity = per_charger_cfg.get("ev_total_energy_sensor")
+        if per_hw_entity:
+            hw_state = self.hass.states.get(per_hw_entity)
+            if hw_state and hw_state.state not in ("unknown", "unavailable"):
+                try:
+                    per_hw_total = float(hw_state.state)
+                except (ValueError, TypeError):
+                    pass
+        detector.update_energy(per_increment, per_hw_total)
+
     def _update_ev_intelligence(
         self, power: PowerReadings, energy,
     ) -> "EVIntelligenceData":
@@ -3289,6 +3330,19 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     self._ev_taper_detectors[cid].update(
                         charger_power, charger_setpoint, charger_connected, now,
                     )
+
+                # Per-charger energy update (#318). Without this every
+                # per-charger detector keeps ``_energy_since_full=0`` so
+                # the SOC estimator falls through to the same default for
+                # every charger — symptom: "Charger 1 and Charger 2 show
+                # identical SOC, both rise when only one is charging"
+                # (RienduPre, 2026-05-31 multi-charger Wallbox + Growatt).
+                # The primary detector's update_energy below at line ~3326
+                # was only feeding the global ``self._ev_taper_detector``,
+                # not the per-charger detectors in ``self._ev_taper_detectors``.
+                self._update_per_charger_detector_energy(
+                    cid, charger_power, interval_hours,
+                )
 
             # Primary charger's detector drives SOC/skip (sync with main detector)
             primary_id = next(iter(self._ev_devices))

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -884,9 +884,17 @@ class EVControlMixin:
         whenever charger[1] is actively charging. Read the THIS-charger
         ``ev_charging_power_sensor`` directly from HA state instead.
 
+        **Unit-aware**: KEBA's native ``sensor.keba_p30_charging_power``
+        reports in kW. Other charger integrations may report in W. Read
+        the sensor's ``unit_of_measurement`` attribute and convert to W
+        when needed. The first cut of this helper compared a raw 4.14
+        (kW) to a 500 W threshold and silently failed every cycle —
+        confirmed on PROD 2026-05-31, KEBA self-resumed at 15:26 and
+        the v1.6.5 fix did not trigger for ~2 minutes until corrected.
+
         Single-charger setups: ``power.ev_power`` is already the single
-        sensor reading, so the fallback path matches what the original
-        code path was doing.
+        sensor reading (normalized to W by ``sensor_reader``), so the
+        fallback path matches what the original code path was doing.
         """
         try:
             charger_cfg = self._get_active_charger_config()
@@ -894,12 +902,17 @@ class EVControlMixin:
             if cps and self.hass is not None:
                 state = self.hass.states.get(cps)
                 if state is not None and state.state not in (None, "unknown", "unavailable"):
-                    return float(state.state)
+                    value = float(state.state)
+                    unit = (state.attributes or {}).get("unit_of_measurement", "W")
+                    if unit == "kW":
+                        value *= 1000
+                    return value
         except (AttributeError, ValueError, TypeError):
             pass
-        # Fallback: ``power.ev_power`` is correct for single-charger; for
-        # multi-charger it's the sum (over-counts but only matters when
-        # no per-charger sensor is configured — rare).
+        # Fallback: ``power.ev_power`` is already in watts (normalized by
+        # sensor_reader). Correct for single-charger; for multi-charger
+        # it's the sum (over-counts but only matters when no per-charger
+        # sensor is configured — rare).
         return float(getattr(power, "ev_power", 0.0) or 0.0)
 
     def _this_charger_drawing_power(self, ev, power) -> bool:

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.5"
+  "version": "1.6.6"
 }

--- a/tests/test_ev_deadline_tariff.py
+++ b/tests/test_ev_deadline_tariff.py
@@ -654,6 +654,69 @@ class TestOffModeTerminatesActiveCharge:
         dev.stop_session.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_kw_unit_conversion_from_native_charger_sensor(self):
+        """KEBA's native ``sensor.keba_p30_charging_power`` reports in
+        kW. The first cut of ``_this_charger_power`` did a raw
+        ``float(state.state)`` and compared 4.14 (kW) to the 500 W
+        threshold — silently failed every cycle. Confirmed on PROD
+        2026-05-31 15:26 during the v1.6.5 soak.
+
+        This test pins unit-aware reading: a state value of "4.14" with
+        ``unit_of_measurement="kW"`` is converted to 4140 W BEFORE the
+        threshold check, so the override fires correctly.
+        """
+        coord = _build_coordinator()
+        coord.config["ev_chargers"] = [{
+            "id": "keba", "charge_mode": "off",
+            "ev_charging_power_sensor": "sensor.keba_p30_charging_power",
+        }]
+        dev = _make_device(device_id="keba", session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+
+        def states_get(eid):
+            if eid == "sensor.keba_p30_charging_power":
+                s = MagicMock()
+                s.state = "4.14"  # KEBA reports kW
+                s.attributes = {"unit_of_measurement": "kW"}
+                return s
+            return None
+        coord.hass.states.get = states_get
+
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled")
+        # ``power.ev_power`` is the fallback (already in W); doesn't matter
+        # here because the per-charger sensor read takes precedence.
+        power = PowerReadings(ev_connected=True, ev_power=0.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_w_unit_passes_through(self):
+        """A charger that reports in W (most non-KEBA) is read raw."""
+        coord = _build_coordinator()
+        coord.config["ev_chargers"] = [{
+            "id": "wallbox", "charge_mode": "off",
+            "ev_charging_power_sensor": "sensor.wallbox_charging_power",
+        }]
+        dev = _make_device(device_id="wallbox", session_active=False)
+        coord._ev_device = dev
+
+        def states_get(eid):
+            if eid == "sensor.wallbox_charging_power":
+                s = MagicMock()
+                s.state = "4140"  # Wallbox reports W
+                s.attributes = {"unit_of_measurement": "W"}
+                return s
+            return None
+        coord.hass.states.get = states_get
+
+        ctx = ChargingContext(ev_connected=True, charging_strategy="disabled")
+        power = PowerReadings(ev_connected=True, ev_power=0.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_log_suppression_then_reset(self):
         """Per-charger ``_off_mode_stop_logged_for`` debounces the WARNING.
 

--- a/tests/test_per_charger_soc_318.py
+++ b/tests/test_per_charger_soc_318.py
@@ -1,0 +1,173 @@
+"""Per-charger SOC isolation in multi-charger setups (#318).
+
+Regression test for the bug where Charger 1 and Charger 2 both reported
+identical SOC values, and Charger 2's SOC rose when only Charger 1 was
+actively charging.
+
+Reported 2026-05-31 by @RienduPre on a multi-charger Wallbox Pulsar +
+Growatt setup (SEM v1.6.3). Root cause: ``_update_ev_intelligence`` at
+``coordinator/coordinator.py`` ran a per-charger loop that called
+``EVTaperDetector.update(...)`` per charger but the energy-tracking
+call ``update_energy(...)`` was only made for the PRIMARY detector at
+line ~3326 — every per-charger detector's ``_energy_since_full`` stayed
+at 0 forever, so ``get_virtual_soc()`` returned the same default for
+every charger.
+
+v1.6.5 fix: extract ``_update_per_charger_detector_energy(cid, …)`` as
+a small helper called inside the per-charger loop. Each detector gets
+its own power increment and (if configured) its own
+``ev_total_energy_sensor`` hardware counter — completely decoupled from
+sibling chargers.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator import SEMCoordinator
+
+
+def _make_coordinator(ev_chargers, hw_total_states=None):
+    """Build a minimal coordinator stub for the helper method under test.
+
+    The helper only reads ``self.config``, ``self._ev_taper_detectors``,
+    and ``self.hass.states.get`` — nothing else. Keeping the fixture
+    surface small makes the tests robust to unrelated coordinator
+    refactors.
+    """
+    coord = SEMCoordinator.__new__(SEMCoordinator)
+    coord.config = {"ev_chargers": ev_chargers}
+    coord._ev_taper_detectors = {c["id"]: MagicMock() for c in ev_chargers}
+    coord.hass = MagicMock()
+
+    def _states_get(eid):
+        if hw_total_states and eid in hw_total_states:
+            s = MagicMock()
+            s.state = hw_total_states[eid]
+            return s
+        return None
+    coord.hass.states.get = _states_get
+    return coord
+
+
+# 10-second coordinator cycle in hours — matches the production
+# ``update_interval=10s`` so the increments below are directly
+# comparable to a real cycle.
+INTERVAL_HOURS = 10 / 3600
+
+
+class TestPerChargerSOCIsolation:
+    """The helper ``_update_per_charger_detector_energy`` is what the
+    fix calls inside the per-charger loop. Test it in isolation so we
+    don't drag the rest of ``_update_ev_intelligence`` in.
+    """
+
+    def test_active_charger_gets_its_own_increment(self):
+        """3 kW charger gets ``3000 × interval / 1000`` kWh — load-bearing
+        for #318."""
+        coord = _make_coordinator([
+            {"id": "left"}, {"id": "right"},
+        ])
+
+        coord._update_per_charger_detector_energy("left", 3000.0, INTERVAL_HOURS)
+
+        det = coord._ev_taper_detectors["left"]
+        det.update_energy.assert_called_once()
+        increment, hw_total = det.update_energy.call_args[0]
+        assert increment == pytest.approx(3000.0 * INTERVAL_HOURS / 1000)
+        assert hw_total is None  # no per-charger HW counter configured
+
+    def test_two_active_chargers_get_distinct_increments(self):
+        """Two chargers at different power → two distinct increments.
+        Pre-fix both ``update_energy`` calls were skipped entirely; now
+        each detector gets its own value."""
+        coord = _make_coordinator([
+            {"id": "left"}, {"id": "right"},
+        ])
+
+        coord._update_per_charger_detector_energy("left", 3000.0, INTERVAL_HOURS)
+        coord._update_per_charger_detector_energy("right", 7000.0, INTERVAL_HOURS)
+
+        left_inc = coord._ev_taper_detectors["left"].update_energy.call_args[0][0]
+        right_inc = coord._ev_taper_detectors["right"].update_energy.call_args[0][0]
+        assert right_inc > left_inc
+        assert right_inc == pytest.approx(7000.0 * INTERVAL_HOURS / 1000)
+        assert left_inc == pytest.approx(3000.0 * INTERVAL_HOURS / 1000)
+
+    def test_idle_charger_gets_no_update(self):
+        """No power → no energy increment delivered. Matches the
+        existing ``charger_power > 0`` gating at the call site so we
+        don't pollute detector state with zero-energy cycles."""
+        coord = _make_coordinator([{"id": "left"}])
+
+        coord._update_per_charger_detector_energy("left", 0.0, INTERVAL_HOURS)
+
+        coord._ev_taper_detectors["left"].update_energy.assert_not_called()
+
+    def test_negative_power_is_treated_as_idle(self):
+        """Defensive: a negative reading (sensor glitch) is treated as
+        idle, not as "discharge"."""
+        coord = _make_coordinator([{"id": "left"}])
+
+        coord._update_per_charger_detector_energy("left", -100.0, INTERVAL_HOURS)
+
+        coord._ev_taper_detectors["left"].update_energy.assert_not_called()
+
+    def test_per_charger_hw_counter_passed_when_configured(self):
+        """If a charger has its own ``ev_total_energy_sensor`` configured,
+        the HW counter value is read from HA state and passed to
+        ``update_energy`` as the drift-correction anchor — the same
+        drift-free tracking the primary detector has."""
+        coord = _make_coordinator(
+            [{"id": "left",
+              "ev_total_energy_sensor": "sensor.left_total_energy"}],
+            hw_total_states={"sensor.left_total_energy": "42.5"},
+        )
+
+        coord._update_per_charger_detector_energy("left", 5000.0, INTERVAL_HOURS)
+
+        increment, hw_total = (
+            coord._ev_taper_detectors["left"].update_energy.call_args[0]
+        )
+        assert hw_total == pytest.approx(42.5)
+
+    def test_unavailable_hw_counter_falls_back_to_increment_only(self):
+        """If the HW counter sensor exists but reads ``unavailable``,
+        the helper passes ``None`` so the detector falls back to
+        incremental-only tracking. No crash, no spurious anchor."""
+        coord = _make_coordinator(
+            [{"id": "left",
+              "ev_total_energy_sensor": "sensor.left_total_energy"}],
+            hw_total_states={"sensor.left_total_energy": "unavailable"},
+        )
+
+        coord._update_per_charger_detector_energy("left", 5000.0, INTERVAL_HOURS)
+
+        increment, hw_total = (
+            coord._ev_taper_detectors["left"].update_energy.call_args[0]
+        )
+        assert hw_total is None
+
+    def test_no_per_charger_hw_counter_passes_none(self):
+        """Without per-charger ``ev_total_energy_sensor``, falls back to
+        incremental-only tracking. Same behaviour the primary detector
+        had pre-fix for installs without a hardware counter."""
+        coord = _make_coordinator([{"id": "left"}])
+
+        coord._update_per_charger_detector_energy("left", 5000.0, INTERVAL_HOURS)
+
+        hw_total = (
+            coord._ev_taper_detectors["left"].update_energy.call_args[0][1]
+        )
+        assert hw_total is None
+
+    def test_unknown_charger_id_is_no_op(self):
+        """Defensive: an unknown ``cid`` (config inconsistency mid-cycle)
+        is a quiet no-op rather than ``KeyError``. Pinning this
+        explicitly so the fix doesn't introduce a new crash class."""
+        coord = _make_coordinator([{"id": "left"}])
+
+        # Should NOT raise.
+        coord._update_per_charger_detector_energy("ghost", 5000.0, INTERVAL_HOURS)
+
+        # And of course the left detector wasn't touched.
+        coord._ev_taper_detectors["left"].update_energy.assert_not_called()


### PR DESCRIPTION
## Summary

Same-day amendment to v1.6.5 after two issues surfaced in the live PROD soak.

### #315 follow-up — kW unit bug in v1.6.5 off-mode stop

Confirmed live on PROD 2026-05-31 15:26 when KEBA self-resumed and v1.6.5's fix did NOT trigger. ``_this_charger_power`` did a unit-naive ``float(state.state)`` and compared a kW value to the 500 W threshold; KEBA's native ``sensor.keba_p30_charging_power`` reports in kW, so ``4.14 < 500`` was always False and the override never fired. KEBA ran uncontrolled for ~2 min until a manual ``keba.disable`` stopped it.

**Fix:** read the sensor's ``unit_of_measurement`` attribute and convert kW → W before the threshold check.

### #318 — per-charger SOC isolation in multi-charger setups

Reported 2026-05-31 by @RienduPre on a multi-charger Wallbox Pulsar + Growatt setup (SEM v1.6.3): Charger 1 and Charger 2 reported identical SOC values, and Charger 2's SOC rose when only Charger 1 was actively charging.

**Root cause:** ``_update_ev_intelligence`` only called ``update_energy()`` on the PRIMARY taper detector; the per-charger detectors in ``_ev_taper_detectors`` never received energy updates → ``_energy_since_full`` stayed at 0 for every charger → identical default SOC.

**Fix:** new helper ``_update_per_charger_detector_energy(cid, charger_power, interval_hours)`` runs inside the per-charger loop. Each detector gets its own power increment and (if configured) its own ``ev_total_energy_sensor`` HW counter for drift-free tracking.

## Tests

| Area | Tests | Status |
|---|---|---|
| #315 kW unit | ``test_kw_unit_conversion_from_native_charger_sensor`` + ``test_w_unit_passes_through`` | ✓ |
| #318 per-charger SOC | ``TestPerChargerSOCIsolation`` (8 tests covering: active charger gets increment, two chargers diverge, idle no-op, negative power treated as idle, HW counter passed through, unavailable HW counter falls back, no HW counter passes None, unknown cid no-op) | ✓ |
| Pre-existing | 2144 baseline | ✓ |

**2161 tests pass** on Python 3.12 (was 2151 + 2 kW + 8 SOC).

## Verification

- HA-TEST clean install pending CI green.
- PROD verification: deploy v1.6.6, leave EV plugged in with mode=off. When KEBA self-resumes (likely within ~15 min based on the 15:26 occurrence today), expect the WARNING log line ``Charger EV Charger self-resumed while mode=off (drawing 4140W)`` + the ``Charging session stopped via keba.disable`` follow-up within one coordinator cycle (~10 s).

## Risk + rollback

| | Risk |
|---|---|
| #315 kW fix | Low — adds unit-aware reading, falls back to raw value when unit attribute missing |
| #318 detector helper | Low — only adds calls; existing primary-detector path unchanged |
| Multi-charger users | Newly served — single-charger setups unaffected by either fix |

Rollback: ``git revert`` — falls back to v1.6.5 (KEBA still self-resumes, identical SOC bug remains).

## Test plan

- [x] Full suite (2161 / 7 skipped)
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] Post-merge: deploy PROD, observe next KEBA self-resume + stop_session response time