### PR TITLE
refactor: v1.6.8 — sweep 12 fleet-power reads in ev_control + AST lint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] — 2026-05-31
+
+Second of the three-release multi-charger cleanup arc (v1.6.7 → v1.6.9).
+**Zero behaviour change** for single-charger users; multi-charger users
+get correctness fixes for 12 fleet-power-sum reads that were silently
+returning the wrong value inside per-charger code paths. Sets up the
+structural enforcement that makes the bug class impossible to
+re-introduce.
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full
+developer-facing invariant.
+
+### Fixed
+
+- **12 fleet-power-sum reads swept in
+  [`coordinator/ev_control.py`](coordinator/ev_control.py)** — every
+  ``power.ev_power`` read inside the per-charger code path (8 in
+  ``_execute_ev_control``, 3 in ``_should_reenable_charger``, 1 in
+  ``_update_session_tracking``) now uses
+  ``self._this_charger_power(ev, power)`` cached as
+  ``this_power_w`` at the top of the method. In multi-charger setups
+  these reads were returning the fleet sum — exactly the bug class
+  that caused #284, #289, #315 (terminator) and #318 (SOC isolation).
+  Each fix was reactive; this sweep closes them all.
+
+### Added
+
+- **AST lint test** ([`tests/test_ev_control_fleet_reads.py`](tests/test_ev_control_fleet_reads.py))
+  — walks the AST of ``ev_control.py`` on every CI run and fails if
+  any ``power.ev_power`` read is missing a ``# FLEET-READ:`` annotation
+  (outside the sanctioned ``_this_charger_power`` helper). Catches the
+  bug class on PR review, not after release.
+
+- **``# FLEET-READ: <reason>`` annotation convention** — documented in
+  ``docs/MULTI_CHARGER.md``. Same-line or previous-line comment opts
+  a deliberate fleet-level read out of the lint with a required
+  human-readable reason.
+
 ## [1.6.7] — 2026-05-31
 
 First of a three-release multi-charger cleanup arc dedicated to v1.6.x.

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -329,6 +329,13 @@ class EVControlMixin:
         ev = self._ev_device
         ev.managed_externally = True  # ALWAYS — coordinator owns EV
 
+        # v1.6.8: cache this charger's power once per call. Avoids reading
+        # the global fleet sum (``power.ev_power``) when we mean THIS
+        # charger's draw — exactly the bug class that caused the v1.6.5
+        # KEBA self-resume regression and the broader sweep this release
+        # ships. See ``docs/MULTI_CHARGER.md`` for the invariant.
+        this_power_w = self._this_charger_power(ev, power)
+
         # === NIGHT CHARGING (peak-managed, ramp-limited) ===
         # Design: evcc-style ramp, configurable min current, IEC 61851 compliant
         if state == ChargingState.NIGHT_CHARGING_ACTIVE:
@@ -343,9 +350,9 @@ class EVControlMixin:
                 return
 
             # Detect already-charging after SEM reload (don't interrupt)
-            if not ev._session_active and power.ev_power > 50:
+            if not ev._session_active and this_power_w > 50:
                 ev._session_active = True
-                _LOGGER.info("Night: KEBA already active (%.0fW), resuming", power.ev_power)
+                _LOGGER.info("Night: KEBA already active (%.0fW), resuming", this_power_w)
 
             # Read configurable EV parameters — per-charger overrides (#193)
             charger_cfg = self._get_active_charger_config()
@@ -399,9 +406,9 @@ class EVControlMixin:
                     self._ev_last_change_time = dt_util.now()
 
                 # Dynamic peak-managed current (only when car is actually drawing)
-                if power.ev_power > 100:
+                if this_power_w > 100:
                     # W/A from actual charger readings (adapts to any car)
-                    watts_per_amp = power.ev_power / max(1, ev._current_setpoint)
+                    watts_per_amp = this_power_w / max(1, ev._current_setpoint)
                     target = self._night_peak_managed_amps(
                         power, watts_per_amp, min_amps, ev.max_current)
                     peak_limit_w = self._get_peak_limit_w()  # for the log line
@@ -428,7 +435,7 @@ class EVControlMixin:
                         await ev._set_current(target)
 
             _LOGGER.debug("Night EV: %dA, %.0fW, remaining=%.1fkWh",
-                          ev._current_setpoint, power.ev_power, remaining_kwh)
+                          ev._current_setpoint, this_power_w, remaining_kwh)
             return
 
         # === NIGHT WAITING STATES: stop session if running ===
