### PR TITLE
test: v1.6.12 — multi-charger off + solar_only scenario test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.12] — 2026-05-31
+
+Closes the last open senior-reviewer item on the v1.6.7 → v1.6.11
+multi-charger cleanup arc — the missing end-to-end scenario covering
+``charger A = off + charger B = solar_only`` mixed-mode. No
+behaviour change for any user.
+
+### Added
+
+- **New scenario test** ``tests/scenarios/2026-05-31_off_plus_solar_only.yaml``
+  exercises the senior-reviewer-flagged hole in coverage:
+  - **Per-charger effective state isolation** (v1.6.4
+    ``_apply_per_charger_off_override``). Charger ``off`` mode →
+    ``SOLAR_IDLE`` (terminate); sibling ``solar_only`` →
+    ``SOLAR_CHARGING_ACTIVE`` (untouched). Pins the #315 mitigation
+    at the unit-pipeline level — would have mechanically caught the
+    v1.6.3 regression at PR-review time.
+  - **Per-charger flow attribution** (v1.6.9
+    ``PowerFlows.per_charger``). With per-charger draw set to
+    ``{left: 4000, right: 0}``, the per-charger split must give
+    ``right`` zero EV-side flow — the user-visible attribution
+    @RienduPre asked for in #316.
+  - **Distribution sum invariant** (Phase B.5 / #284) re-asserted on
+    top of the mixed-mode case.
+
+- **Scenario harness extensions** in ``tests/scenario_harness.py``:
+  - ``TIMELINE_FIELDS`` accepts ``ev_power_per_charger: {cid: watts}``
+    so multi-charger flow attribution can be driven from YAML.
+  - Cycle results now include ``per_charger_effective_states`` and
+    ``per_charger_flows`` when the scenario has 2+ chargers.
+  - Two new ``expect.multi_charger`` assertion blocks:
+    ``per_charger_effective_states`` (exact match or
+    ``{cid}_contains: substring``) and ``per_charger_flow_max`` for
+    per-charger upper-bound caps.
+
+### Docs
+
+- ``docs/MULTI_CHARGER.md`` roadmap updated: the off + solar_only
+  scenario gap is now closed (was a senior-reviewer FIX-BEFORE-MERGE
+  on the v1.6.7-v1.6.10 arc).
+- CHANGELOG entry per the
+  ``feedback_docs_per_release`` rule — docs are part of every
+  release, not a follow-up.
+
 ## [1.6.11] — 2026-05-31
 
 Diagnostics improvement + doc polish closing the senior-engineer

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -141,6 +141,7 @@ the structural invariant.
 | **v1.6.9** | Per-charger flow attribution + per-charger notification flap suppression | ✓ shipped |
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
+| **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
 
 ### What landed under the abstraction
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.11"
+  "version": "1.6.12"
 }

--- a/tests/scenario_harness.py
+++ b/tests/scenario_harness.py
@@ -66,6 +66,12 @@ TIMELINE_FIELDS = {
     "battery_soc", "battery_temperature", "battery_soc_unavailable",
     "ev_connected", "ev_charging",
     "home_consumption_power",  # override the derived value when needed
+    # v1.6.12: per-charger EV draw in watts as a mapping ``{cid: watts}``.
+    # When present, populates ``PowerReadings.ev_power_per_charger`` so
+    # the flow calculator can produce ``PowerFlows.per_charger`` for
+    # multi-charger scenarios. ``ev_power`` is still the fleet sum; the
+    # values here should add to it (the harness does NOT auto-derive).
+    "ev_power_per_charger",
 }
 
 
@@ -166,6 +172,15 @@ def _build_power_readings(effective: Dict[str, Any]):
     # Allow explicit override of home_consumption_power for stale-sensor scenarios
     if "home_consumption_power" in effective:
         pr.home_consumption_power = float(effective["home_consumption_power"])
+    # v1.6.12: per-charger EV power for ``flow_calculator.calculate_power_flows``
+    # per-charger split. Sticky timeline carries the mapping forward like
+    # any other field.
+    if "ev_power_per_charger" in effective:
+        per_charger = effective["ev_power_per_charger"]
+        if isinstance(per_charger, dict):
+            pr.ev_power_per_charger = {
+                str(k): float(v) for k, v in per_charger.items()
+            }
     return pr
 
 
