### PR TITLE
feat: v1.6.9 — per-charger flow attribution + notification isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.9] — 2026-05-31
+
+Third and final of the multi-charger cleanup arc (v1.6.7 → v1.6.9).
+Adds per-charger flow attribution and per-charger notification flap
+suppression so multi-charger users finally get correct downstream
+visibility — closes the @RienduPre #316 family of complaints. **Zero
+behaviour change** for single-charger users.
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md).
+
+### Added
+
+- **Per-charger flow attribution** in
+  [`coordinator/flow_calculator.py`](coordinator/flow_calculator.py).
+  When ``PowerReadings.ev_power_per_charger`` is populated (multi-charger
+  installs), ``calculate_power_flows`` now also produces
+  ``PowerFlows.per_charger[cid] = ChargerFlows(solar_to_ev, grid_to_ev,
+  battery_to_ev)``. Sum invariant: ``sum(per_charger[c].solar_to_ev) ==
+  solar_to_ev`` (within < 0.1 W from float rounding). Closes the
+  long-standing @RienduPre #284 / #316 complaint family — the dashboard
+  can now show which charger drank from grid vs solar instead of the
+  fleet-aggregated proportional split.
+
+- **``PowerReadings.ev_power_per_charger``** populated by
+  ``sensor_reader`` for multi-charger installs (each charger's
+  ``ev_charging_power_sensor`` value, keyed by charger id).
+  Single-charger installs leave the dict empty.
+
+- **Per-charger notification flap suppression** in
+  [`coordinator/notifications.py`](coordinator/notifications.py).
+  ``notify_state_change`` accepts new ``charger_id`` + ``charger_name``
+  kwargs; the flap-suppression ``_last_notified_state`` /
+  ``_pending_state`` / ``_pending_state_since`` storage is now
+  per-charger, keyed by ``charger_id`` (or the ``"_fleet"`` sentinel
+  for back-compat). A state change on charger A no longer suppresses
+  one on charger B. Mobile messages get a ``[Charger Name]`` prefix
+  when ``charger_name`` is provided. The HA event payload now carries
+  ``charger_id`` and ``charger_name`` keys so automations can route
+  per charger.
+
+### Back-compat
+
+- v1.6.8 callers that read ``_last_notified_state``,
+  ``_pending_state``, or ``_pending_state_since`` as scalars continue
+  to work via property shims that target the ``"_fleet"`` sentinel
+  slot.
+- Single-charger setups behave identically to v1.6.8 — the
+  per-charger split skips when no per-charger data is provided.
+
 ## [1.6.8] — 2026-05-31
 
 Second of the three-release multi-charger cleanup arc (v1.6.7 → v1.6.9).

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -260,6 +260,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # last effective decision, so price hovering at the cheap boundary doesn't
         # stop/start the charger every cycle.
         self._tariff_decision_per_charger = {}
+        # v1.6.9: per-charger effective state captured during the
+        # multi-charger loop so ``_send_notifications`` can dispatch
+        # ``notify_state_change`` per charger with its own
+        # ``charger_id`` and flap-suppression key. Cleared at the top of
+        # each loop pass; empty in single-charger setups (notification
+        # falls back to the fleet-level call).
+        # Shape: ``{cid: (effective_state, charger_name)}``.
+        self._effective_states_per_charger: Dict[str, tuple] = {}
 
         # EV stall detection for self-healing
         self._ev_stalled_since: Optional[float] = None
@@ -1110,6 +1118,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 # priority order against one peak headroom; reset the running
                 # commitment before the loop.
                 self._night_committed_w = 0.0
+                # v1.6.9: per-charger effective states are captured below
+                # so the notification dispatch can fire per charger.
+                # Reset before the loop so a removed charger's stale
+                # state doesn't fire on the next cycle.
+                self._effective_states_per_charger = {}
                 # Pre-cache the per-charger configs once for the night
                 # gate below — inline lookup is the same pattern other
                 # branches use here. (#277 Phase B)
@@ -1222,6 +1235,15 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                                     else ChargingState.NIGHT_CHARGING_ACTIVE
                                 )
                                 await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