@@ -493,7 +500,7 @@ class EVControlMixin:
                 # Surplus is sufficient — track how long it's been sufficient
                 self._ev_enable_surplus_since = self._ev_enable_surplus_since or now_ts
 
-                if ev._session_active and power.ev_power > 100:
+                if ev._session_active and this_power_w > 100:
                     # Already charging — update current immediately, reset disable timer
                     target_current = min(ev.max_current,
                                          max(ev.min_current, ev.watts_to_current(budget_w)))
@@ -525,7 +532,7 @@ class EVControlMixin:
 
                 if (self._ev_charge_started_at
                         and (now_ts - self._ev_charge_started_at) < disable_delay
-                        and power.ev_power > 100):
+                        and this_power_w > 100):
                     # Within disable delay and actually charging — hold at minimum current
                     if ev._current_setpoint != ev.min_current:
                         await ev._set_current(ev.min_current)
@@ -542,7 +549,7 @@ class EVControlMixin:
 
             _LOGGER.debug(
                 "Solar EV: budget=%.0fW (%s), current=%.0fA, ev_power=%.0fW, session=%s",
-                budget_w, state, ev._current_setpoint, power.ev_power,
+                budget_w, state, ev._current_setpoint, this_power_w,
                 "active" if ev._session_active else "inactive",
             )
             return
@@ -732,9 +739,11 @@ class EVControlMixin:
         ev = self._ev_device
         if not ev._session_active:
             return False
+        # v1.6.8: per-charger power (not fleet sum). See ``docs/MULTI_CHARGER.md``.
+        this_power_w = self._this_charger_power(ev, power)
         # SEM set current >= min but charger reports no power → stalled
         if (ev._current_setpoint >= ev.min_current
-                and power.ev_power < 50
+                and this_power_w < 50
                 and power.ev_connected):
             # Car already deemed not-accepting this session — stay quiet
             if getattr(self, "_ev_charge_refused", False):
@@ -753,13 +762,13 @@ class EVControlMixin:
                         "EV not accepting charge after %d re-enable attempts "
                         "(setpoint=%.0fA, power=%.0fW) — car likely full; "
                         "pausing re-enable until power resumes or car unplugged",
-                        max_attempts, ev._current_setpoint, power.ev_power,
+                        max_attempts, ev._current_setpoint, this_power_w,
                     )
                     return False
                 _LOGGER.warning(
                     "EV charger stalled (setpoint=%.0fA, power=%.0fW) — "
                     "re-enabling (attempt %d/%d)",
-                    ev._current_setpoint, power.ev_power,
+                    ev._current_setpoint, this_power_w,
                     self._ev_reenable_attempts, max_attempts,
                 )
                 return True
@@ -988,8 +997,14 @@ class EVControlMixin:
 
         self._last_ev_connected = power.ev_connected
 