@@ -457,6 +472,63 @@ async def run_scenario(yaml_path: Path) -> ScenarioRun:
             "flow_battery_to_ev_power": power_flows.battery_to_ev,
         }
 
+        # v1.6.12: per-charger flow attribution. When the scenario
+        # populated ``ev_power_per_charger`` on the readings,
+        # ``calculate_power_flows`` produces a per-charger flow map
+        # (``PowerFlows.per_charger[cid] = ChargerFlows(...)``) that
+        # closes the #316 family. Surface those flows in the cycle
+        # result so the assertion machinery can pin them.
+        if power_flows.per_charger:
+            result["per_charger_flows"] = {
+                cid: {
+                    "solar_to_ev": cf.solar_to_ev,
+                    "grid_to_ev": cf.grid_to_ev,
+                    "battery_to_ev": cf.battery_to_ev,
+                }
+                for cid, cf in power_flows.per_charger.items()
+            }
+
+        # v1.6.12: per-charger effective state — exercise the same
+        # ``_apply_per_charger_off_override`` static helper the
+        # production multi-charger loop calls at coordinator.py:1217.
+        # Maps the fleet ``charging_state`` (from the state machine, or
+        # a synthetic ``SOLAR_CHARGING_ACTIVE`` here since the harness
+        # skips the state machine) onto each charger's effective state
+        # using its per-charger ``charge_mode``. This is the surface
+        # that #315's regression class shows up on.
+        ev_chargers_cfg = coord.config.get("ev_chargers") or []
+        if len(ev_chargers_cfg) >= 2 and strategy is not None:
+            from custom_components.solar_energy_management.consts.states import (
+                ChargingState,
+            )
+            from custom_components.solar_energy_management.coordinator import (
+                SEMCoordinator,
+            )
+            # Pick a fleet baseline that lets each charger's override
+            # branch reveal itself. SOLAR_CHARGING_ACTIVE = primary is
+            # actively charging; the override turns a per-charger
+            # ``off`` mode into SOLAR_IDLE (terminate) and leaves
+            # ``solar_only`` / ``min_plus_solar`` untouched.
+            global_state = (
+                ChargingState.SOLAR_CHARGING_ACTIVE
+                if strategy == "solar_only" else ChargingState.SOLAR_IDLE
+            )
+            per_charger_states: Dict[str, str] = {}
+            for c in ev_chargers_cfg:
+                cid = c.get("id") or "ev_charger"
+                # ``charge_mode`` lives in per-charger config; fall back
+                # through the same precedence the production helper
+                # uses (per-charger > global > default).
+                per_mode = c.get("charge_mode") or coord.config.get(
+                    "charge_mode", "min_plus_solar",
+                )
+                per_charger_states[cid] = (
+                    SEMCoordinator._apply_per_charger_off_override(
+                        global_state, per_mode,
+                    )
+                )
+            result["per_charger_effective_states"] = per_charger_states
+
         # Multi-charger distribution (Phase B.5 / #284). The canonical
         # ``ev_budget_obj`` computed above already represents the total
         # fleet budget; we pass its ``net_w`` through the real
@@ -623,6 +695,80 @@ def assert_expectations(run: ScenarioRun, scenario: Dict[str, Any]) -> None:
                     f"budget. Distributor returned {allocs}. "
                     f"Phase B.5 / #284 regression."
                 )
