### PR TITLE
cleanup: v1.6.10 — #308 + #309 + #310 code-quality follow-ups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.10] — 2026-05-31
+
+Code-quality cleanup release. Closes the three follow-up issues filed
+during the v1.6.4 → v1.6.6 review cycle (#308, #309, #310). **Zero
+behaviour change** for any user.
+
+### Refactored
+
+- **#308 — dead ``now`` / ``min_pv`` consumer branches dropped from
+  ``coordinator/charging_control.py``.** Post-#305 the strategy
+  producer ``_determine_charging_strategy`` only emits ``solar_only`` /
+  ``battery_assist`` / ``night_grid`` / ``idle`` / ``disabled`` —
+  neither ``"now"`` nor ``"min_pv"`` was reachable in production. The
+  unreachable branches are gone; ``ChargingState.SOLAR_MIN_PV`` is
+  still alive via the ``night_grid`` → ``EVBudgetStrategy.MIN_PV``
+  producer mapping. The two synthetic-context tests
+  (``test_min_pv_mode``, ``test_now_mode``) that exercised the dead
+  branches are removed.
+
+- **#309 — global-select cleanup block in ``select.py`` folded into
+  the registry-key sweep added by #304.** The 12-line explicit
+  ``async_remove`` block for ``{entry_id}_ev_target_type``,
+  ``{entry_id}_ev_target_mode``, ``{entry_id}_ev_charging_mode`` was
+  redundant with the sweep at the bottom of ``async_setup_entry``:
+  each of those unique IDs has the ``{entry_id}_`` prefix and a key
+  that's not in ``valid_keys``, so the sweep removes them just as
+  cleanly. Per-charger values were seeded from the globals by the
+  v3→v4 migration; no data is lost.
+
+- **#310 — gravestone comments in ``tests/test_soc_zone_strategy.py``
+  consolidated** into a single ``Removed tests`` block at the top of
+  the module. Three multi-line tombstones (one each from #277 Phase C,
+  Phase D.2 / #282, and #305) collapsed to a three-bullet list with
+  ``git log -S`` as the pointer for full history.
+
 ## [1.6.9] — 2026-05-31
 
 Third and final of the multi-charger cleanup arc (v1.6.7 → v1.6.9).

--- a/coordinator/charging_control.py
+++ b/coordinator/charging_control.py
@@ -59,9 +59,8 @@ class ChargingContext:
             SOLAR_IDLE → actuator stop_session(); ``"idle"`` is the
             transient pause (Zone 1, solar<200W, target met) which
             stays in CHARGING_ALLOWED (warm, waiting for surplus).
-            (The legacy ``"min_pv"`` value was retired in #305 — no
-            producer remains and the consuming branch at line 208 is
-            inert.)
+            The legacy ``"min_pv"`` + ``"now"`` values were retired
+            in #305 (producer) and #308 (consumer).
         charging_strategy_reason: Human-readable explanation of strategy choice.
         night_target_kwh: Night charging target (kWh), may be forecast-adjusted if enabled.
             For night mode, remaining is derived from this field directly.
@@ -224,13 +223,14 @@ class ChargingStateMachine:
         if ctx.soc_limit_active:
             return ChargingState.SOLAR_TARGET_REACHED
 
-        # Now mode: charge at max immediately
-        if ctx.charging_strategy == "now":
-            return ChargingState.SOLAR_MIN_PV  # Reuse Min+PV path (grid + surplus)
-
-        # Min+PV mode: guarantee minimum from grid, add solar surplus on top
-        if ctx.charging_strategy == "min_pv":
-            return ChargingState.SOLAR_MIN_PV
+        # The ``"now"`` and ``"min_pv"`` consumer branches were dropped in
+        # v1.6.10 (#308). Post-#305 the strategy producer
+        # ``_determine_charging_strategy`` only emits ``solar_only`` /
+        # ``battery_assist`` / ``night_grid`` / ``idle`` / ``disabled`` —
+        # neither ``"now"`` nor ``"min_pv"`` is reachable in production.
+        # ``ChargingState.SOLAR_MIN_PV`` is still alive via the
+        # ``night_grid`` → ``EVBudgetStrategy.MIN_PV`` mapping in the
+        # canonical-budget producer.
 
         # Daily target only limits night (grid) charging, not solar.
         # Solar surplus is free — always charge if available.

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.9"
+  "version": "1.6.10"
 }

--- a/select.py
+++ b/select.py
@@ -73,22 +73,15 @@ async def async_setup_entry(
     """Set up SEM select entities."""
     coordinator: SEMCoordinator = entry.runtime_data
 
-    # Remove the now-removed GLOBAL target-type select (#255): ev_target_type is
-    # per-charger only. Drop both the renamed global entity and its legacy
-    # ev_target_mode predecessor (#235) from the registry. Per-charger values were
-    # seeded from the global by the v3→v4 migration, so no data is lost.
-    try:
-        registry = er.async_get(hass)
-        for uid in (
-            f"{entry.entry_id}_ev_target_type", f"{entry.entry_id}_ev_target_mode",
-            f"{entry.entry_id}_ev_charging_mode",
-        ):
-            eid = registry.async_get_entity_id("select", DOMAIN, uid)
-            if eid:
-                registry.async_remove(eid)
-                _LOGGER.info("Removed global select %s (now per-charger, #255)", eid)
-    except Exception as e:
-        _LOGGER.debug("Global select removal skipped: %s", e)
+    # v1.6.10 (#309): the explicit removal block for the now-removed
+    # GLOBAL selects (``{entry_id}_ev_target_type``,
+    # ``{entry_id}_ev_target_mode``, ``{entry_id}_ev_charging_mode``)
+    # was folded into the registry-key sweep below. Each of those
+    # unique_ids has the prefix ``{entry_id}_`` and a key that is NOT
+    # in ``valid_keys = {SELECT_TYPES keys} | per_charger_keys``, so
+    # the sweep removes them just as cleanly. Per-charger values were
+    # seeded from the globals by the v3→v4 migration (#255), so no
+    # data is lost.
 
     entities = [
         SEMSelectEntity(coordinator, entry, description)

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -259,23 +259,13 @@ def test_solar_target_reached(sm):
     assert state == ChargingState.SOLAR_CHARGING_ALLOWED
 
 
-def test_min_pv_mode(sm):
-    """Pin the state-machine mapping for ``charging_strategy="min_pv"``.
-
-    Post-#305 the producer side (`_determine_charging_strategy` and
-    `_canonical_strategy_from_legacy`) no longer emits the legacy
-    ``"min_pv"`` string, so `charging_control.py:208` is unreachable
-    in production. This test still exercises that branch directly
-    via a synthetic context to keep the SOLAR_MIN_PV mapping pinned
-    in case a future producer is reintroduced. If both the producer
-    and the consumer are dropped together, delete this test too.
-    """
-    ctx = _ctx(
-        ev_connected=True,
-        charging_strategy="min_pv",
-    )
-    state = sm.update_state(ctx)
-    assert state == ChargingState.SOLAR_MIN_PV
+# ``test_min_pv_mode`` + ``test_now_mode`` removed in #308 (v1.6.10):
+# the producer side dropped these strategies in #305 (PR #311) and the
+# consumer branches in ``charging_control.py:228-233`` were the only
+# remaining reachers. With both dropped, the synthetic-context tests
+# no longer pin a live mapping; ``ChargingState.SOLAR_MIN_PV`` is
+# still alive via the ``night_grid`` → ``EVBudgetStrategy.MIN_PV``
+# producer mapping at ``coordinator.py:2345``.
 
 
 def test_battery_assist_mode(sm):
@@ -287,16 +277,6 @@ def test_battery_assist_mode(sm):
     )
     state = sm.update_state(ctx)
     assert state == ChargingState.SOLAR_SUPER_CHARGING
-
-
-def test_now_mode(sm):
-    """Test 'now' strategy uses SOLAR_MIN_PV path."""
-    ctx = _ctx(
-        ev_connected=True,
-        charging_strategy="now",
-    )
-    state = sm.update_state(ctx)
-    assert state == ChargingState.SOLAR_MIN_PV
 
 
 # ──────────────────────────────────────────────

--- a/tests/test_soc_zone_strategy.py
+++ b/tests/test_soc_zone_strategy.py
@@ -1,13 +1,21 @@
-"""Tests for SOC zone strategy: _determine_charging_strategy() (and historically also _calculate_solar_ev_budget, removed in Phase D.2 #282 — coverage moved to canonical EVBudget tests and scenario harness).
+"""Tests for SOC zone strategy: ``_determine_charging_strategy()``.
 
-Codified from real-world scenario on 2026-03-22 where battery drained to 20% SOC.
-Investigation confirmed zones held correctly: battery assist stopped at 70% (Zone 2 boundary),
-remaining drain was evening home consumption.
+Codified from a real-world scenario on 2026-03-22 where the battery
+drained to 20 % SOC. Investigation confirmed the zones held correctly:
+battery assist stopped at 70 % (Zone 2 boundary), remaining drain was
+evening home consumption.
 
 Real-world data:
   Solar: 36.65 kWh, Home: 29.98 kWh, EV: 15.52 kWh
   Battery charge: 13.55 kWh, discharge: 9.54 kWh → SOC ended at 20%
   PROD config: battery_priority_soc=90, buffer/auto_start/floor at defaults (70/90/60)
+
+Removed tests — for archaeology, see ``git log -S <name>`` in this file:
+  * ``test_charging_mode_minpv_returns_min_pv`` — #277 Phase C
+  * ``TestCalculateSolarEvBudget`` — Phase D.2 (#282), coverage moved
+    to canonical EVBudget tests + the scenario harness.
+  * ``TestAutoMode`` — #305 (``_auto_mode_strategy`` deleted as dead
+    code after Phase C).
 """
 import pytest
 from unittest.mock import MagicMock, patch
@@ -249,14 +257,6 @@ class TestDetermineChargingStrategy:
         )
         assert strategy == "disabled"
 
-    # ``test_charging_mode_minpv_returns_min_pv`` removed in #277 Phase C:
-    # the ``minpv`` legacy mode no longer dispatches to ``("min_pv", …)``
-    # from ``_determine_charging_strategy``. Per the maintainer's
-    # Phase C decision (Q1: zone-adaptive), legacy ``minpv`` users
-    # migrated to ``min_plus_solar`` get zone-adaptive day behaviour;
-    # the ``min_pv`` strategy value is now only reachable via the
-    # night-grid → MIN_PV canonical-budget mapping in
-    # ``_canonical_strategy_from_legacy``.
 
     def test_low_solar_returns_idle(self):
         """Solar < 200W → idle (not enough sun)."""
@@ -414,24 +414,6 @@ class TestZoneDebounce:
         # Held at Zone 2 — no Charging→Idle blip
         assert strategy == "solar_only"
         assert "Zone 2" in reason
-
-
-# ===========================================================================
-# TestCalculateSolarEvBudget removed in Phase D.2 (#282): the
-# ``_calculate_solar_ev_budget`` mixin method was deleted along with
-# the other legacy budget primitives. The Zone 3/4 proportional ramp +
-# measured-discharge semantics now live in
-# ``flow_calculator.calculate_canonical_ev_budget`` (BATTERY_ASSIST
-# branch) and are exercised by ``tests/scenarios/2026-05-29_budget_
-# unify_battery_assist.yaml`` end-to-end and by the canonical-budget
-# unit tests for the per-zone shape.
-
-
-# TestAutoMode removed in #305: ``_auto_mode_strategy`` was deleted
-# as dead code (no charge mode dispatched to it post-#277 Phase C).
-# The previous 3 tests exercised the helper directly; if a future
-# opt-in ``auto`` mode resurrects the forecast-aware switcher, restore
-# both the method and its tests together from the #305 commit.
 
 
 class TestSelfConsumptionStrategy:


### PR DESCRIPTION
## Summary

Code-quality cleanup release closing the three follow-up issues from the v1.6.4 → v1.6.6 review cycle. **Zero behaviour change** for any user — pure dead-code removal + comment consolidation.

**Fixes #308** — drops the dead ``now`` / ``min_pv`` consumer branches in ``coordinator/charging_control.py`` (lines 228-233). Post-#305 the strategy producer ``_determine_charging_strategy`` only emits ``solar_only`` / ``battery_assist`` / ``night_grid`` / ``idle`` / ``disabled`` — neither value was reachable. Also drops the two synthetic-context tests (``test_min_pv_mode`` / ``test_now_mode``) that pinned the dead branches.

``ChargingState.SOLAR_MIN_PV`` stays alive via the ``night_grid`` → ``EVBudgetStrategy.MIN_PV`` producer mapping in ``coordinator.py:2345``.

**Fixes #309** — folds the global-select cleanup block at ``select.py:80-91`` into the registry-key sweep added by #304. The explicit ``async_remove`` for ``{entry_id}_ev_target_type``, ``{entry_id}_ev_target_mode``, ``{entry_id}_ev_charging_mode`` is fully redundant — the sweep handles each of those unique_ids identically. Replaced with a 7-line explanatory comment.

**Fixes #310** — consolidates three multi-line gravestone comments in ``tests/test_soc_zone_strategy.py`` into a single three-bullet ``Removed tests`` list in the module docstring. ``git log -S <name>`` is the pointer for full history.

## Tests

**2191 pass** on Python 3.12 (2193 v1.6.9 baseline − 2 dead tests removed in #308). Zero existing tests broke.

## Risk + rollback

6 files changed, 74 insertions / 84 deletions. No new APIs, no migrations, no entity additions or removals. Rollback = revert the merge.

## Test plan

- [x] Full test suite (2191 / 7 skipped)
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] Bundles into the v1.6.7 → v1.6.10 release stack as the final cleanup before HACS publish