-        # Detect session start: EV charging and no active session
-        if power.ev_power > 50 and not self._session_data.active:
+        # Detect session start: EV charging and no active session.
+        # v1.6.8: per-charger power. ``_update_session_tracking`` is called
+        # from inside the per-charger loop in ``coordinator.py:970``, after
+        # ``self._session_data`` has been swapped to this charger's
+        # ``SessionData`` instance — so the start-detection threshold must
+        # also key off THIS charger's draw, not the fleet sum.
+        this_power_w = self._this_charger_power(self._ev_device, power)
+        if this_power_w > 50 and not self._session_data.active:
             self._session_data = SessionData(
                 active=True,
                 start_time=dt_util.now().isoformat(),

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -29,9 +29,11 @@ fleet's" — can be enforced structurally rather than by memory.
 
 ## The invariant
 
-> **Inside a `with PerChargerContext.for_charger(...)` block, never read
-> `power.ev_power` directly. Use `pcc.this_power_w` (added in v1.6.8) or
-> tag the read explicitly with `# FLEET-READ: <reason>`.**
+> **Inside a `with PerChargerContext.for_charger(...)` block — including
+> any method called from inside that block, transitively — never read
+> `power.ev_power` directly. Use `self._this_charger_power(ev, power)`
+> (cached as `this_power_w` at the top of the method) or tag the read
+> explicitly with `# FLEET-READ: <reason>`.**
 
 Likewise: never read `self._ev_*` directly; the context owns them and
 they reflect THIS charger only during the block. Reading them from
@@ -40,6 +42,36 @@ outside the block returns the primary charger's view (the legacy
 
 To add a new per-charger field, edit `PerChargerContext` only —
 don't add new ad-hoc swap dicts.
+
+### `# FLEET-READ:` annotation
+
+The lint test at `tests/test_ev_control_fleet_reads.py` parses
+`coordinator/ev_control.py` and fails CI on any `power.ev_power` read
+that is **not** either (a) inside the sanctioned `_this_charger_power`
+helper or (b) annotated with `# FLEET-READ: <reason>` on the same line
+or the immediately preceding line. The reason text is required and
+shows up in code review — keep it short and concrete:
+
+```python
+# Bad — would fail the lint
+if power.ev_power > 100:
+    ...
+
+# Good (per-charger; the right answer 99% of the time)
+this_power_w = self._this_charger_power(ev, power)
+if this_power_w > 100:
+    ...
+
+# Good (rare: genuinely fleet-level, e.g. a fleet-aggregating sensor)
+# FLEET-READ: aggregating total EV draw for the dashboard fleet card
+fleet_ev_w = power.ev_power
+```
+
+The lint is intentionally cheap (AST walk, no runtime) so it runs on
+every PR. If you find yourself reaching for the annotation, ask
+yourself: is this code actually inside the per-charger loop? If yes,
+you almost certainly want `this_power_w`. If no, you don't need the
+annotation at all — the lint only flags reads inside `ev_control.py`.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.7"
+  "version": "1.6.8"
 }