+
+        # v1.6.12: per-charger effective state assertion. Pinning the
+        # output of ``_apply_per_charger_off_override`` per charger
+        # closes the gap the senior-engineer review flagged on the
+        # v1.6.7→v1.6.10 arc (no scenario covered charger A=off +
+        # charger B=solar_only mixed). YAML shape:
+        #   multi_charger:
+        #     per_charger_effective_states:
+        #       charger_left: "solar_idle"     # exact match (case-insensitive)
+        #       charger_right_contains: "charging_allowed"   # substring
+        pces = mc.get("per_charger_effective_states") or {}
+        if pces:
+            cycles_with_states = [
+                c for c in run.cycles
+                if "per_charger_effective_states" in c.result
+            ]
+            assert cycles_with_states, (
+                "expect.multi_charger.per_charger_effective_states is set "
+                "but no cycle recorded per-charger effective states. "
+                "The scenario's ``ev_chargers`` block needs 2+ entries "
+                "AND a ``charge_mode`` on each charger."
+            )
+            last_states = cycles_with_states[-1].result["per_charger_effective_states"]
+            for key, expected in pces.items():
+                if key.endswith("_contains"):
+                    cid = key[: -len("_contains")]
+                    got = str(last_states.get(cid, "")).lower()
+                    assert str(expected).lower() in got, (
+                        f"per-charger effective state mismatch: charger "
+                        f"{cid!r} ended up as {got!r}, expected substring "
+                        f"{expected!r}. All states: {last_states}"
+                    )
+                else:
+                    cid = key
+                    got = str(last_states.get(cid, "")).lower()
+                    assert got == str(expected).lower(), (
+                        f"per-charger effective state mismatch: charger "
+                        f"{cid!r} ended up as {got!r}, expected exactly "
+                        f"{expected!r}. All states: {last_states}"
+                    )
+
+        # v1.6.12: per-charger flow attribution assertion. Pin the
+        # ``PowerFlows.per_charger`` map populated by
+        # ``flow_calculator.calculate_power_flows`` when the readings
+        # carry ``ev_power_per_charger``. The fleet-sum invariant is
+        # tested by ``test_per_charger_flows_319.py``; here we pin the
+        # per-charger user-visible attribution that closes #316. YAML:
+        #   multi_charger:
+        #     per_charger_flow_max:
+        #       charger_left:
+        #         grid_to_ev: 0       # solar_only must not draw grid
+        #       charger_right:
+        #         grid_to_ev: 10000   # min_plus_solar may
+        pcfm = mc.get("per_charger_flow_max") or {}
+        if pcfm:
+            cycles_with_flows = [
+                c for c in run.cycles if "per_charger_flows" in c.result
+            ]
+            assert cycles_with_flows, (
+                "expect.multi_charger.per_charger_flow_max is set but no "
+                "cycle recorded per-charger flows. The scenario timeline "
+                "needs ``ev_power_per_charger`` populated."
+            )
+            for cid, limits in pcfm.items():
+                for c in cycles_with_flows:
+                    flows = c.result["per_charger_flows"].get(cid) or {}
+                    for flow_key, max_w in limits.items():
+                        actual = float(flows.get(flow_key, 0.0))
+                        assert actual <= float(max_w) + 0.5, (
+                            f"Cycle t={c.t_seconds}: charger {cid!r} "
+                            f"per-charger flow {flow_key}={actual:.1f} W "
+                            f"exceeds max {float(max_w):.1f} W. "
+                            f"Full flows for charger: {flows}"
+                        )
 
         # `priority_order: true` — when budget can only feed N of M chargers,
         # the N lower-numbered priority chargers must get the budget.