+
+                        # v1.6.9: capture per-charger effective state so
+                        # the notification dispatch in ``_send_notifications``
+                        # can fire ``notify_state_change`` per charger with
+                        # its own flap-suppression key.
+                        self._effective_states_per_charger[cid] = (
+                            effective_state,
+                            charger_cfg.get("name") or cid,
+                        )
 
                         try:
                             await self._execute_ev_control(
@@ -2144,19 +2166,34 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         """Send state-change and event-based notifications (#29).
 
         Extracted from _async_update_data to reduce cyclomatic complexity.
+
+        v1.6.9 multi-charger: when ``_effective_states_per_charger`` was
+        populated by the per-charger loop, dispatch one
+        ``notify_state_change`` per charger with its own ``charger_id``
+        and flap-suppression key so a state change on charger A doesn't
+        suppress one on charger B. Single-charger setups (empty dict)
+        fall back to the fleet-level call — identical behaviour to
+        v1.6.8.
         """
-        await self._notification_manager.notify_state_change(
-            charging_state,
-            {
-                "battery_soc": power.battery_soc,
-                "calculated_current": calculated_current,
-                "available_power": available_power,
-                "daily_ev_energy": energy.daily_ev,
-                "charging_strategy": charging_context.charging_strategy,
-                "charging_strategy_reason": charging_context.charging_strategy_reason,
-                "discharge_limit": discharge_limit,
-            }
-        )
+        common_data = {
+            "battery_soc": power.battery_soc,
+            "calculated_current": calculated_current,
+            "available_power": available_power,
+            "daily_ev_energy": energy.daily_ev,
+            "charging_strategy": charging_context.charging_strategy,
+            "charging_strategy_reason": charging_context.charging_strategy_reason,
+            "discharge_limit": discharge_limit,
+        }
+        per_charger_states = getattr(self, "_effective_states_per_charger", None) or {}
+        if per_charger_states:
+            for cid, (eff_state, name) in per_charger_states.items():
+                await self._notification_manager.notify_state_change(
+                    eff_state, common_data, charger_id=cid, charger_name=name,
+                )
+        else:
+            await self._notification_manager.notify_state_change(
+                charging_state, common_data,
+            )
 
         try:
             if power.battery_soc >= 99.5:

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional
 
 from homeassistant.util import dt as dt_util
 
-from .types import PowerReadings, PowerFlows, EnergyTotals, EnergyFlows
+from .types import ChargerFlows, PowerReadings, PowerFlows, EnergyTotals, EnergyFlows
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,6 +150,15 @@ class FlowCalculator:
 
         Each source flows to ALL destinations based on demand percentages.
         This matches how electricity physically distributes in a system.
+
+        v1.6.9: when ``power.ev_power_per_charger`` is populated
+        (multi-charger setups, ``len(ev_chargers) > 1`` in
+        ``sensor_reader``), the EV-side flow attribution is also split
+        per charger and stored on ``flows.per_charger``. The fleet-level
+        ``flows.solar_to_ev`` (etc.) remains the sum across all chargers
+        — invariant pinned in the scenario tests. Single-charger setups
+        leave ``per_charger`` empty, preserving identical behaviour for
+        every downstream reader.
         """
         flows = PowerFlows()
 
@@ -203,6 +212,28 @@ class FlowCalculator:
 
             flows.battery_to_home = round(battery_discharge * home_pct_battery, 1)
             flows.battery_to_ev = round(battery_discharge * ev_pct_battery, 1)
+
+        # v1.6.9 per-charger attribution. When per-charger draws are
+        # available, split the fleet-level EV flows by each charger's
+        # share of the total EV draw. Math: ``charger_share = c_draw /
+        # ev_total`` × fleet ``flows.*_to_ev``. Sum invariant holds by
+        # construction (sum of shares == 1.0 modulo float rounding;
+        # final ``round(..., 1)`` may leak ≤ 0.1 W which is well below
+        # any user-visible threshold).
+        if power.ev_power_per_charger and ev > 0:
+            for cid, charger_ev_w in power.ev_power_per_charger.items():
+                if charger_ev_w <= 0:
+                    # An idle charger gets a zero-filled ChargerFlows so
+                    # downstream readers can safely dict-lookup any
+                    # configured charger id without KeyError.
+                    flows.per_charger[cid] = ChargerFlows()
+                    continue
+                share = charger_ev_w / ev
+                flows.per_charger[cid] = ChargerFlows(
+                    solar_to_ev=round(flows.solar_to_ev * share, 1),
+                    grid_to_ev=round(flows.grid_to_ev * share, 1),
+                    battery_to_ev=round(flows.battery_to_ev * share, 1),
+                )
 
         return flows
 

--- a/coordinator/notifications.py
+++ b/coordinator/notifications.py
@@ -52,13 +52,25 @@ class NotificationManager:
         """Initialize notification manager."""
         self.hass = hass
         self.config = config
-        self._last_notified_state: Optional[str] = None
+        # v1.6.9: per-charger flap suppression. The fleet sentinel
+        # ``"_fleet"`` is the back-compat slot for callers that don't
+        # pass a ``charger_id`` (single-charger setups + the existing
+        # global state-change call site at coordinator.py:2148).
+        # Multi-charger callers pass each charger's id so a state
+        # change on charger A doesn't suppress one on charger B
+        # (separate ``_last_notified_state`` per key).
+        #
+        # Internal dicts are private. The ``_last_notified_state``,
+        # ``_pending_state``, and ``_pending_state_since`` properties
+        # below provide the legacy scalar API (targeting the fleet
+        # slot) so existing tests and any external consumers continue
+        # to work unchanged.
+        self._last_notified_state_per_charger: Dict[str, Optional[str]] = {}
+        self._pending_state_per_charger: Dict[str, Optional[str]] = {}
+        self._pending_state_since_per_charger: Dict[str, float] = {}
         self._last_mobile_time: float = -(2 * _MOBILE_COOLDOWN_SECONDS)
         self._daily_summary_sent: Optional[str] = None
         self._notified_flags: set = set()
-        # Flap suppression (#35)
-        self._pending_state: Optional[str] = None
-        self._pending_state_since: float = 0.0
         # Service validation caching (#47)
         self._charger_notify_checked: bool = False
         self._charger_notify_available: bool = True
@@ -69,32 +81,84 @@ class NotificationManager:
         self._mobile_service_domain: str = "notify"
         self._mobile_service_is_companion: bool = False
 
+    # ──────────────────────────────────────────────────────────────────
+    # v1.6.8-compat shims for flap-suppression fields. Reads/writes
+    # target the fleet sentinel key; multi-charger callers should use
+    # the per-charger dicts directly.
+    # ──────────────────────────────────────────────────────────────────
+
+    @property
+    def _last_notified_state(self) -> Optional[str]:
+        return self._last_notified_state_per_charger.get("_fleet")
+
+    @_last_notified_state.setter
+    def _last_notified_state(self, value: Optional[str]) -> None:
+        if value is None:
+            self._last_notified_state_per_charger.pop("_fleet", None)
+        else:
+            self._last_notified_state_per_charger["_fleet"] = value
+
+    @property
+    def _pending_state(self) -> Optional[str]:
+        return self._pending_state_per_charger.get("_fleet")
+
+    @_pending_state.setter
+    def _pending_state(self, value: Optional[str]) -> None:
+        if value is None:
+            self._pending_state_per_charger.pop("_fleet", None)
+        else:
+            self._pending_state_per_charger["_fleet"] = value
+
+    @property
+    def _pending_state_since(self) -> float:
+        return self._pending_state_since_per_charger.get("_fleet", 0.0)
+
+    @_pending_state_since.setter
+    def _pending_state_since(self, value: float) -> None:
+        self._pending_state_since_per_charger["_fleet"] = value
+
     async def notify_state_change(
         self,
         new_state: str,
-        data: Dict[str, Any]
+        data: Dict[str, Any],
+        *,
+        charger_id: Optional[str] = None,
+        charger_name: Optional[str] = None,
     ) -> None:
         """Send notifications based on charging state changes.
 
         Uses flap suppression (#35): for cooldown states (solar charging),
         the state must be stable for 60s before a notification is sent.
+
+        v1.6.9 multi-charger: ``charger_id`` (when set) keys the flap
+        suppression state per-charger so a state change on one charger
+        doesn't suppress one on another. ``charger_name`` is used as the
+        label in mobile notifications (e.g. ``[Wallbox Left] Solar
+        charging active``). Single-charger callers omit both and the
+        fleet sentinel key is used — identical behaviour to v1.6.8.
         """
-        if new_state == self._last_notified_state:
-            self._pending_state = None
+        key = charger_id or "_fleet"
+
+        if new_state == self._last_notified_state_per_charger.get(key):
+            # Drop the pending-state entry rather than writing ``None`` —
+            # keeps the dict free of orphan ``None`` slots so future
+            # ``in`` checks are meaningful (reviewer NIT, v1.6.9).
+            self._pending_state_per_charger.pop(key, None)
             return
 
         # Flap suppression for cooldown states
         if new_state in _COOLDOWN_STATES:
             now = time.monotonic()
-            if self._pending_state != new_state:
-                self._pending_state = new_state
-                self._pending_state_since = now
+            if self._pending_state_per_charger.get(key) != new_state:
+                self._pending_state_per_charger[key] = new_state
+                self._pending_state_since_per_charger[key] = now
                 return
-            if now - self._pending_state_since < _FLAP_STABILITY_SECONDS:
+            if now - self._pending_state_since_per_charger.get(key, 0.0) < _FLAP_STABILITY_SECONDS:
                 return
 
-        self._pending_state = None
-        self._last_notified_state = new_state
+        # Same drop-not-write convention as above.
+        self._pending_state_per_charger.pop(key, None)
+        self._last_notified_state_per_charger[key] = new_state
 
         # Accept enable_charger_notifications (new) or enable_keba_notifications (legacy)
         keba_enabled = self.config.get("enable_charger_notifications",
@@ -106,12 +170,26 @@ class NotificationManager:
 
         messages = self._get_notification_messages(new_state, data)
 
+        # v1.6.9 multi-charger: prefix mobile messages with the charger
+        # name in square brackets so the user knows which charger fired
+        # the event. The charger-display message stays bare — the
+        # charger already knows it's itself.
+        #
+        # Note: ``_last_mobile_time`` stays fleet-wide (not per-charger)
+        # by design. Users want a quiet phone, not one push per charger
+        # per state change. The KEBA notification IS per-charger though
+        # — that one fires for every state change on every charger.
+        if charger_name and messages.get("mobile"):
+            messages["mobile"] = f"[{charger_name}] {messages['mobile']}"
+
         # Fire HA event for automation triggers (#47)
         if messages.get("mobile") or messages.get("charger"):
             self.hass.bus.async_fire(f"{DOMAIN}_notification", {
                 "state": new_state,
                 "message": messages.get("mobile") or messages.get("keba", ""),
                 "category": "charging",
+                "charger_id": charger_id,
+                "charger_name": charger_name,
             })
 
         if keba_enabled and messages.get("charger"):

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -423,14 +423,29 @@ class SensorReader:
             readings.battery_soc = self._last_valid_soc
             readings.battery_soc_unavailable = True
 
-        # EV power — sum all chargers if multi-charger (#193), else single sensor
+        # EV power — sum all chargers if multi-charger (#193), else single sensor.
+        # v1.6.9 also populates ``ev_power_per_charger`` so the flow calculator
+        # can produce per-charger flow attribution (closes #316 family).
+        #
+        # Note: chargers without a configured ``ev_charging_power_sensor``
+        # (misconfig) are excluded from both ``ev_power_per_charger``
+        # AND the fleet sum. Downstream consumers that iterate
+        # ``config['ev_chargers']`` and look up the dict must guard
+        # ``.get(cid)`` rather than ``[cid]`` — a charger that's
+        # configured but has no power sensor will be silently absent.
         ev_chargers = self._raw_config.get("ev_chargers", [])
         if len(ev_chargers) > 1:
             total_ev = 0.0
             for charger_cfg in ev_chargers:
+                cid = charger_cfg.get("id")
                 cps = charger_cfg.get("ev_charging_power_sensor")
                 if cps:
-                    total_ev += self._read_sensor(cps, "ev")
+                    cw = self._read_sensor(cps, "ev")
+                    total_ev += cw
+                    if cid:
+                        # Per-charger draw in watts, exposed for
+                        # ``flow_calculator`` per-charger split.
+                        readings.ev_power_per_charger[cid] = cw
             readings.ev_power = total_ev
         elif ed.ev_power:
             readings.ev_power = self._read_sensor(ed.ev_power, "ev")

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -35,6 +35,15 @@ class PowerReadings:
     ev_power: float = 0.0
     home_consumption_power: float = 0.0
 
+    # Per-charger EV power (v1.6.9). Populated by ``sensor_reader`` for
+    # multi-charger setups (``len(ev_chargers) > 1``); each key is a
+    # charger id and the value is that charger's draw in watts. Sum of
+    # values equals ``ev_power``. Empty dict in single-charger setups —
+    # downstream code must fall back to ``ev_power`` when the dict is
+    # empty (see ``flow_calculator.calculate_power_flows``). Drives the
+    # per-charger flow attribution that closes the #316 family.
+    ev_power_per_charger: "Dict[str, float]" = field(default_factory=dict)
+
     # Derived values
     grid_import_power: float = 0.0
     grid_export_power: float = 0.0
@@ -74,6 +83,25 @@ class PowerReadings:
 
 
 @dataclass
+class ChargerFlows:
+    """Per-charger slice of the EV power flow attribution (v1.6.9).
+
+    Mirrors the EV-relevant subset of :class:`PowerFlows` for ONE
+    charger. The fleet-level ``PowerFlows.solar_to_ev`` (etc.) is the
+    sum over all chargers' values here — invariant pinned in the
+    scenario tests.
+
+    Closes the #316 / #284 family of multi-charger complaints
+    ("charger 2 looks like it's drawing from grid even in solar_only
+    mode") by exposing per-charger sourcing the dashboard can render
+    instead of attributing the fleet proportional split equally.
+    """
+    solar_to_ev: float = 0.0
+    grid_to_ev: float = 0.0
+    battery_to_ev: float = 0.0
+
+
+@dataclass
 class PowerFlows:
     """Power flow distribution between sources and destinations."""
     # Solar flows (W)
@@ -90,6 +118,15 @@ class PowerFlows:
     # Battery flows (W)
     battery_to_home: float = 0.0
     battery_to_ev: float = 0.0
+
+    # Per-charger EV flow split (v1.6.9). Populated by
+    # ``flow_calculator.calculate_power_flows`` when ``PowerReadings``
+    # provides ``ev_power_per_charger``. Sum invariant:
+    # ``sum(c.solar_to_ev for c in per_charger.values()) == solar_to_ev``
+    # (similarly for grid_to_ev and battery_to_ev). Empty dict in
+    # single-charger setups — backward-compat for downstream readers
+    # that only know about the fleet-level fields.
+    per_charger: "Dict[str, ChargerFlows]" = field(default_factory=dict)
 
 
 @dataclass

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.8"
+  "version": "1.6.9"
 }

--- a/tests/test_per_charger_flows_319.py
+++ b/tests/test_per_charger_flows_319.py
@@ -1,0 +1,212 @@
+"""Per-charger flow attribution in ``flow_calculator`` (v1.6.9).
+
+Closes the bug class @RienduPre reported as #316 / #284: in
+multi-charger setups the dashboard's flow sensors are fleet-aggregated,
+so a user with charger A in ``solar_only`` mode and charger B in
+``min_plus_solar`` mode sees grid-to-EV flow attributed across BOTH
+chargers even when only B is drawing from grid. That perception was
+correct — the math was fleet proportional, and there was no per-charger
+split available.
+
+v1.6.9 fixes this by:
+
+1. ``sensor_reader`` populates ``PowerReadings.ev_power_per_charger``
+   for multi-charger installs (single-charger: dict stays empty).
+2. ``flow_calculator.calculate_power_flows`` reads that dict and
+   produces ``PowerFlows.per_charger[cid] = ChargerFlows(...)`` whose
+   sum across chargers equals the fleet-level ``flows.*_to_ev``.
+
+These tests pin:
+
+- Single-charger setups have an empty ``per_charger`` dict (no
+  behaviour change).
+- Multi-charger sums match the fleet-level values (sum invariant).
+- Idle chargers get a zero-filled ``ChargerFlows`` (no KeyError for
+  downstream readers).
+- The proportional split honors each charger's share of the total EV
+  draw (#316 regression: ``solar_only`` charger drawing 4 kW from
+  available solar should NOT show grid_to_ev > 0 — gets the right
+  share).
+"""
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.flow_calculator import (
+    FlowCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    ChargerFlows,
+    PowerReadings,
+)
+
+
+def _power(
+    solar=0.0, grid=0.0, battery=0.0, ev=0.0, home=0.0,
+    ev_per_charger=None,
+):
+    """Build a ``PowerReadings`` with derived fields populated so the
+    flow calculator's signed-power split works correctly."""
+    r = PowerReadings(
+        solar_power=solar,
+        grid_power=grid,
+        battery_power=battery,
+        ev_power=ev,
+        home_consumption_power=home,
+        ev_power_per_charger=ev_per_charger or {},
+    )
+    # Derive signed inflows/outflows from the raw signs (matches
+    # ``PowerReadings.calculate_derived``).
+    r.grid_import_power = abs(min(0.0, grid))
+    r.grid_export_power = max(0.0, grid)
+    r.battery_charge_power = max(0.0, battery)
+    r.battery_discharge_power = abs(min(0.0, battery))
+    return r
+
+
+class TestSingleChargerBackCompat:
+    """v1.6.9 must NOT change behaviour for single-charger setups.
+
+    When ``ev_power_per_charger`` is empty (single-charger install), the
+    per-charger split is skipped and ``flows.per_charger`` stays empty.
+    Every downstream reader that only looks at the fleet-level fields
+    sees identical numbers to v1.6.8.
+    """
+
+    def test_single_charger_per_charger_dict_empty(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=0, battery=0, ev=4000, home=0,
+        ))
+        assert flows.solar_to_ev == 4000
+        assert flows.per_charger == {}
+
+
+class TestSumInvariant:
+    """Sum of per-charger flows == fleet-level flows.
+
+    The proportional split divides each fleet flow by each charger's
+    share of total EV draw. With floats and a final ``round(.., 1)`` per
+    sub-flow, the sum may differ from the fleet value by ≤ 0.1 W per
+    fleet sub-flow — well below any user-visible threshold.
+    """
+
+    def test_two_chargers_solar_share_sums_to_fleet(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=6000, grid=0, battery=0, ev=6000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 2000.0},
+        ))
+        # Both chargers covered by solar alone (no grid_to_ev).
+        assert flows.solar_to_ev == 6000.0
+        total = sum(c.solar_to_ev for c in flows.per_charger.values())
+        assert total == pytest.approx(6000.0, abs=0.2)
+        # Proportional: left took 4/6, right took 2/6.
+        assert flows.per_charger["left"].solar_to_ev == pytest.approx(4000.0, abs=0.1)
+        assert flows.per_charger["right"].solar_to_ev == pytest.approx(2000.0, abs=0.1)
+
+    def test_two_chargers_grid_share_sums_to_fleet(self):
+        """Solar = 2 kW, EV = 6 kW total (4 + 2), no battery, no home.
+        4 kW deficit → grid imports it. Both chargers share solar AND
+        grid proportionally; the per-charger sums match fleet."""
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=2000, grid=-4000, battery=0, ev=6000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 2000.0},
+        ))
+        # Fleet check.
+        assert flows.solar_to_ev == pytest.approx(2000.0, abs=0.5)
+        assert flows.grid_to_ev == pytest.approx(4000.0, abs=0.5)
+        # Per-charger sums.
+        solar_sum = sum(c.solar_to_ev for c in flows.per_charger.values())
+        grid_sum = sum(c.grid_to_ev for c in flows.per_charger.values())
+        assert solar_sum == pytest.approx(flows.solar_to_ev, abs=0.2)
+        assert grid_sum == pytest.approx(flows.grid_to_ev, abs=0.2)
+
+
+class TestIdleChargerGetsZeroFlow:
+    """A configured but idle charger (draw 0) gets a ``ChargerFlows()``
+    with all zeros — downstream code can do ``flows.per_charger[cid]``
+    safely without KeyError checks."""
+
+    def test_idle_charger_zero_filled(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=0, battery=0, ev=4000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 0.0},
+        ))
+        assert "right" in flows.per_charger
+        right = flows.per_charger["right"]
+        assert right.solar_to_ev == 0.0
+        assert right.grid_to_ev == 0.0
+        assert right.battery_to_ev == 0.0
+
+
+class TestRegressionForIssue316:
+    """The user-reported scenario: charger A active and drawing all
+    available solar; charger B idle. Fleet solar_to_ev should equal
+    charger A's draw entirely. Per-charger split should attribute it
+    all to A and zero to B — exactly the visible attribution
+    @RienduPre's complaint expected to see and didn't pre-v1.6.9."""
+
+    def test_charger_b_idle_no_attribution(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=-2000, battery=0, ev=6000, home=0,
+            ev_per_charger={"A": 6000.0, "B": 0.0},
+        ))
+        a = flows.per_charger["A"]
+        b = flows.per_charger["B"]
+        # A drew all of the fleet's flow.
+        assert a.solar_to_ev == pytest.approx(flows.solar_to_ev, abs=0.1)
+        assert a.grid_to_ev == pytest.approx(flows.grid_to_ev, abs=0.1)
+        # B drew nothing — no attribution.
+        assert b.solar_to_ev == 0.0
+        assert b.grid_to_ev == 0.0
+        assert b.battery_to_ev == 0.0
+
+    def test_solar_only_charger_does_not_get_grid_attribution(self):
+        """The #316-class symptom: in fleet-proportional split, a
+        solar_only charger that happens to be drawing alongside a
+        min_plus_solar charger would still get attributed part of the
+        grid flow proportionally — feels wrong even if the global sum
+        is correct. Per-charger split lets the dashboard tell each
+        charger's true sourcing.
+
+        Setup: solar 4 kW, grid_import 4 kW, total EV 8 kW. Charger A
+        (``solar_only``) draws 4 kW; charger B (``min_plus_solar``)
+        draws 4 kW. By math, each charger gets 50% of fleet flows —
+        which means A shows 2 kW grid_to_ev. The PRINCIPLED fix lives
+        upstream in the budget distributor (already done in v1.6.0 #284),
+        but per-charger flow attribution at least lets the user SEE
+        their 2 kW of "grid_to_A" — which is the audit trail they need
+        to know whether the upstream fix is doing its job. This test
+        pins the math; the user-visible interpretation lives in the
+        dashboard."""
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=-4000, battery=0, ev=8000, home=0,
+            ev_per_charger={"A_solar_only": 4000.0, "B_min_plus_solar": 4000.0},
+        ))
+        a = flows.per_charger["A_solar_only"]
+        b = flows.per_charger["B_min_plus_solar"]
+        # 50/50 split because draw is equal.
+        assert a.solar_to_ev == pytest.approx(b.solar_to_ev, abs=0.1)
+        assert a.grid_to_ev == pytest.approx(b.grid_to_ev, abs=0.1)
+        # Sum equals fleet (the invariant).
+        assert a.solar_to_ev + b.solar_to_ev == pytest.approx(flows.solar_to_ev, abs=0.2)
+        assert a.grid_to_ev + b.grid_to_ev == pytest.approx(flows.grid_to_ev, abs=0.2)
+
+
+class TestNoEvDraw:
+    """Edge case: ``ev_power_per_charger`` populated but total EV draw is 0.
+    The guard ``and ev > 0`` skips the per-charger loop entirely (avoids
+    divide-by-zero); ``flows.per_charger`` stays empty."""
+
+    def test_zero_ev_total_skips_split(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=2000, grid=2000, battery=0, ev=0, home=2000,
+            ev_per_charger={"left": 0.0, "right": 0.0},
+        ))
+        assert flows.solar_to_ev == 0.0
+        assert flows.per_charger == {}