--- a/tests/test_ev_control_fleet_reads.py
+++ b/tests/test_ev_control_fleet_reads.py
@@ -1,0 +1,222 @@
+"""AST lint: every ``power.ev_power`` read in ``ev_control.py`` must be
+either inside the per-charger helper or carry a ``# FLEET-READ:`` tag.
+
+The recurring bug class through v1.6.0 → v1.6.6 was per-charger code
+paths accidentally reading the fleet-summed ``power.ev_power``. v1.6.7
+lifted the swap mechanism into ``PerChargerContext`` and v1.6.8 sweeps
+the remaining reads in ``coordinator/ev_control.py`` to use
+``self._this_charger_power(ev, power)`` cached as ``this_power_w``
+locally.
+
+This test pins that invariant going forward — any new ``power.ev_power``
+read added to ``ev_control.py`` must be annotated with
+``# FLEET-READ: <reason>`` on the same line (or the immediately
+preceding line) or the test fails CI. This is the cheapest enforcement
+that catches the bug class on PR review rather than after release.
+
+The ``_this_charger_power`` helper itself is exempt — it's the
+sanctioned fallback path. Docstrings and comments mentioning
+``power.ev_power`` are also exempt because they're text, not code.
+
+See ``docs/MULTI_CHARGER.md`` for the full invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+EV_CONTROL_PY = (
+    Path(__file__).resolve().parent.parent / "coordinator" / "ev_control.py"
+)
+
+# Functions whose body is allowed to read ``power.ev_power`` directly.
+# Currently only the helper that DEFINES the fleet-fallback path.
+EXEMPT_FUNCTIONS = frozenset({"_this_charger_power"})
+
+# The annotation that opts a single read out of the lint. Place it as a
+# line comment on the same line as the read OR on the line above:
+#
+#     foo = power.ev_power  # FLEET-READ: explanation
+#
+#     # FLEET-READ: explanation
+#     foo = power.ev_power
+ANNOTATION = "# FLEET-READ:"
+
+
+def _find_function_for_line(tree: ast.Module, line: int) -> str | None:
+    """Return the innermost function definition enclosing the given line.
+
+    Walks the AST top-down looking for ``FunctionDef`` /
+    ``AsyncFunctionDef`` nodes whose line range contains ``line``.
+    Returns the name of the deepest match, or ``None`` if the read is at
+    module scope (which would itself be a bug — included in the lint
+    output for visibility).
+    """
+    best: tuple[int, str] | None = None  # (start_line, name)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = getattr(node, "end_lineno", node.lineno)
+            if start <= line <= end:
+                if best is None or start > best[0]:
+                    best = (start, node.name)
+    return best[1] if best else None
+
+
+def _read_lines() -> list[str]:
+    return EV_CONTROL_PY.read_text().splitlines()
+
+
+def _find_ev_power_reads(tree: ast.Module) -> list[tuple[int, str]]:
+    """Return ``(line, enclosing_function)`` for every ``power.ev_power``
+    attribute read in the file."""
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "ev_power"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "power"
+        ):
+            func = _find_function_for_line(tree, node.lineno) or "<module>"
+            hits.append((node.lineno, func))
+    return hits
+
+
+def _is_annotated(lines: list[str], line_no: int) -> bool:
+    """True if the read at ``line_no`` (1-based) carries a
+    ``# FLEET-READ:`` annotation on the same line or the immediately
+    preceding line.
+
+    Note: only **same-line** or **previous-line** annotations are
+    recognised. Two-lines-above doesn't count — keep the annotation
+    visually adjacent to the read so reviewers see it.
+
+    Also: only the ``power.ev_power`` dotted form is checked by the
+    lint (see ``_find_ev_power_reads``). ``getattr(power, "ev_power",
+    ...)`` would bypass the AST walker — by convention treat that as
+    forbidden anywhere outside ``_this_charger_power``, but it is not
+    mechanically enforced.
+    """
+    idx = line_no - 1  # to 0-based
+    same = lines[idx] if 0 <= idx < len(lines) else ""
+    prev = lines[idx - 1] if 0 < idx < len(lines) else ""
+    return ANNOTATION in same or ANNOTATION in prev
+
+
+class TestEvPowerReads:
+    """Pin the multi-charger invariant at lint level.
+
+    These tests parse ``coordinator/ev_control.py`` and check every
+    ``power.ev_power`` AST node. They do not exercise runtime behaviour
+    — that's covered by the unit and scenario tests.
+    """
+
+    def test_all_reads_are_exempt_or_annotated(self):
+        """Every ``power.ev_power`` read must be either inside the
+        sanctioned ``_this_charger_power`` helper OR carry a
+        ``# FLEET-READ:`` annotation explaining why a fleet sum is
+        deliberately wanted.
+
+        When this test fails, the message lists each offending read with
+        its line number and enclosing function. Fix by either:
+
+        1. Replacing the read with ``this_power_w`` (cached via
+           ``self._this_charger_power(ev, power)`` at the top of the
+           function) — the right answer for per-charger code paths.
+        2. Adding ``# FLEET-READ: <reason>`` immediately above or on the
+           same line — for the rare case where you genuinely mean the
+           fleet sum (e.g. a sensor that aggregates across the fleet).
+
+        Coverage caveats (intentional, both rare in practice):
+
+        - Only the ``power.ev_power`` dotted form is walked. A
+          ``getattr(power, "ev_power", 0.0)`` would silently bypass the
+          AST check — by convention this is treated as forbidden too,
+          but not mechanically enforced.
+        - The annotation must be on the same line as the read or the
+          one immediately above. Two-lines-above won't satisfy the
+          check — keep the annotation visually adjacent.
+        """
+        source = EV_CONTROL_PY.read_text()
+        tree = ast.parse(source)
+        lines = source.splitlines()
+
+        offenders: list[str] = []
+        for line_no, func in _find_ev_power_reads(tree):
+            if func in EXEMPT_FUNCTIONS:
+                continue
+            if _is_annotated(lines, line_no):
+                continue
+            offenders.append(f"  L{line_no} in {func}()")
+
+        assert not offenders, (
+            "Found unannotated ``power.ev_power`` reads in "
+            "``coordinator/ev_control.py`` outside the sanctioned helper "
+            "``_this_charger_power``. In multi-charger setups "
+            "``power.ev_power`` is the GLOBAL SUM across all chargers — "
+            "reading it directly inside a per-charger code path is the "
+            "bug class that caused #284, #289, #315 and #318.\n\n"
+            "Each offender:\n" + "\n".join(offenders) + "\n\n"
+            "Fix: either replace with ``this_power_w`` cached via "
+            "``self._this_charger_power(ev, power)`` (preferred), or "
+            "annotate with ``# FLEET-READ: <reason>`` on the same line or "
+            "the line immediately above (only when fleet semantics are "
+            "explicitly wanted).\n\n"
+            "See docs/MULTI_CHARGER.md for the full invariant."
+        )
+
+    def test_helper_is_only_exempt_function(self):
+        """The exemption list is intentionally minimal — exactly one
+        function. If you find yourself wanting to add another, talk to
+        a maintainer first; almost certainly the right answer is the
+        ``# FLEET-READ:`` annotation on the specific read instead."""
+        assert EXEMPT_FUNCTIONS == frozenset({"_this_charger_power"})
+
+    def test_lint_actually_detects_unannotated_reads(self):
+        """Sanity: if we deliberately strip the ``# FLEET-READ:``
+        annotations and re-run the analysis on a synthetic source, the
+        offender list is non-empty. Guards against the lint silently
+        passing because the AST walk found nothing (e.g. after a future
+        refactor that renames ``power`` to ``readings`` everywhere)."""
+        synthetic = (
+            "def f(power):\n"
+            "    if power.ev_power > 100:\n"  # unannotated -> should be flagged
+            "        return True\n"
+            "    return False\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits, "AST walker failed to find a power.ev_power read"
+        # The synthetic source has no annotation -> the offender list is
+        # non-empty.
+        unannotated = [h for h in hits if not _is_annotated(lines, h[0])]
+        assert unannotated, "Lint failed to flag unannotated read"
+
+    def test_annotation_on_same_line_exempts(self):
+        synthetic = (
+            "def f(power):\n"
+            "    return power.ev_power  # FLEET-READ: aggregate sensor\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits, "AST walker failed to find the read"
+        assert all(_is_annotated(lines, h[0]) for h in hits)
+
+    def test_annotation_on_previous_line_exempts(self):
+        synthetic = (
+            "def f(power):\n"
+            "    # FLEET-READ: aggregate sensor\n"
+            "    return power.ev_power\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits
+        assert all(_is_annotated(lines, h[0]) for h in hits)


### PR DESCRIPTION
## Summary

Second of three planned multi-charger cleanup releases (v1.6.7 → v1.6.9). **Zero behaviour change** for single-charger users; multi-charger users get correctness fixes for 12 fleet-power-sum reads in per-charger code paths + structural enforcement against the bug class.

## Why

Between v1.6.0 and v1.6.6 we shipped four hotfixes for variants of the same bug class (#284, #289, #315, #318) — each one a `power.ev_power` fleet-sum read in a per-charger code path. Each fix added the `_this_charger_power` helper to one site. This release sweeps the remaining 12 sites and adds an AST lint test that fails CI on any new fleet-sum reads going forward.

## Changes

| File | Reads converted | Notes |
|---|---|---|
| `coordinator/ev_control.py::_execute_ev_control` | 8 | Night branch (KEBA-resume, peak-managed current, disable-delay) + solar branch (session gate, logs) |
| `coordinator/ev_control.py::_should_reenable_charger` | 3 | Stall detection was silently broken for multi-charger — couldn't fire for charger B while A was drawing |
| `coordinator/ev_control.py::_update_session_tracking` | 1 | Session-start detection used the swapped `self._ev_device` |
| `tests/test_ev_control_fleet_reads.py` | NEW | AST lint enforcing `# FLEET-READ:` annotation |
| `docs/MULTI_CHARGER.md` | extended | New "FLEET-READ annotation" subsection |

`# FLEET-READ:` annotation convention:
```python
# Right answer 99% of the time:
this_power_w = self._this_charger_power(ev, power)
if this_power_w > 100:
    ...

# Rare: genuinely fleet-level
# FLEET-READ: aggregating total EV draw for dashboard fleet card
fleet_ev_w = power.ev_power
```

## Verification

- **2177 tests pass** on Python 3.12 (2172 v1.6.7 baseline + 5 new AST lint tests).
- **Reviewer (ruflo-core:reviewer)**: OK-TO-SHIP with two NITs covering edge cases — both folded in.
- Confirmed via grep: zero remaining `power.ev_power` AST nodes outside `_this_charger_power`. All four textual matches are in docstrings/comments.

## Risk + rollback

Mechanical sweep — each replacement is semantically `this charger's power instead of fleet sum`, which is what every per-charger code path always needed. Single-charger users see no change because `_this_charger_power` falls back to `power.ev_power` when only one charger is configured. Rollback = revert the merge.

## Test plan

- [x] Full test suite (2177 / 7 skipped)
- [x] Reviewer pass
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] No release until v1.6.9 lands — bundled as one base