--- a/tests/scenarios/2026-05-31_off_plus_solar_only.yaml
+++ b/tests/scenarios/2026-05-31_off_plus_solar_only.yaml
@@ -1,0 +1,153 @@
+name: "2026-05-31 multi-charger off + solar_only — v1.6.9 dispatch + #315 regression"
+description: |
+  Built in v1.6.12 to close the senior-engineer review gap on the
+  v1.6.7→v1.6.10 multi-charger cleanup arc — no scenario covered the
+  case where one charger is in ``off`` mode while a sibling is in
+  ``solar_only``. The gap is exactly where #315 (v1.6.4 / v1.6.5
+  off-mode self-resume) and the @RienduPre #284 / #316 flow-attribution
+  family hit production.
+
+  What this scenario pins, step by step:
+
+  1. **Per-charger effective state isolation** (v1.6.4
+     ``_apply_per_charger_off_override``). Fleet ``charging_state =
+     SOLAR_CHARGING_ACTIVE`` is the primary charger's view. The override
+     must turn charger_right's ``off`` mode into ``SOLAR_IDLE`` (which
+     in production routes through the actuator's terminal-state branch
+     → ``stop_session()`` → ``keba.disable``). Charger_left's
+     ``solar_only`` mode must stay untouched.
+
+  2. **Per-charger flow attribution** (v1.6.9 ``PowerFlows.per_charger``).
+     With ``ev_power_per_charger = {charger_left: 4000, charger_right:
+     0}``, the per-charger split must give all the EV-side flow to
+     ``charger_left`` and zero to ``charger_right``. This is the
+     visible attribution that @RienduPre asked for in #316.
+
+  3. **Budget distribution still sums to ≤ canonical** (Phase B.5 /
+     #284 invariant). Re-uses the contract from
+     ``2026-05-29_multi_charger_split.yaml`` so the cleanup didn't
+     regress the existing distribution math.
+
+  Why this is a YAML scenario and not a live test: HA-TEST has one
+  real KEBA. Faking a second charger with a deterministic state we
+  can assert on is exactly what this harness is for — see
+  ``tests/scenario_harness.py``.
+
+config:
+  battery_capacity_kwh: 15.0
+  battery_buffer_soc: 70
+  battery_auto_start_soc: 90
+  battery_priority_soc: 30
+  battery_assist_floor_soc: 60
+  battery_assist_max_power: 4500
+  # Solar_only on the primary so the fleet strategy is solar_only; that
+  # in turn makes the harness lift fleet ``charging_state`` to
+  # SOLAR_CHARGING_ACTIVE which gives the off-mode override branch a
+  # non-trivial input.
+  ev_charging_mode: "pv"
+  ev_min_current: 6
+  ev_max_current: 16
+  ev_phases: 3
+  ev_voltage: 230
+  daily_ev_target: 7.0
+
+  ev_chargers:
+    - id: charger_left
+      name: "Wallbox Left"
+      priority: 1
+      min_current: 6
+      max_current: 16
+      phases: 3
+      voltage: 230
+      # Solar-only mode: must not get terminated by the per-charger
+      # override; should keep participating in the budget split.
+      charge_mode: "solar_only"
+      ev_charging_mode: "pv"
+      daily_ev_target: 7.0
+    - id: charger_right
+      name: "Wallbox Right"
+      priority: 2
+      min_current: 6
+      max_current: 16
+      phases: 3
+      voltage: 230
+      # Off: per-charger override should produce SOLAR_IDLE for THIS
+      # charger so the actuator's TERMINAL branch fires. This is the
+      # #315 regression class.
+      charge_mode: "off"
+      ev_charging_mode: "pv"
+      daily_ev_target: 7.0
+
+cycle_seconds: 30
+
+# Steady-state regime: enough surplus to keep charger_left active, no
+# battery assist (SOC 75% = Zone 3, surplus only). charger_right is in
+# off mode, so even though it could physically draw, SEM must terminate
+# it via the override. We model that here by setting its per-charger
+# ev_power to 0 and giving charger_left the full draw.
+timeline:
+  # Solar 6000 W, EV 4000 W, grid_export 500 W → derived home ≈ 1500 W.
+  # No battery in play (SOC 75 = Zone 3 surplus-only). All flow into the
+  # EV comes from solar — no grid_to_ev. This is the canonical
+  # ``solar_only`` regime the assertion targets.
+  - t: 0
+    solar_power: 6000
+    grid_power: 500            # positive = exporting 500 W
+    battery_power: 0
+    battery_soc: 75
+    ev_power: 4000             # fleet sum — all of it is charger_left
+    ev_connected: true
+    # Per-charger draw mapping — only charger_left is actually pulling.
+    # The flow calculator splits the fleet flows by these shares.
+    ev_power_per_charger:
+      charger_left: 4000
+      charger_right: 0
+
+  - t: 30  # sticky-inherited steady state
+  - t: 60
+  - t: 90
+
+expect:
+  # The strategy decision logic is locked in by
+  # 2026-05-29_budget_unify_battery_assist.yaml. Here we just need a
+  # solar regime so the fleet state lifts to SOLAR_CHARGING_ACTIVE
+  # (the input the override branch needs to reveal itself).
+  strategy_substring: "solar_only"
+
+  multi_charger:
+    # Phase B.5 / #284 invariant re-asserted on top of the new mixed-mode
+    # case. Distribution math must not regress.
+    total_equals_canonical: true
+    tolerance_w: 1.0
+
+    # The headline v1.6.12 assertion: per-charger effective state
+    # follows per-charger ``charge_mode``, not the fleet view.
+    per_charger_effective_states:
+      # charger_left is solar_only → fleet SOLAR_CHARGING_ACTIVE
+      # passes through untouched. Match the substring rather than the
+      # exact ChargingState enum value so the test survives an enum
+      # rename / reorganisation.
+      charger_left_contains: "charging_active"
+      # charger_right is off → override forces SOLAR_IDLE which the
+      # actuator's terminal branch turns into ``stop_session()``.
+      # This is the #315 mitigation pinned at the unit-pipeline level.
+      charger_right_contains: "idle"
+
+    # The headline v1.6.12 flow assertion: with no actual EV draw on
+    # charger_right, the per-charger flow split must show zero EV
+    # attribution to charger_right. Pre-v1.6.9 the dashboard would
+    # have shown the fleet-proportional split which gave charger_right
+    # part of charger_left's solar — exactly @RienduPre's #316
+    # complaint.
+    per_charger_flow_max:
+      charger_right:
+        solar_to_ev: 0
+        grid_to_ev: 0
+        battery_to_ev: 0
+      # charger_left should NOT exceed the fleet solar_to_ev. The
+      # exact value depends on the home-consumption derivation, so we
+      # only cap the upper bound at a generous ceiling — the sum
+      # invariant (per-charger sums == fleet) is unit-tested
+      # separately in test_per_charger_flows_319.py.
+      charger_left:
+        grid_to_ev: 100  # solar_only must not drink grid


### PR DESCRIPTION
## Summary

Closes the last open senior-reviewer item on the v1.6.7→v1.6.11 multi-charger cleanup arc — the missing end-to-end scenario covering ``charger A = off + charger B = solar_only`` mixed-mode. No behaviour change.

## What's new

- **New scenario** ``tests/scenarios/2026-05-31_off_plus_solar_only.yaml``:
  - ``charger_left`` (priority 1, mode = solar_only) drinks all the EV power.
  - ``charger_right`` (priority 2, mode = off) is terminated by the per-charger override.
  - Asserts per-charger effective states (the #315 mitigation), per-charger flow attribution (the #316 user-visible payoff), AND the Phase B.5 distribution invariant — three previously-separate assertions in one scenario.

- **Scenario harness extensions** in ``tests/scenario_harness.py``:
  - ``TIMELINE_FIELDS`` accepts ``ev_power_per_charger: {cid: W}``.
  - Cycle results gain ``per_charger_effective_states`` + ``per_charger_flows``.
  - Two new ``expect.multi_charger`` blocks: ``per_charger_effective_states`` and ``per_charger_flow_max``.

## Verification

- **2197 tests pass** on Python 3.12 (2196 v1.6.11 baseline + 1 new scenario).
- Scenario runs in <10 ms; harness extensions cost ~30 lines added.
- The scenario calls ``SEMCoordinator._apply_per_charger_off_override`` directly as a static method — no full coordinator instance needed.

## Docs (per the per-release rule)

- ``docs/MULTI_CHARGER.md`` roadmap entry added for v1.6.12.
- ``CHANGELOG.md`` covers scenario, harness extensions, reviewer-gap closure.

## Test plan

- [x] Full suite (2197 / 7 skipped)
- [ ] CI: Tests 3.12 + 3.13, Hassfest, HACS, card-test
- [ ] After merge: bundle v1.6.7→v1.6.12 as the one base release on HACS

## Risk + rollback

5 files changed, 345 insertions / 1 deletion. New scenario YAML + harness additions are purely additive — existing scenarios run unchanged. Rollback = revert.