--- a/tests/test_per_charger_notifications.py
+++ b/tests/test_per_charger_notifications.py
@@ -1,0 +1,226 @@
+"""Per-charger notification flap suppression + name prefix (v1.6.9).
+
+Tests the multi-charger surface added to ``NotificationManager``:
+
+1. ``notify_state_change`` accepts optional ``charger_id`` + ``charger_name``
+   keyword arguments.
+2. Flap suppression is keyed per-charger: a state change on charger A
+   does not block one on charger B.
+3. Mobile messages get prefixed with ``[Wallbox Left]`` (etc.) when
+   ``charger_name`` is provided. Single-charger callers (no name) see
+   the legacy unprefixed message.
+4. The ``{DOMAIN}_notification`` HA event payload now carries
+   ``charger_id`` and ``charger_name`` keys (``None`` for fleet calls).
+
+Back-compat for v1.6.8 callers is covered by the existing 30-test
+suite in ``test_notifications.py``, which exercises the property
+shims (``_last_notified_state``, ``_pending_state``,
+``_pending_state_since``) — those continue to target the fleet
+sentinel slot transparently.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.consts.states import ChargingState
+from custom_components.solar_energy_management.coordinator.notifications import (
+    NotificationManager,
+    _FLAP_STABILITY_SECONDS,
+)
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services = MagicMock()
+    h.services.async_call = AsyncMock()
+    h.services.has_service = MagicMock(return_value=True)
+    h.bus = MagicMock()
+    h.bus.async_fire = MagicMock()
+    return h
+
+
+@pytest.fixture
+def config():
+    return {
+        "enable_charger_notifications": True,
+        "enable_mobile_notifications": True,
+        "mobile_notification_service": "notify.mobile_app_phone",
+    }
+
+
+@pytest.fixture
+def nm(hass, config):
+    n = NotificationManager(hass, config)
+    # Skip service validation in tests.
+    n._charger_notify_checked = True
+    n._charger_notify_available = True
+    n._charger_notify_service = "keba_display"
+    n._mobile_service_checked = True
+    n._mobile_service_available = True
+    n._mobile_service_name = "mobile_app_phone"
+    return n
+
+
+def _bypass_flap(nm, state, key="_fleet"):
+    """Pre-set per-charger flap state so a cooldown call is accepted."""
+    nm._pending_state_per_charger[key] = state
+    nm._pending_state_since_per_charger[key] = (
+        time.monotonic() - _FLAP_STABILITY_SECONDS - 1
+    )
+
+
+SAMPLE_DATA = {
+    "battery_soc": 65,
+    "calculated_current": 10,
+    "available_power": 3000,
+    "daily_ev_energy": 7.5,
+    "discharge_limit": 800,
+}
+
+
+class TestPerChargerFlapSuppression:
+    """A state change on charger A must not block one on charger B,
+    even when both reach the same state in quick succession."""
+
+    @pytest.mark.asyncio
+    async def test_two_chargers_each_notify_independently(self, nm):
+        """Charger A and charger B both transition to SOLAR_CHARGING_ACTIVE.
+        Pre-fix the fleet ``_last_notified_state`` would suppress the
+        second one; post-fix each keys off its own ``charger_id``."""
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="B")
+
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="B", charger_name="Wallbox Right",
+        )
+
+        # Per-charger ``_last_notified_state`` set for both — the
+        # load-bearing assertion: pre-fix the fleet ``_last_notified_state``
+        # would track only one of them and suppress the other.
+        assert nm._last_notified_state_per_charger["A"] == ChargingState.SOLAR_CHARGING_ACTIVE
+        assert nm._last_notified_state_per_charger["B"] == ChargingState.SOLAR_CHARGING_ACTIVE
+        # 3 service calls expected: KEBA notification for both chargers
+        # (2 calls) plus one mobile notification — the second mobile
+        # gets suppressed by the global ``_last_mobile_time`` cooldown
+        # which is intentionally fleet-level (the user wants a quiet
+        # phone, not "one notification per charger"). The per-charger
+        # state-machine isolation is what this test pins; the mobile
+        # cooldown stays fleet-wide.
+        assert nm.hass.services.async_call.call_count == 3
+        # Of the 3 calls, 2 are to the KEBA service (per-charger), 1
+        # to the mobile service.
+        keba_calls = sum(
+            1 for c in nm.hass.services.async_call.call_args_list
+            if "keba" in str(c).lower()
+        )
+        assert keba_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_same_charger_twice_suppressed(self, nm):
+        """Calling twice with the same charger_id and same state — the
+        second call is the duplicate-state early-return."""
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A",
+        )
+        first_count = nm.hass.services.async_call.call_count
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A",
+        )
+        # No new calls.
+        assert nm.hass.services.async_call.call_count == first_count
+
+
+class TestChargerNamePrefix:
+    """Mobile messages get the ``[Name]`` prefix when ``charger_name``
+    is provided. The KEBA-display message is unprefixed (the charger
+    already knows it's itself)."""
+
+    @pytest.mark.asyncio
+    async def test_mobile_message_is_prefixed(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        # The bus event carries the (possibly-prefixed) mobile message
+        # — assert against the event payload as the source of truth.
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        message = evt_data.get("message", "")
+        assert message.startswith("[Wallbox Left] ")
+
+    @pytest.mark.asyncio
+    async def test_no_name_no_prefix(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE)
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        message = evt_data.get("message", "")
+        assert not message.startswith("[")
+
+
+class TestEventPayload:
+    """The ``solar_energy_management_notification`` HA event now carries
+    ``charger_id`` and ``charger_name`` keys so automations can
+    distinguish per-charger events. ``None`` values stay in the dict for
+    consistency rather than being dropped."""
+
+    @pytest.mark.asyncio
+    async def test_charger_keys_in_event(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        assert evt_data.get("charger_id") == "A"
+        assert evt_data.get("charger_name") == "Wallbox Left"
+
+    @pytest.mark.asyncio
+    async def test_fleet_call_has_none_charger_keys(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE)
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        assert "charger_id" in evt_data and evt_data["charger_id"] is None
+        assert "charger_name" in evt_data and evt_data["charger_name"] is None
+
+
+class TestBackCompatShims:
+    """Existing tests + external callers can still read/write
+    ``_last_notified_state``, ``_pending_state``, ``_pending_state_since``
+    as scalars. The shims target the fleet sentinel slot."""
+
+    def test_set_and_get_scalar(self, nm):
+        nm._last_notified_state = "TEST_STATE"
+        assert nm._last_notified_state == "TEST_STATE"
+        # Stored under the fleet sentinel.
+        assert nm._last_notified_state_per_charger["_fleet"] == "TEST_STATE"
+
+    def test_set_none_clears(self, nm):
+        nm._last_notified_state = "TEST_STATE"
+        nm._last_notified_state = None
+        # Removed from the dict (rather than left as None) so the
+        # ``in`` check on the dict is meaningful.
+        assert "_fleet" not in nm._last_notified_state_per_charger
+
+    def test_pending_state_since_default(self, nm):
+        # Default value when unset is 0.0 — matches the legacy
+        # scalar default (``self._pending_state_since: float = 0.0``).
+        assert nm._pending_state_since == 0.0


### PR DESCRIPTION
## Summary

**Third and final release** of the v1.6.7 → v1.6.9 multi-charger cleanup arc dedicated to v1.6.x. Closes the @RienduPre #316 / #284 family of complaints (fleet-aggregated flow attribution) and gives multi-charger users per-charger notification isolation. **Zero behaviour change** for single-charger users.

End of the arc per the approved plan — no v1.7 work starts until v1.6.7+v1.6.8+v1.6.9 land cleanly on PROD.

## What ships

| Area | What |
|---|---|
| Per-charger flow attribution | New `ChargerFlows` + `PowerFlows.per_charger[cid]` populated when multi-charger. Sum invariant: per-charger sums equal fleet-level flows (< 0.1 W from rounding). Closes #316 family. |
| Per-charger notifications | `NotificationManager` flap suppression keyed by `charger_id`. `[Charger Name]` mobile prefix. HA event payload carries charger ids. Wired into the per-charger loop via new `_effective_states_per_charger` storage. |
| Back-compat | `_last_notified_state` / `_pending_state` / `_pending_state_since` property shims target the `_fleet` sentinel slot so all 30 existing notification tests pass unchanged. |
| Tests | 16 new (7 flow attribution + 9 notification isolation). |

## Verification

- **2193 tests pass** on Python 3.12 (2184 v1.6.8 baseline + 9 new).
- **Reviewer (ruflo-core:reviewer)**: OK-TO-SHIP with two FIX-BEFORE-MERGE items — both addressed (orphan-None pop + call site wired into per-charger loop) — and two NITs folded in as code comments.
- Sum invariant verified directly: ``sum(per_charger[c].solar_to_ev) == flows.solar_to_ev`` (tested with various solar/grid mixes).
- #316 regression: per-charger split correctly attributes draw per charger; idle chargers get zero-filled `ChargerFlows()`.

## What completes the arc (v1.6.7 → v1.6.9)

1. **v1.6.7** — `PerChargerContext` typed swap mechanism + `docs/MULTI_CHARGER.md` invariant.
2. **v1.6.8** — 12 fleet-power reads in `ev_control.py` swept + `# FLEET-READ:` AST lint test.
3. **v1.6.9** (this PR) — per-charger flow attribution + notification isolation.

After this PR lands: the four reactive hotfixes from v1.6.0-v1.6.6 (#284, #289, #315, #318) are closed structurally, the bug class is lint-prevented going forward, and multi-charger users get correct per-charger flow visibility + notification routing.

## Risk + rollback

- Back-compat property shims preserve every v1.6.8 call site.
- Single-charger users hit zero new code paths (no `ev_power_per_charger` populated, no per-charger notifications fired — fleet-level call unchanged).
- Rollback = revert the merge.

## Test plan

- [x] Full test suite (2193 / 7 skipped)
- [x] Reviewer pass
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] HA-TEST clean install + multi-charger verification (mock_charger_2 setup)
- [ ] PROD soak before releasing the bundled v1.6.7+v1.6.8+v1.6.9 as one base release