### PR TITLE
refactor: v1.6.7 — lift per-charger swap dict into PerChargerContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.7] — 2026-05-31
+
+First of a three-release multi-charger cleanup arc dedicated to v1.6.x.
+**Zero user-visible behaviour change** for single-charger users; multi-charger
+users see the same outputs but with the underlying swap mechanism now
+typed and unit-tested.
+
+The cleanup arc addresses a recurring bug class found in v1.6.0–v1.6.6
+(#284, #289, #315, #318): per-charger context swaps with fleet-level
+reads leaking through. This release lifts the swap mechanism; v1.6.8
+sweeps the fleet-power reads in `ev_control.py` and adds per-charger
+strategy; v1.6.9 adds per-charger flow attribution + notifications
+(closes the #316 family).
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full
+developer-facing invariant.
+
+### Refactored
+
+- **`PerChargerContext`** — new
+  [`coordinator/per_charger_context.py`](coordinator/per_charger_context.py)
+  module that owns the per-charger swap lifecycle. The ad-hoc
+  ``saved = {...}`` dict at `coordinator.py:1136-1258` that swapped
+  eight coordinator attributes per iteration (and was easy to miss
+  when adding new per-charger fields) is now a typed context manager
+  with unit tests pinning every swap invariant. Adding a new
+  per-charger field is now one place to edit instead of three.
+
+### Docs
+
+- **New `docs/MULTI_CHARGER.md`** — developer-facing invariant doc
+  covering the bug class, the `PerChargerContext` contract, how to
+  add new per-charger fields, and the v1.6.7-v1.6.9 roadmap.
+- **`CONTRIBUTING.md`** — new "Multi-charger correctness" section
+  pointing future contributors at the invariant.
+
 ## [1.6.6] — 2026-05-31
 
 Same-day hotfix for v1.6.5 — the per-charger power read at

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,28 @@ Open an issue with the `enhancement` label. Describe the use case, not just the 
 - Add tests for new features
 - Update translations (15 languages: de, en, es, fr, it, nl, pt, pl, sv, cs, da, fi, hu, ro, no) for user-facing text
 
+### Multi-charger correctness
+
+SEM was originally single-charger; multi-charger support was added
+incrementally. Between v1.6.0 and v1.6.6 we shipped four hotfixes for
+variants of the same bug class: **per-charger context swaps with
+fleet-level reads leaking through**. The structural fix landed in
+v1.6.7 as `PerChargerContext` (see
+[`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full invariant).
+
+**Two rules of thumb when working on the coordinator:**
+
+1. Inside a `with PerChargerContext.for_charger(...)` block (the
+   multi-charger loop in `coordinator/coordinator.py`), never read
+   `power.ev_power` directly — use the per-charger helper or annotate
+   the read with `# FLEET-READ: <reason>`.
+2. To add new per-charger state, edit
+   [`coordinator/per_charger_context.py`](coordinator/per_charger_context.py)
+   — don't add new ad-hoc `saved = {...}` swap dicts.
+
+If you're not sure whether a code path runs inside the per-charger loop,
+read the doc — the answer is there.
+
 ## Development Setup
 
 ```bash

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -49,6 +49,7 @@ from .sensor_reader import SensorReader
 from .energy_calculator import EnergyCalculator
 from .flow_calculator import FlowCalculator
 from .charging_control import ChargingStateMachine, ChargingContext
+from .per_charger_context import PerChargerContext
 from .storage import SEMStorage
 from .notifications import NotificationManager
 from .surplus_controller import SurplusController
@@ -1132,130 +1133,114 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                         if not self._mode_allows_night_charging(per_cfg):
                             continue  # mode opts this charger out of night
 
-                    # Save coordinator-level state, swap in per-charger state
-                    saved = {
-                        "dev": self._ev_device,
-                        "stalled": self._ev_stalled_since,
-                        "enable": self._ev_enable_surplus_since,
-                        "started": self._ev_charge_started_at,
-                        "change": self._ev_last_change_time,
-                        "reenable_attempts": self._ev_reenable_attempts,
-                        "charge_refused": self._ev_charge_refused,
-                    }
-                    self._ev_device = ev_dev
-                    self._ev_stalled_since = self._ev_stalled_since_per_charger.get(cid)
-                    self._ev_enable_surplus_since = self._ev_enable_surplus_per_charger.get(cid)
-                    self._ev_charge_started_at = self._ev_charge_started_per_charger.get(cid)
-                    self._ev_last_change_time = self._ev_last_change_per_charger.get(cid)
-                    self._ev_reenable_attempts = self._ev_reenable_attempts_per_charger.get(cid, 0)
-                    self._ev_charge_refused = self._ev_charge_refused_per_charger.get(cid, False)
-                    self._current_charger_budget = ev_budget_per_charger.get(cid)
-                    # Set per-charger night target (#193)
-                    per_charger_target = getattr(self, '_night_target_per_charger_map', {}).get(cid)
-                    if per_charger_target is not None:
-                        self._night_target_per_charger = per_charger_target
-
-                    # Per-charger SOC target and surplus limit (#215)
-                    saved_vehicle_soc_ctrl = self._cycle_vehicle_soc
-                    ev_chargers_cfg = self.config.get("ev_chargers", [])
-                    charger_cfg = next((c for c in ev_chargers_cfg if c.get("id") == cid), {})
-                    per_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
-                    if per_soc_entity:
-                        soc_st = self.hass.states.get(per_soc_entity)
-                        if soc_st and soc_st.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                            try:
-                                self._cycle_vehicle_soc = float(soc_st.state)
-                            except (ValueError, TypeError):
-                                _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_soc_entity, soc_st.state)
-                    # Ceiling (Max) gates surplus; floor (Min) drives night top-up (#245)
-                    per_remaining = self._calculate_remaining_need(
-                        energy, self._cycle_vehicle_soc, charger_cfg, bound="max"
+                    # v1.6.7: the swap/restore dance that used to live
+                    # inline here as ``saved = {...}`` + a final
+                    # ``finally`` block is now owned by
+                    # ``PerChargerContext``. Everything in this block is
+                    # the per-charger computation that was already
+                    # specific to this iteration (SOC entity read, Min/Max
+                    # remaining, night plan, etc.) — it stays inline for
+                    # v1.6.7 and migrates onto the context object in
+                    # v1.6.8/v1.6.9.
+                    pcc = PerChargerContext.for_charger(
+                        self, cid, ev_dev, ev_budget_per_charger,
+                        chargers_by_id=_chargers_by_id,
                     )
-                    per_remaining_floor = self._calculate_remaining_need(
-                        energy, self._cycle_vehicle_soc, charger_cfg, bound="min"
-                    )
-                    # Surplus stops at this charger's Max ceiling (default full) (#245)
-                    per_target_reached = per_remaining <= 0.1
-                    charging_context.soc_limit_active = per_target_reached
-                    charging_context.daily_target_reached = per_target_reached
-                    charging_context.remaining_ev_energy = per_remaining
-                    charging_context.night_target_kwh = per_charger_target if per_charger_target is not None else per_remaining_floor
+                    with pcc:
+                        # Set per-charger night target (#193). The
+                        # scalar ``_night_target_per_charger`` is read by
+                        # downstream methods that still expect it; the
+                        # per-charger map drives the in-loop math.
+                        per_charger_target = getattr(
+                            self, '_night_target_per_charger_map', {},
+                        ).get(cid)
+                        if per_charger_target is not None:
+                            self._night_target_per_charger = per_charger_target
 
-                    # Per-charger deadline + tariff plan (#246/#247): recompute
-                    # for THIS charger and pick its effective night state. Each car
-                    # can have its own deadline / tariff toggle, so the displayed
-                    # (primary) state isn't authoritative for the rest.
-                    effective_state = charging_state
-                    charging_context.night_deadline_amps = 0
-                    charging_context.night_deadline_active = False
-                    charging_context.night_tariff_wait = False
-                    charging_context.night_deadline_reachable = True
-
-                    # Per-charger off-mode override (v1.6.3 hotfix follow-up).
-                    # The global ``charging_state`` is derived from the primary
-                    # charger only — the multi-charger loop needs to correct it
-                    # per charger so an OFF primary doesn't bleed its terminate
-                    # into the other chargers. See the helper for details.
-                    per_mode = self._effective_charge_mode_for(charger_cfg)
-                    effective_state = self._apply_per_charger_off_override(
-                        charging_state, per_mode
-                    )
-                    if charging_state in (
-                        ChargingState.NIGHT_CHARGING_ACTIVE,
-                        ChargingState.TARIFF_WAITING_FOR_CHEAP,
-                    ):
-                        pc_target = charging_context.night_target_kwh
-                        if pc_target <= 0.1:
-                            effective_state = ChargingState.NIGHT_TARGET_REACHED
-                        else:
-                            plan = self._compute_night_plan(charger_cfg, pc_target, energy)
-                            self._night_plan_per_charger[cid] = plan
-                            charging_context.night_deadline_amps = plan.deadline_amps
-                            charging_context.night_deadline_active = plan.deadline_active
-                            charging_context.night_tariff_wait = plan.should_wait_for_cheap
-                            charging_context.night_deadline_reachable = plan.reachable
-                            effective_state = (
-                                ChargingState.TARIFF_WAITING_FOR_CHEAP
-                                if plan.should_wait_for_cheap
-                                else ChargingState.NIGHT_CHARGING_ACTIVE
-                            )
-                            await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
-
-                    try:
-                        await self._execute_ev_control(
-                            effective_state, power, energy, charging_context
+                        # Per-charger SOC target and surplus limit (#215).
+                        # ``_cycle_vehicle_soc`` is one of the swap fields
+                        # PerChargerContext restores in ``__exit__``.
+                        charger_cfg = pcc.charger_cfg
+                        per_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
+                        if per_soc_entity:
+                            soc_st = self.hass.states.get(per_soc_entity)
+                            if soc_st and soc_st.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                                try:
+                                    self._cycle_vehicle_soc = float(soc_st.state)
+                                except (ValueError, TypeError):
+                                    _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_soc_entity, soc_st.state)
+                        # Ceiling (Max) gates surplus; floor (Min) drives night top-up (#245)
+                        per_remaining = self._calculate_remaining_need(
+                            energy, self._cycle_vehicle_soc, charger_cfg, bound="max"
                         )
-                        # Add this charger's just-committed draw to the shared night
-                        # peak budget so lower-priority chargers size against the
-                        # remaining headroom (#274/H1). Estimate from the setpoint
-                        # (the commitment), not the lagging measured power.
+                        per_remaining_floor = self._calculate_remaining_need(
+                            energy, self._cycle_vehicle_soc, charger_cfg, bound="min"
+                        )
+                        # Surplus stops at this charger's Max ceiling (default full) (#245)
+                        per_target_reached = per_remaining <= 0.1
+                        charging_context.soc_limit_active = per_target_reached
+                        charging_context.daily_target_reached = per_target_reached
+                        charging_context.remaining_ev_energy = per_remaining
+                        charging_context.night_target_kwh = per_charger_target if per_charger_target is not None else per_remaining_floor
+
+                        # Per-charger deadline + tariff plan (#246/#247): recompute
+                        # for THIS charger and pick its effective night state. Each car
+                        # can have its own deadline / tariff toggle, so the displayed
+                        # (primary) state isn't authoritative for the rest.
+                        effective_state = charging_state
+                        charging_context.night_deadline_amps = 0
+                        charging_context.night_deadline_active = False
+                        charging_context.night_tariff_wait = False
+                        charging_context.night_deadline_reachable = True
+
+                        # Per-charger off-mode override (v1.6.3 hotfix follow-up).
+                        # The global ``charging_state`` is derived from the primary
+                        # charger only — the multi-charger loop needs to correct it
+                        # per charger so an OFF primary doesn't bleed its terminate
+                        # into the other chargers. See the helper for details.
+                        per_mode = self._effective_charge_mode_for(charger_cfg)
+                        effective_state = self._apply_per_charger_off_override(
+                            charging_state, per_mode
+                        )
+                        if charging_state in (
+                            ChargingState.NIGHT_CHARGING_ACTIVE,
+                            ChargingState.TARIFF_WAITING_FOR_CHEAP,
+                        ):
+                            pc_target = charging_context.night_target_kwh
+                            if pc_target <= 0.1:
+                                effective_state = ChargingState.NIGHT_TARGET_REACHED
+                            else:
+                                plan = self._compute_night_plan(charger_cfg, pc_target, energy)
+                                self._night_plan_per_charger[cid] = plan
+                                charging_context.night_deadline_amps = plan.deadline_amps
+                                charging_context.night_deadline_active = plan.deadline_active
+                                charging_context.night_tariff_wait = plan.should_wait_for_cheap
+                                charging_context.night_deadline_reachable = plan.reachable
+                                effective_state = (
+                                    ChargingState.TARIFF_WAITING_FOR_CHEAP
+                                    if plan.should_wait_for_cheap
+                                    else ChargingState.NIGHT_CHARGING_ACTIVE
+                                )
+                                await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
+
                         try:
-                            self._night_committed_w += max(0.0, (
-                                ev_dev._current_setpoint * ev_dev.phases * ev_dev.voltage
-                            ))
-                        except (AttributeError, TypeError):
-                            pass
-                    except (HomeAssistantError, ServiceValidationError) as e:
-                        _LOGGER.error("EV control service failed for %s: %s", cid, e)
-                    except ValueError as e:
-                        _LOGGER.warning("EV control invalid value for %s: %s", cid, e)
-                    finally:
-                        # Save back per-charger state, restore coordinator state
-                        self._ev_stalled_since_per_charger[cid] = self._ev_stalled_since
-                        self._ev_enable_surplus_per_charger[cid] = self._ev_enable_surplus_since
-                        self._ev_charge_started_per_charger[cid] = self._ev_charge_started_at
-                        self._ev_last_change_per_charger[cid] = self._ev_last_change_time
-                        self._ev_reenable_attempts_per_charger[cid] = self._ev_reenable_attempts
-                        self._ev_charge_refused_per_charger[cid] = self._ev_charge_refused
-                        self._ev_device = saved["dev"]
-                        self._ev_stalled_since = saved["stalled"]
-                        self._ev_enable_surplus_since = saved["enable"]
-                        self._ev_charge_started_at = saved["started"]
-                        self._ev_last_change_time = saved["change"]
-                        self._ev_reenable_attempts = saved["reenable_attempts"]
-                        self._ev_charge_refused = saved["charge_refused"]
-                        self._current_charger_budget = None
-                        self._cycle_vehicle_soc = saved_vehicle_soc_ctrl
+                            await self._execute_ev_control(
+                                effective_state, power, energy, charging_context
+                            )
+                            # Add this charger's just-committed draw to the shared night
+                            # peak budget so lower-priority chargers size against the
+                            # remaining headroom (#274/H1). Estimate from the setpoint
+                            # (the commitment), not the lagging measured power.
+                            try:
+                                self._night_committed_w += max(0.0, (
+                                    ev_dev._current_setpoint * ev_dev.phases * ev_dev.voltage
+                                ))
+                            except (AttributeError, TypeError):
+                                pass
+                        except (HomeAssistantError, ServiceValidationError) as e:
+                            _LOGGER.error("EV control service failed for %s: %s", cid, e)
+                        except ValueError as e:
+                            _LOGGER.warning("EV control invalid value for %s: %s", cid, e)
                 self._save_ev_session_state()
             elif self._ev_device and not self._observer_mode:
                 try:

--- a/coordinator/per_charger_context.py
+++ b/coordinator/per_charger_context.py
@@ -1,0 +1,256 @@
+"""Per-charger context manager (v1.6.7).
+
+Lifts the ad-hoc ``saved = {...}`` swap dict at the head of the
+per-charger loop in ``coordinator.py`` into a typed context manager so:
+
+1. **The swap surface is one place to edit.** Adding a new per-charger
+   field used to require touching three locations (the saved dict, the
+   per-charger storage dict, the restore block). Now: add a field here.
+
+2. **The per-charger invariant is structural.** Inside a
+   ``with PerChargerContext.for_charger(...)`` block, you read
+   ``pcc.this_power_w`` etc. — not ``power.ev_power``. Future code
+   reviewers and the AST lint planned for v1.6.8 can mechanically check
+   this.
+
+3. **Zero behaviour change for v1.6.7.** The semantics of the swap +
+   restore + per-charger persistence are exactly what the
+   ``coordinator.py:1136-1258`` block did. Single-charger users never
+   enter the multi-charger loop and so are unaffected.
+
+See ``docs/MULTI_CHARGER.md`` for the full invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from .coordinator import SEMCoordinator
+
+
+@dataclass
+class PerChargerContext:
+    """Per-charger state for ONE iteration of the multi-charger loop.
+
+    Use via the ``for_charger`` classmethod as a context manager:
+
+    .. code-block:: python
+
+        for cid, ev_dev in sorted_chargers:
+            with PerChargerContext.for_charger(
+                coord, cid, ev_dev, budget_per_charger,
+            ) as pcc:
+                if pcc.skipped_for_night:
+                    continue
+                await coord._execute_ev_control(
+                    pcc.effective_state, power, energy, charging_context,
+                )
+
+    The ``__enter__`` hook swaps the coordinator's primary-charger
+    attributes (``_ev_device``, ``_ev_stalled_since``, etc.) to this
+    charger's values; ``__exit__`` persists any updates back into the
+    per-charger storage dicts and restores the primary's fleet view.
+
+    Fields are populated incrementally across v1.6.7 — v1.6.9:
+
+    - v1.6.7: identity (``cid``, ``ev_dev``, ``charger_cfg``) + the swap
+      mechanism (no new computed fields; the existing inline maths in
+      ``coordinator.py`` continue to run inside the ``with`` block).
+    - v1.6.8: ``effective_strategy``, ``this_power_w`` migrated from
+      ``ev_control._this_charger_power``.
+    - v1.6.9: ``per_charger_flows`` from the per-charger flow calculator.
+    """
+
+    # ------------------------------------------------------------------
+    # Identity (set by ``for_charger``)
+    # ------------------------------------------------------------------
+    cid: str
+    """The charger id (``ev_chargers[].id``). Stable across cycles."""
+
+    ev_dev: Any
+    """The ``EVDevice`` (KEBA, Wallbox, …) instance for this charger."""
+
+    charger_cfg: dict
+    """The per-charger config dict from ``ev_chargers`` (or ``{}``)."""
+
+    # ------------------------------------------------------------------
+    # Budget + skip flag (set by ``for_charger``)
+    # ------------------------------------------------------------------
+    budget_w: Optional[float] = None
+    """Per-charger surplus budget in watts, or ``None`` outside a solar
+    state (matches ``self._current_charger_budget`` semantics)."""
+
+    skipped_for_night: bool = False
+    """``True`` when the charger's mode opts it out of the current night
+    state (set during ``for_charger`` based on ``_mode_allows_night_charging``)."""
+
+    # ------------------------------------------------------------------
+    # Internal: references + the swap snapshot.
+    # ------------------------------------------------------------------
+    _coord: "Optional[SEMCoordinator]" = field(default=None, repr=False)
+    """The coordinator. Held so ``__enter__/__exit__`` can mutate it."""
+
+    _saved: dict = field(default_factory=dict, repr=False)
+    """Coordinator attributes captured at ``__enter__``, restored at
+    ``__exit__``. Mirrors the pre-v1.6.7 ``saved = {...}`` dict."""
+
+    _saved_vehicle_soc: Any = field(default=None, repr=False)
+    """``_cycle_vehicle_soc`` captured separately because it has its own
+    legacy save path (``saved_vehicle_soc_ctrl`` in the old code)."""
+
+    _entered: bool = field(default=False, repr=False)
+    """Guard against nested entry. The coordinator loop is single-threaded
+    per cycle; nesting would corrupt the swap snapshot."""
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+    @classmethod
+    def for_charger(
+        cls,
+        coordinator: "SEMCoordinator",
+        cid: str,
+        ev_dev: Any,
+        ev_budget_per_charger: dict,
+        chargers_by_id: Optional[dict] = None,
+    ) -> "PerChargerContext":
+        """Build a per-charger context.
+
+        Looks up the per-charger config dict and the per-charger budget
+        from the cycle-level distribution. Computes ``skipped_for_night``
+        based on the charger's mode and the current global charging
+        state — but only when the global state is a night state; for
+        solar states, ``skipped_for_night`` stays ``False`` and the
+        caller proceeds normally.
+
+        Args:
+            coordinator: the ``SEMCoordinator`` instance (passed so we
+                can mutate it in ``__enter__``).
+            cid: this charger's id.
+            ev_dev: this charger's ``EVDevice`` instance.
+            ev_budget_per_charger: the per-charger budget dict from
+                ``self._surplus_controller.distribute_ev_budget``. May
+                contain a value for ``cid`` (solar state) or be empty
+                (night state).
+            chargers_by_id: optional pre-built ``{cid: cfg}`` lookup the
+                caller can pass to avoid rebuilding it inside the loop.
+                If ``None``, this method rebuilds it from
+                ``coordinator.config``.
+
+        Returns:
+            A ``PerChargerContext`` ready to be used as a context manager.
+        """
+        if chargers_by_id is None:
+            chargers_by_id = {
+                (c.get("id") or "ev_charger"): c
+                for c in (coordinator.config.get("ev_chargers") or [])
+                if isinstance(c, dict)
+            }
+        charger_cfg = chargers_by_id.get(cid, {})
+        budget_w = ev_budget_per_charger.get(cid) if ev_budget_per_charger else None
+        return cls(
+            cid=cid,
+            ev_dev=ev_dev,
+            charger_cfg=charger_cfg,
+            budget_w=budget_w,
+            _coord=coordinator,
+        )
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "PerChargerContext":
+        """Push this charger's state onto the coordinator.
+
+        Captures the coordinator's primary-charger attributes into
+        ``_saved`` so ``__exit__`` can restore them; then writes this
+        charger's per-charger state (read from the coordinator's
+        ``_ev_*_per_charger`` dicts) into the primary attributes so
+        downstream methods that still read ``self._ev_*`` see THIS
+        charger's view.
+
+        Raises:
+            RuntimeError: on nested entry. The per-charger loop is
+                strictly serial; nesting would clobber ``_saved``.
+        """
+        if self._entered:
+            raise RuntimeError(
+                "PerChargerContext entered twice — the per-charger loop "
+                "must be serial. This indicates a coordinator init or "
+                "refactor bug."
+            )
+        self._entered = True
+        coord = self._coord
+        assert coord is not None, "PerChargerContext._coord must be set"
+
+        # Snapshot the primary attributes BEFORE swapping in this charger's
+        # values. The same set of fields the legacy ``saved = {...}`` dict
+        # captured at coordinator.py:1136-1144 in the pre-v1.6.7 code.
+        self._saved = {
+            "dev": coord._ev_device,
+            "stalled": coord._ev_stalled_since,
+            "enable": coord._ev_enable_surplus_since,
+            "started": coord._ev_charge_started_at,
+            "change": coord._ev_last_change_time,
+            "reenable_attempts": coord._ev_reenable_attempts,
+            "charge_refused": coord._ev_charge_refused,
+            "current_charger_budget": coord._current_charger_budget,
+        }
+        self._saved_vehicle_soc = coord._cycle_vehicle_soc
+
+        # Push this charger's state onto the coordinator.
+        coord._ev_device = self.ev_dev
+        coord._ev_stalled_since = coord._ev_stalled_since_per_charger.get(self.cid)
+        coord._ev_enable_surplus_since = coord._ev_enable_surplus_per_charger.get(self.cid)
+        coord._ev_charge_started_at = coord._ev_charge_started_per_charger.get(self.cid)
+        coord._ev_last_change_time = coord._ev_last_change_per_charger.get(self.cid)
+        coord._ev_reenable_attempts = coord._ev_reenable_attempts_per_charger.get(self.cid, 0)
+        coord._ev_charge_refused = coord._ev_charge_refused_per_charger.get(self.cid, False)
+        coord._current_charger_budget = self.budget_w
+
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        """Pop this charger's state back into per-charger dicts and
+        restore the primary view.
+
+        Always runs (including on exceptions raised by
+        ``_execute_ev_control``) so the coordinator's primary view is
+        never left mid-swap. Mirrors the ``finally:`` block at the
+        coordinator.py:1242-1258 in the pre-v1.6.7 code.
+
+        Returns:
+            ``False`` so exceptions propagate to the caller (matching
+            the legacy ``try/except (HomeAssistantError, ServiceValidationError)``
+            handling in coordinator.py).
+        """
+        coord = self._coord
+        assert coord is not None, "PerChargerContext._coord must be set"
+        try:
+            # Save back this charger's per-charger state.
+            coord._ev_stalled_since_per_charger[self.cid] = coord._ev_stalled_since
+            coord._ev_enable_surplus_per_charger[self.cid] = coord._ev_enable_surplus_since
+            coord._ev_charge_started_per_charger[self.cid] = coord._ev_charge_started_at
+            coord._ev_last_change_per_charger[self.cid] = coord._ev_last_change_time
+            coord._ev_reenable_attempts_per_charger[self.cid] = coord._ev_reenable_attempts
+            coord._ev_charge_refused_per_charger[self.cid] = coord._ev_charge_refused
+
+            # Restore primary view.
+            coord._ev_device = self._saved["dev"]
+            coord._ev_stalled_since = self._saved["stalled"]
+            coord._ev_enable_surplus_since = self._saved["enable"]
+            coord._ev_charge_started_at = self._saved["started"]
+            coord._ev_last_change_time = self._saved["change"]
+            coord._ev_reenable_attempts = self._saved["reenable_attempts"]
+            coord._ev_charge_refused = self._saved["charge_refused"]
+            # ``_current_charger_budget`` is cleared to ``None`` in the
+            # legacy code rather than restored to its pre-loop value —
+            # preserve that semantic (the post-loop reader treats
+            # non-None as "I'm currently inside a per-charger iteration").
+            coord._current_charger_budget = None
+            coord._cycle_vehicle_soc = self._saved_vehicle_soc
+        finally:
+            self._entered = False
+        return False  # never swallow exceptions

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -1,0 +1,134 @@
+# Multi-Charger Correctness — Developer Guide
+
+This document is the source of truth for **developers** working on SEM's
+multi-charger code paths. For end-user setup with multiple chargers, see
+[`MULTI_DEVICE_GUIDE.md`](MULTI_DEVICE_GUIDE.md).
+
+---
+
+## The bug class we keep finding
+
+Between v1.6.0 and v1.6.6 SEM shipped four hotfixes for variants of the
+same bug — each one a "per-charger context swap with fleet-level reads
+still leaking through":
+
+| Release | Issue | Fix shape |
+|---|---|---|
+| v1.6.0 | #284 | Distributor used the legacy `_calculate_solar_ev_budget` formula instead of the canonical `EVBudget.net_w` |
+| v1.6.5 | #289 | Fleet aggregation on the 10 s cycle hid sub-cycle KEBA spikes |
+| v1.6.5 | #315 | `_this_charger_power` helper introduced because the off-mode terminator read `power.ev_power` (fleet sum) |
+| v1.6.6 | #318 | `_update_per_charger_detector_energy` helper introduced because `update_energy()` was only called on the primary detector |
+
+Each was a separate band-aid. The v1.6.7 cleanup
+([`PerChargerContext`](../coordinator/per_charger_context.py)) lifts the
+swap mechanism into a typed context manager so that the **invariant** —
+"inside a per-charger iteration, read this charger's view, not the
+fleet's" — can be enforced structurally rather than by memory.
+
+---
+
+## The invariant
+
+> **Inside a `with PerChargerContext.for_charger(...)` block, never read
+> `power.ev_power` directly. Use `pcc.this_power_w` (added in v1.6.8) or
+> tag the read explicitly with `# FLEET-READ: <reason>`.**
+
+Likewise: never read `self._ev_*` directly; the context owns them and
+they reflect THIS charger only during the block. Reading them from
+outside the block returns the primary charger's view (the legacy
+"fleet" semantic for backward compat).
+
+To add a new per-charger field, edit `PerChargerContext` only —
+don't add new ad-hoc swap dicts.
+
+---
+
+## What the context manager owns
+
+`coordinator/per_charger_context.py` ([source](../coordinator/per_charger_context.py)):
+
+| Coordinator attribute | Role |
+|---|---|
+| `_ev_device` | The active charger's `EVDevice` instance |
+| `_ev_stalled_since` | Per-charger stall detection state |
+| `_ev_enable_surplus_since` | Per-charger enable-surplus timer |
+| `_ev_charge_started_at` | Per-charger session start timestamp |
+| `_ev_last_change_time` | Per-charger ramp-rate gate |
+| `_ev_reenable_attempts` | Per-charger re-enable retry counter |
+| `_ev_charge_refused` | Per-charger "charger refused" flag |
+| `_current_charger_budget` | This charger's slice of `EVBudget.net_w` |
+| `_cycle_vehicle_soc` | This charger's vehicle SOC (per `vehicle_soc_entity`) |
+
+The corresponding `_per_charger` dicts (e.g.
+`_ev_stalled_since_per_charger: Dict[str, datetime]`) are the **storage**;
+the context manager pushes from them on `__enter__` and saves back on
+`__exit__`.
+
+---
+
+## How to add a new per-charger field
+
+1. Add it as a field on the `PerChargerContext` dataclass.
+2. Add a `_<field>_per_charger: Dict[str, ...]` to `SEMCoordinator`.
+3. Push/save in `__enter__`/`__exit__` — mirror the existing fields.
+4. Add a unit test in `tests/test_per_charger_context.py` asserting:
+   - In-context reads see this charger's value.
+   - Mutations persist to the per-charger dict after exit.
+   - Different chargers don't see each other's value.
+
+That's it. **Don't** add a new `saved = {...}` dict in
+`coordinator.py`; the loop body already wraps everything in a `with`
+block.
+
+---
+
+## Why a `with` block instead of a function?
+
+Because the existing code at the per-charger loop body is ~120 lines of
+inline mathematics (Min/Max remaining, night plan, off-mode override,
+strategy dispatch) that all mutate the shared `charging_context` object
+in place. Wrapping it in a function would require either threading every
+mutation through a return value (giant call site, fragile to extend) or
+mutating via reference (no clearer than the current state). The `with`
+form keeps the inline code identical and just owns the lifecycle of the
+swap.
+
+A future v1.7+ refactor *might* migrate the inline math onto methods on
+`PerChargerContext` (e.g. `pcc.compute_remaining_to_min()`,
+`pcc.effective_state`) — but that's incremental work, not a blocker for
+the structural invariant.
+
+---
+
+## Roadmap (v1.6.x cleanup)
+
+| Release | Theme | Status |
+|---|---|---|
+| v1.6.7 | Lift swap dict into `PerChargerContext` | **In progress** |
+| v1.6.8 | Per-charger strategy + `ev_control.py` fleet-read sweep + AST lint test | Planned |
+| v1.6.9 | Per-charger flow attribution + notifications (closes #316 family) | Planned |
+| v1.7 | New features — **only after** v1.6.9 lands clean on PROD | Blocked on above |
+
+See [`/home/sem/.claude/plans/greedy-whistling-nebula.md`](../../.claude/plans/greedy-whistling-nebula.md)
+for the full plan.
+
+---
+
+## Tests that pin the invariant
+
+- `tests/test_per_charger_context.py` — unit tests for the swap mechanism.
+- `tests/scenarios/2026-05-29_multi_charger_split.yaml` — Phase B.5
+  multi-charger budget distribution (RienduPre's Growatt + Wallbox setup).
+- v1.6.8 will add `tests/test_ev_control_fleet_reads.py` — AST walk that
+  fails CI if any `power.ev_power` read inside a per-charger loop is
+  missing the `# FLEET-READ:` annotation.
+
+---
+
+## See also
+
+- [`MULTI_DEVICE_GUIDE.md`](MULTI_DEVICE_GUIDE.md) — end-user setup for
+  multi-charger / multi-inverter installs.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — overall coordinator design.
+- [`EV_CHARGING_LOGIC.md`](EV_CHARGING_LOGIC.md) — Charge mode + budget
+  priority cascade.

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.6"
+  "version": "1.6.7"
 }

--- a/tests/test_per_charger_context.py
+++ b/tests/test_per_charger_context.py
@@ -1,0 +1,220 @@
+"""Tests for ``coordinator/per_charger_context.py`` (v1.6.7).
+
+The context manager is a mechanical lift of the ad-hoc ``saved = {...}``
+swap dict at ``coordinator.py:1136-1258``. These tests pin:
+
+1. The swap captures every primary-charger attribute the legacy code
+   captured (no field bleeds into the next iteration).
+2. The save-back persists this charger's state to the
+   ``_ev_*_per_charger`` dicts.
+3. The restore is idempotent on exceptions (the ``finally``-like
+   semantic).
+4. Nested entry is forbidden — a sanity check for the single-threaded
+   per-cycle invariant.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.per_charger_context import (
+    PerChargerContext,
+)
+
+
+def _make_coord(ev_chargers=None):
+    """A minimal coordinator stub with only the per-charger swap surface.
+
+    Keeping the fixture small means future coordinator refactors won't
+    flake these tests — we only depend on the 8 ``_ev_*`` attributes the
+    swap touches.
+    """
+    coord = MagicMock()
+    coord.config = {"ev_chargers": ev_chargers or [{"id": "left"}, {"id": "right"}]}
+    # Primary view (the "fleet" attributes that get swapped per iteration).
+    coord._ev_device = None
+    coord._ev_stalled_since = None
+    coord._ev_enable_surplus_since = None
+    coord._ev_charge_started_at = None
+    coord._ev_last_change_time = None
+    coord._ev_reenable_attempts = 0
+    coord._ev_charge_refused = False
+    coord._current_charger_budget = None
+    coord._cycle_vehicle_soc = None
+    # Per-charger storage dicts (populated/read by the context manager).
+    coord._ev_stalled_since_per_charger = {}
+    coord._ev_enable_surplus_per_charger = {}
+    coord._ev_charge_started_per_charger = {}
+    coord._ev_last_change_per_charger = {}
+    coord._ev_reenable_attempts_per_charger = {}
+    coord._ev_charge_refused_per_charger = {}
+    return coord
+
+
+class TestSwapInvariant:
+    """The primary view must be restored exactly after the ``with`` block."""
+
+    def test_restores_primary_after_clean_exit(self):
+        """No mutation, clean exit: primary view unchanged."""
+        coord = _make_coord()
+        coord._ev_device = "FLEET_DEV"
+        coord._ev_stalled_since = "FLEET_STALL"
+        coord._cycle_vehicle_soc = 42.0
+
+        ev_dev = MagicMock(name="left_dev")
+        with PerChargerContext.for_charger(coord, "left", ev_dev, {"left": 4000.0}):
+            # Inside: coordinator sees the per-charger view.
+            assert coord._ev_device is ev_dev
+            assert coord._current_charger_budget == 4000.0
+
+        # Outside: primary view restored.
+        assert coord._ev_device == "FLEET_DEV"
+        assert coord._ev_stalled_since == "FLEET_STALL"
+        assert coord._cycle_vehicle_soc == 42.0
+
+    def test_restores_primary_after_exception(self):
+        """If the body raises, primary view is still restored.
+
+        The legacy code used a ``try/finally`` block; the context manager
+        must offer the same guarantee so a charger-control failure can't
+        leak its swap into the next iteration.
+        """
+        coord = _make_coord()
+        coord._ev_device = "FLEET_DEV"
+
+        ev_dev = MagicMock(name="left_dev")
+        with pytest.raises(RuntimeError, match="boom"):
+            with PerChargerContext.for_charger(coord, "left", ev_dev, {"left": 4000.0}):
+                assert coord._ev_device is ev_dev
+                raise RuntimeError("boom")
+
+        assert coord._ev_device == "FLEET_DEV"
+        assert coord._current_charger_budget is None  # legacy semantic
+
+    def test_per_charger_state_persists_across_iterations(self):
+        """Mutations to ``_ev_stalled_since`` inside the context land in
+        the per-charger dict so the next iteration of THIS charger sees
+        them."""
+        coord = _make_coord()
+        ev_dev_left = MagicMock(name="left_dev")
+        ev_dev_right = MagicMock(name="right_dev")
+
+        # First pass through charger "left": stash a stalled timestamp.
+        stall_ts = datetime(2026, 5, 31, 16, 0, 0)
+        with PerChargerContext.for_charger(coord, "left", ev_dev_left, {}):
+            coord._ev_stalled_since = stall_ts
+            coord._ev_reenable_attempts = 3
+            coord._ev_charge_refused = True
+
+        # Persisted to the per-charger dicts.
+        assert coord._ev_stalled_since_per_charger["left"] == stall_ts
+        assert coord._ev_reenable_attempts_per_charger["left"] == 3
+        assert coord._ev_charge_refused_per_charger["left"] is True
+
+        # Primary view back to its pre-entry default (None / 0 / False).
+        assert coord._ev_stalled_since is None
+        assert coord._ev_reenable_attempts == 0
+        assert coord._ev_charge_refused is False
+
+        # Second iteration over a DIFFERENT charger: does not see left's state.
+        with PerChargerContext.for_charger(coord, "right", ev_dev_right, {}):
+            assert coord._ev_stalled_since is None
+            assert coord._ev_reenable_attempts == 0
+            assert coord._ev_charge_refused is False
+
+        # Third iteration over left again: sees its own state.
+        with PerChargerContext.for_charger(coord, "left", ev_dev_left, {}):
+            assert coord._ev_stalled_since == stall_ts
+            assert coord._ev_reenable_attempts == 3
+            assert coord._ev_charge_refused is True
+
+
+class TestSkipFlag:
+    """``skipped_for_night`` is the v1.6.7 carry-over for the existing
+    ``_mode_allows_night_charging`` gate. This release leaves the
+    actual computation in the coordinator loop body; the field is wired
+    so v1.6.8 can move it into ``for_charger`` without a signature
+    change."""
+
+    def test_skip_default_false(self):
+        coord = _make_coord()
+        pcc = PerChargerContext.for_charger(coord, "left", MagicMock(), {})
+        assert pcc.skipped_for_night is False
+
+
+class TestNestingGuard:
+    """Re-entering a context without exiting the previous one would
+    clobber the snapshot. Sanity check the single-threaded invariant."""
+
+    def test_nested_entry_raises(self):
+        coord = _make_coord()
+        ev_dev = MagicMock()
+        with PerChargerContext.for_charger(coord, "left", ev_dev, {}) as pcc:
+            with pytest.raises(RuntimeError, match="entered twice"):
+                pcc.__enter__()
+
+
+class TestCfgLookup:
+    """``for_charger`` resolves the per-charger config dict from
+    ``coordinator.config['ev_chargers']``."""
+
+    def test_finds_matching_config(self):
+        coord = _make_coord([
+            {"id": "left", "name": "Wallbox Left"},
+            {"id": "right", "name": "Wallbox Right"},
+        ])
+        pcc = PerChargerContext.for_charger(coord, "right", MagicMock(), {})
+        assert pcc.charger_cfg == {"id": "right", "name": "Wallbox Right"}
+
+    def test_missing_id_yields_empty_cfg(self):
+        """A charger present in ``_ev_devices`` but not in ``ev_chargers``
+        (mid-migration state) gets an empty dict rather than crashing."""
+        coord = _make_coord([{"id": "left"}])
+        pcc = PerChargerContext.for_charger(coord, "ghost", MagicMock(), {})
+        assert pcc.charger_cfg == {}
+
+    def test_prebuilt_lookup_used_when_passed(self):
+        """The caller can pre-build ``chargers_by_id`` for the loop and
+        pass it in to avoid rebuilding it once per charger."""
+        coord = _make_coord([{"id": "left", "name": "from-config"}])
+        prebuilt = {"left": {"id": "left", "name": "from-prebuilt"}}
+        pcc = PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {}, chargers_by_id=prebuilt,
+        )
+        assert pcc.charger_cfg["name"] == "from-prebuilt"
+
+    def test_chargers_by_id_none_rebuilds_from_config(self):
+        """When ``chargers_by_id`` is omitted, ``for_charger`` rebuilds
+        the dict from ``coordinator.config['ev_chargers']`` rather than
+        crashing. Exercises the fallback path that the coordinator loop
+        bypasses (it always passes a pre-built dict)."""
+        coord = _make_coord([
+            {"id": "left", "name": "rebuilt-left"},
+            {"id": "right", "name": "rebuilt-right"},
+        ])
+        pcc = PerChargerContext.for_charger(
+            coord, "right", MagicMock(), {},  # no chargers_by_id arg
+        )
+        assert pcc.charger_cfg["name"] == "rebuilt-right"
+
+
+class TestBudget:
+    """The budget passed to ``for_charger`` is forwarded into
+    ``self._current_charger_budget`` and reset to ``None`` on exit
+    (matching the legacy semantic where ``None`` means "not currently
+    inside a per-charger iteration")."""
+
+    def test_budget_pushed_then_cleared(self):
+        coord = _make_coord()
+        with PerChargerContext.for_charger(coord, "left", MagicMock(), {"left": 6800.0}):
+            assert coord._current_charger_budget == 6800.0
+        assert coord._current_charger_budget is None
+
+    def test_budget_none_when_charger_not_in_dict(self):
+        """The night-state path doesn't populate ``ev_budget_per_charger`` —
+        in that case the per-charger budget is ``None`` rather than 0."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(coord, "left", MagicMock(), {}):
+            assert coord._current_charger_budget is None
+        assert coord._current_charger_budget is None


### PR DESCRIPTION
## Summary

First of three planned multi-charger cleanup releases (v1.6.7→v1.6.9) dedicated to v1.6.x — **no v1.7 until v1.6.9 lands clean on PROD**. See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full developer-facing roadmap.

**Zero behaviour change** — pure mechanical refactor. Single-charger users never enter the multi-charger loop and so are unaffected.

## Why

Between v1.6.0 and v1.6.6 SEM shipped four hotfixes for variants of the same bug class — per-charger context swaps with fleet-level reads still leaking through. Each fix added a new band-aid helper:

| Release | Issue | Fix shape |
|---|---|---|
| v1.6.0 | #284 | Distributor used legacy formula instead of canonical `EVBudget.net_w` |
| v1.6.5 | #289 | Fleet aggregation hid sub-cycle KEBA spikes |
| v1.6.5 | #315 | `_this_charger_power` helper introduced — terminator was reading `power.ev_power` (fleet sum) |
| v1.6.6 | #318 | `_update_per_charger_detector_energy` helper introduced — primary detector only |

This release lifts the **swap mechanism itself** into a typed `PerChargerContext` so the invariant — "inside a per-charger iteration, read this charger's view, not the fleet's" — can be enforced structurally (v1.6.8 will add the AST lint).

## Changes

- **New `coordinator/per_charger_context.py`** — typed context manager with `for_charger()` factory + `__enter__/__exit__`. Captures the 8 coordinator attributes the legacy `saved = {...}` dict captured, plus `_cycle_vehicle_soc`. `_current_charger_budget` is cleared to `None` on exit (legacy semantic preserved).

- **`coordinator/coordinator.py:1120-1258`** — replaced inline `saved = {...}` + restore `finally:` with `with PerChargerContext.for_charger(...): ...`. Inline per-charger maths stays inline (migrates to context-object methods in v1.6.8/v1.6.9).

- **`tests/test_per_charger_context.py`** — 11 unit tests pinning swap invariants.

- **New `docs/MULTI_CHARGER.md`** — developer-facing invariant doc.

- **`CONTRIBUTING.md`** — new "Multi-charger correctness" section.

## Verification

- **2172 tests pass** on Python 3.12 (2161 baseline + 11 new). Zero existing tests broke.
- **Reviewer (ruflo-core:reviewer)**: OK-TO-SHIP with one NIT (missing `chargers_by_id=None` fallback test — folded in).
- Specifically verified: swap field parity with legacy; `_cycle_vehicle_soc` unconditional restore; `finally:` → `__exit__` exception semantics; `_current_charger_budget` cleared-to-None semantic preserved.

## Risk + rollback

Mechanical refactor; single-file `coordinator.py` change plus a new module. Single-charger code path is structurally bypassed (never enters the multi-charger loop). Rollback = revert the merge.

## Test plan

- [x] Full test suite green (2172 / 7 skipped)
- [x] Reviewer pass
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] HA-TEST clean install + multi-charger verification using mock_charger_2 setup
- [ ] Post-merge: PROD deploy + 24h soak before v1.6.8 branch opens