### PR TITLE
Release v1.6.12 — multi-charger cleanup arc (v1.6.7 → v1.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,55 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.9] — 2026-05-31
+
+Third and final of the multi-charger cleanup arc (v1.6.7 → v1.6.9).
+Adds per-charger flow attribution and per-charger notification flap
+suppression so multi-charger users finally get correct downstream
+visibility — closes the @RienduPre #316 family of complaints. **Zero
+behaviour change** for single-charger users.
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md).
+
+### Added
+
+- **Per-charger flow attribution** in
+  [`coordinator/flow_calculator.py`](coordinator/flow_calculator.py).
+  When ``PowerReadings.ev_power_per_charger`` is populated (multi-charger
+  installs), ``calculate_power_flows`` now also produces
+  ``PowerFlows.per_charger[cid] = ChargerFlows(solar_to_ev, grid_to_ev,
+  battery_to_ev)``. Sum invariant: ``sum(per_charger[c].solar_to_ev) ==
+  solar_to_ev`` (within < 0.1 W from float rounding). Closes the
+  long-standing @RienduPre #284 / #316 complaint family — the dashboard
+  can now show which charger drank from grid vs solar instead of the
+  fleet-aggregated proportional split.
+
+- **``PowerReadings.ev_power_per_charger``** populated by
+  ``sensor_reader`` for multi-charger installs (each charger's
+  ``ev_charging_power_sensor`` value, keyed by charger id).
+  Single-charger installs leave the dict empty.
+
+- **Per-charger notification flap suppression** in
+  [`coordinator/notifications.py`](coordinator/notifications.py).
+  ``notify_state_change`` accepts new ``charger_id`` + ``charger_name``
+  kwargs; the flap-suppression ``_last_notified_state`` /
+  ``_pending_state`` / ``_pending_state_since`` storage is now
+  per-charger, keyed by ``charger_id`` (or the ``"_fleet"`` sentinel
+  for back-compat). A state change on charger A no longer suppresses
+  one on charger B. Mobile messages get a ``[Charger Name]`` prefix
+  when ``charger_name`` is provided. The HA event payload now carries
+  ``charger_id`` and ``charger_name`` keys so automations can route
+  per charger.
+
+### Back-compat
+
+- v1.6.8 callers that read ``_last_notified_state``,
+  ``_pending_state``, or ``_pending_state_since`` as scalars continue
+  to work via property shims that target the ``"_fleet"`` sentinel
+  slot.
+- Single-charger setups behave identically to v1.6.8 — the
+  per-charger split skips when no per-charger data is provided.
+
 ## [1.6.8] — 2026-05-31
 
 Second of the three-release multi-charger cleanup arc (v1.6.7 → v1.6.9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,50 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.12] — 2026-05-31
+
+Closes the last open senior-reviewer item on the v1.6.7 → v1.6.11
+multi-charger cleanup arc — the missing end-to-end scenario covering
+``charger A = off + charger B = solar_only`` mixed-mode. No
+behaviour change for any user.
+
+### Added
+
+- **New scenario test** ``tests/scenarios/2026-05-31_off_plus_solar_only.yaml``
+  exercises the senior-reviewer-flagged hole in coverage:
+  - **Per-charger effective state isolation** (v1.6.4
+    ``_apply_per_charger_off_override``). Charger ``off`` mode →
+    ``SOLAR_IDLE`` (terminate); sibling ``solar_only`` →
+    ``SOLAR_CHARGING_ACTIVE`` (untouched). Pins the #315 mitigation
+    at the unit-pipeline level — would have mechanically caught the
+    v1.6.3 regression at PR-review time.
+  - **Per-charger flow attribution** (v1.6.9
+    ``PowerFlows.per_charger``). With per-charger draw set to
+    ``{left: 4000, right: 0}``, the per-charger split must give
+    ``right`` zero EV-side flow — the user-visible attribution
+    @RienduPre asked for in #316.
+  - **Distribution sum invariant** (Phase B.5 / #284) re-asserted on
+    top of the mixed-mode case.
+
+- **Scenario harness extensions** in ``tests/scenario_harness.py``:
+  - ``TIMELINE_FIELDS`` accepts ``ev_power_per_charger: {cid: watts}``
+    so multi-charger flow attribution can be driven from YAML.
+  - Cycle results now include ``per_charger_effective_states`` and
+    ``per_charger_flows`` when the scenario has 2+ chargers.
+  - Two new ``expect.multi_charger`` assertion blocks:
+    ``per_charger_effective_states`` (exact match or
+    ``{cid}_contains: substring``) and ``per_charger_flow_max`` for
+    per-charger upper-bound caps.
+
+### Docs
+
+- ``docs/MULTI_CHARGER.md`` roadmap updated: the off + solar_only
+  scenario gap is now closed (was a senior-reviewer FIX-BEFORE-MERGE
+  on the v1.6.7-v1.6.10 arc).
+- CHANGELOG entry per the
+  ``feedback_docs_per_release`` rule — docs are part of every
+  release, not a follow-up.
+
 ## [1.6.11] — 2026-05-31
 
 Diagnostics improvement + doc polish closing the senior-engineer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.11] — 2026-05-31
+
+Diagnostics improvement + doc polish closing the senior-engineer
+review NITs on the v1.6.7 → v1.6.10 multi-charger cleanup arc. No
+behaviour change.
+
+### Added
+
+- **Recent SEM log lines in the Copy diagnostics dump** —
+  ``diagnostics.py::_get_recent_sem_logs`` reads the last 2 MB of
+  ``home-assistant.log``, filters for
+  ``solar_energy_management`` mentions, and includes up to 80 matching
+  lines as ``recent_logs`` in the diagnostics output. Bug reports now
+  come pre-loaded with the surrounding log context so we don't have
+  to ask reporters for a separate ``ha core logs`` dump. Supervisor
+  installs (no flat log file, journald-based) get a one-line
+  placeholder explaining how to attach logs manually.
+
+### Docs
+
+- ``CLAUDE.md`` — new "Multi-charger correctness" pointer to
+  [``docs/MULTI_CHARGER.md``](docs/MULTI_CHARGER.md) so future AI
+  sessions can find the invariant doc without needing to grep.
+- ``docs/MULTI_CHARGER.md`` — updated the roadmap to reflect what
+  **actually shipped** vs what was planned. Specifically: the original
+  v1.6.7 design proposed migrating ``effective_state``,
+  ``this_power_w``, ``night_plan`` onto ``PerChargerContext`` in
+  v1.6.8/v1.6.9 — none of those landed. The current dataclass has
+  ``cid`` / ``ev_dev`` / ``charger_cfg`` / ``budget_w`` /
+  ``skipped_for_night`` only. Per-charger flow **sensors** (data is on
+  ``PowerFlows.per_charger`` but no top-level HA entities yet) were
+  also descoped. Both are deferred to v1.7+ in the roadmap so the doc
+  no longer oversells the abstraction.
+
 ## [1.6.10] — 2026-05-31
 
 Code-quality cleanup release. Closes the three follow-up issues filed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.10] — 2026-05-31
+
+Code-quality cleanup release. Closes the three follow-up issues filed
+during the v1.6.4 → v1.6.6 review cycle (#308, #309, #310). **Zero
+behaviour change** for any user.
+
+### Refactored
+
+- **#308 — dead ``now`` / ``min_pv`` consumer branches dropped from
+  ``coordinator/charging_control.py``.** Post-#305 the strategy
+  producer ``_determine_charging_strategy`` only emits ``solar_only`` /
+  ``battery_assist`` / ``night_grid`` / ``idle`` / ``disabled`` —
+  neither ``"now"`` nor ``"min_pv"`` was reachable in production. The
+  unreachable branches are gone; ``ChargingState.SOLAR_MIN_PV`` is
+  still alive via the ``night_grid`` → ``EVBudgetStrategy.MIN_PV``
+  producer mapping. The two synthetic-context tests
+  (``test_min_pv_mode``, ``test_now_mode``) that exercised the dead
+  branches are removed.
+
+- **#309 — global-select cleanup block in ``select.py`` folded into
+  the registry-key sweep added by #304.** The 12-line explicit
+  ``async_remove`` block for ``{entry_id}_ev_target_type``,
+  ``{entry_id}_ev_target_mode``, ``{entry_id}_ev_charging_mode`` was
+  redundant with the sweep at the bottom of ``async_setup_entry``:
+  each of those unique IDs has the ``{entry_id}_`` prefix and a key
+  that's not in ``valid_keys``, so the sweep removes them just as
+  cleanly. Per-charger values were seeded from the globals by the
+  v3→v4 migration; no data is lost.
+
+- **#310 — gravestone comments in ``tests/test_soc_zone_strategy.py``
+  consolidated** into a single ``Removed tests`` block at the top of
+  the module. Three multi-line tombstones (one each from #277 Phase C,
+  Phase D.2 / #282, and #305) collapsed to a three-bullet list with
+  ``git log -S`` as the pointer for full history.
+
 ## [1.6.9] — 2026-05-31
 
 Third and final of the multi-charger cleanup arc (v1.6.7 → v1.6.9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.7] — 2026-05-31
+
+First of a three-release multi-charger cleanup arc dedicated to v1.6.x.
+**Zero user-visible behaviour change** for single-charger users; multi-charger
+users see the same outputs but with the underlying swap mechanism now
+typed and unit-tested.
+
+The cleanup arc addresses a recurring bug class found in v1.6.0–v1.6.6
+(#284, #289, #315, #318): per-charger context swaps with fleet-level
+reads leaking through. This release lifts the swap mechanism; v1.6.8
+sweeps the fleet-power reads in `ev_control.py` and adds per-charger
+strategy; v1.6.9 adds per-charger flow attribution + notifications
+(closes the #316 family).
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full
+developer-facing invariant.
+
+### Refactored
+
+- **`PerChargerContext`** — new
+  [`coordinator/per_charger_context.py`](coordinator/per_charger_context.py)
+  module that owns the per-charger swap lifecycle. The ad-hoc
+  ``saved = {...}`` dict at `coordinator.py:1136-1258` that swapped
+  eight coordinator attributes per iteration (and was easy to miss
+  when adding new per-charger fields) is now a typed context manager
+  with unit tests pinning every swap invariant. Adding a new
+  per-charger field is now one place to edit instead of three.
+
+### Docs
+
+- **New `docs/MULTI_CHARGER.md`** — developer-facing invariant doc
+  covering the bug class, the `PerChargerContext` contract, how to
+  add new per-charger fields, and the v1.6.7-v1.6.9 roadmap.
+- **`CONTRIBUTING.md`** — new "Multi-charger correctness" section
+  pointing future contributors at the invariant.
+
 ## [1.6.6] — 2026-05-31
 
 Same-day hotfix for v1.6.5 — the per-charger power read at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] — 2026-05-31
+
+Second of the three-release multi-charger cleanup arc (v1.6.7 → v1.6.9).
+**Zero behaviour change** for single-charger users; multi-charger users
+get correctness fixes for 12 fleet-power-sum reads that were silently
+returning the wrong value inside per-charger code paths. Sets up the
+structural enforcement that makes the bug class impossible to
+re-introduce.
+
+See [`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full
+developer-facing invariant.
+
+### Fixed
+
+- **12 fleet-power-sum reads swept in
+  [`coordinator/ev_control.py`](coordinator/ev_control.py)** — every
+  ``power.ev_power`` read inside the per-charger code path (8 in
+  ``_execute_ev_control``, 3 in ``_should_reenable_charger``, 1 in
+  ``_update_session_tracking``) now uses
+  ``self._this_charger_power(ev, power)`` cached as
+  ``this_power_w`` at the top of the method. In multi-charger setups
+  these reads were returning the fleet sum — exactly the bug class
+  that caused #284, #289, #315 (terminator) and #318 (SOC isolation).
+  Each fix was reactive; this sweep closes them all.
+
+### Added
+
+- **AST lint test** ([`tests/test_ev_control_fleet_reads.py`](tests/test_ev_control_fleet_reads.py))
+  — walks the AST of ``ev_control.py`` on every CI run and fails if
+  any ``power.ev_power`` read is missing a ``# FLEET-READ:`` annotation
+  (outside the sanctioned ``_this_charger_power`` helper). Catches the
+  bug class on PR review, not after release.
+
+- **``# FLEET-READ: <reason>`` annotation convention** — documented in
+  ``docs/MULTI_CHARGER.md``. Same-line or previous-line comment opts
+  a deliberate fleet-level read out of the lint with a required
+  human-readable reason.
+
 ## [1.6.7] — 2026-05-31
 
 First of a three-release multi-charger cleanup arc dedicated to v1.6.x.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,28 @@ Open an issue with the `enhancement` label. Describe the use case, not just the 
 - Add tests for new features
 - Update translations (15 languages: de, en, es, fr, it, nl, pt, pl, sv, cs, da, fi, hu, ro, no) for user-facing text
 
+### Multi-charger correctness
+
+SEM was originally single-charger; multi-charger support was added
+incrementally. Between v1.6.0 and v1.6.6 we shipped four hotfixes for
+variants of the same bug class: **per-charger context swaps with
+fleet-level reads leaking through**. The structural fix landed in
+v1.6.7 as `PerChargerContext` (see
+[`docs/MULTI_CHARGER.md`](docs/MULTI_CHARGER.md) for the full invariant).
+
+**Two rules of thumb when working on the coordinator:**
+
+1. Inside a `with PerChargerContext.for_charger(...)` block (the
+   multi-charger loop in `coordinator/coordinator.py`), never read
+   `power.ev_power` directly — use the per-charger helper or annotate
+   the read with `# FLEET-READ: <reason>`.
+2. To add new per-charger state, edit
+   [`coordinator/per_charger_context.py`](coordinator/per_charger_context.py)
+   — don't add new ad-hoc `saved = {...}` swap dicts.
+
+If you're not sure whether a code path runs inside the per-charger loop,
+read the doc — the answer is there.
+
 ## Development Setup
 
 ```bash

--- a/coordinator/charging_control.py
+++ b/coordinator/charging_control.py
@@ -59,9 +59,8 @@ class ChargingContext:
             SOLAR_IDLE → actuator stop_session(); ``"idle"`` is the
             transient pause (Zone 1, solar<200W, target met) which
             stays in CHARGING_ALLOWED (warm, waiting for surplus).
-            (The legacy ``"min_pv"`` value was retired in #305 — no
-            producer remains and the consuming branch at line 208 is
-            inert.)
+            The legacy ``"min_pv"`` + ``"now"`` values were retired
+            in #305 (producer) and #308 (consumer).
         charging_strategy_reason: Human-readable explanation of strategy choice.
         night_target_kwh: Night charging target (kWh), may be forecast-adjusted if enabled.
             For night mode, remaining is derived from this field directly.
@@ -224,13 +223,14 @@ class ChargingStateMachine:
         if ctx.soc_limit_active:
             return ChargingState.SOLAR_TARGET_REACHED
 
-        # Now mode: charge at max immediately
-        if ctx.charging_strategy == "now":
-            return ChargingState.SOLAR_MIN_PV  # Reuse Min+PV path (grid + surplus)
-
-        # Min+PV mode: guarantee minimum from grid, add solar surplus on top
-        if ctx.charging_strategy == "min_pv":
-            return ChargingState.SOLAR_MIN_PV
+        # The ``"now"`` and ``"min_pv"`` consumer branches were dropped in
+        # v1.6.10 (#308). Post-#305 the strategy producer
+        # ``_determine_charging_strategy`` only emits ``solar_only`` /
+        # ``battery_assist`` / ``night_grid`` / ``idle`` / ``disabled`` —
+        # neither ``"now"`` nor ``"min_pv"`` is reachable in production.
+        # ``ChargingState.SOLAR_MIN_PV`` is still alive via the
+        # ``night_grid`` → ``EVBudgetStrategy.MIN_PV`` mapping in the
+        # canonical-budget producer.
 
         # Daily target only limits night (grid) charging, not solar.
         # Solar surplus is free — always charge if available.

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -260,6 +260,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # last effective decision, so price hovering at the cheap boundary doesn't
         # stop/start the charger every cycle.
         self._tariff_decision_per_charger = {}
+        # v1.6.9: per-charger effective state captured during the
+        # multi-charger loop so ``_send_notifications`` can dispatch
+        # ``notify_state_change`` per charger with its own
+        # ``charger_id`` and flap-suppression key. Cleared at the top of
+        # each loop pass; empty in single-charger setups (notification
+        # falls back to the fleet-level call).
+        # Shape: ``{cid: (effective_state, charger_name)}``.
+        self._effective_states_per_charger: Dict[str, tuple] = {}
 
         # EV stall detection for self-healing
         self._ev_stalled_since: Optional[float] = None
@@ -1110,6 +1118,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 # priority order against one peak headroom; reset the running
                 # commitment before the loop.
                 self._night_committed_w = 0.0
+                # v1.6.9: per-charger effective states are captured below
+                # so the notification dispatch can fire per charger.
+                # Reset before the loop so a removed charger's stale
+                # state doesn't fire on the next cycle.
+                self._effective_states_per_charger = {}
                 # Pre-cache the per-charger configs once for the night
                 # gate below — inline lookup is the same pattern other
                 # branches use here. (#277 Phase B)
@@ -1222,6 +1235,15 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                                     else ChargingState.NIGHT_CHARGING_ACTIVE
                                 )
                                 await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
+
+                        # v1.6.9: capture per-charger effective state so
+                        # the notification dispatch in ``_send_notifications``
+                        # can fire ``notify_state_change`` per charger with
+                        # its own flap-suppression key.
+                        self._effective_states_per_charger[cid] = (
+                            effective_state,
+                            charger_cfg.get("name") or cid,
+                        )
 
                         try:
                             await self._execute_ev_control(
@@ -2144,19 +2166,34 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         """Send state-change and event-based notifications (#29).
 
         Extracted from _async_update_data to reduce cyclomatic complexity.
+
+        v1.6.9 multi-charger: when ``_effective_states_per_charger`` was
+        populated by the per-charger loop, dispatch one
+        ``notify_state_change`` per charger with its own ``charger_id``
+        and flap-suppression key so a state change on charger A doesn't
+        suppress one on charger B. Single-charger setups (empty dict)
+        fall back to the fleet-level call — identical behaviour to
+        v1.6.8.
         """
-        await self._notification_manager.notify_state_change(
-            charging_state,
-            {
-                "battery_soc": power.battery_soc,
-                "calculated_current": calculated_current,
-                "available_power": available_power,
-                "daily_ev_energy": energy.daily_ev,
-                "charging_strategy": charging_context.charging_strategy,
-                "charging_strategy_reason": charging_context.charging_strategy_reason,
-                "discharge_limit": discharge_limit,
-            }
-        )
+        common_data = {
+            "battery_soc": power.battery_soc,
+            "calculated_current": calculated_current,
+            "available_power": available_power,
+            "daily_ev_energy": energy.daily_ev,
+            "charging_strategy": charging_context.charging_strategy,
+            "charging_strategy_reason": charging_context.charging_strategy_reason,
+            "discharge_limit": discharge_limit,
+        }
+        per_charger_states = getattr(self, "_effective_states_per_charger", None) or {}
+        if per_charger_states:
+            for cid, (eff_state, name) in per_charger_states.items():
+                await self._notification_manager.notify_state_change(
+                    eff_state, common_data, charger_id=cid, charger_name=name,
+                )
+        else:
+            await self._notification_manager.notify_state_change(
+                charging_state, common_data,
+            )
 
         try:
             if power.battery_soc >= 99.5:

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -49,6 +49,7 @@ from .sensor_reader import SensorReader
 from .energy_calculator import EnergyCalculator
 from .flow_calculator import FlowCalculator
 from .charging_control import ChargingStateMachine, ChargingContext
+from .per_charger_context import PerChargerContext
 from .storage import SEMStorage
 from .notifications import NotificationManager
 from .surplus_controller import SurplusController
@@ -1132,130 +1133,114 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                         if not self._mode_allows_night_charging(per_cfg):
                             continue  # mode opts this charger out of night
 
-                    # Save coordinator-level state, swap in per-charger state
-                    saved = {
-                        "dev": self._ev_device,
-                        "stalled": self._ev_stalled_since,
-                        "enable": self._ev_enable_surplus_since,
-                        "started": self._ev_charge_started_at,
-                        "change": self._ev_last_change_time,
-                        "reenable_attempts": self._ev_reenable_attempts,
-                        "charge_refused": self._ev_charge_refused,
-                    }
-                    self._ev_device = ev_dev
-                    self._ev_stalled_since = self._ev_stalled_since_per_charger.get(cid)
-                    self._ev_enable_surplus_since = self._ev_enable_surplus_per_charger.get(cid)
-                    self._ev_charge_started_at = self._ev_charge_started_per_charger.get(cid)
-                    self._ev_last_change_time = self._ev_last_change_per_charger.get(cid)
-                    self._ev_reenable_attempts = self._ev_reenable_attempts_per_charger.get(cid, 0)
-                    self._ev_charge_refused = self._ev_charge_refused_per_charger.get(cid, False)
-                    self._current_charger_budget = ev_budget_per_charger.get(cid)
-                    # Set per-charger night target (#193)
-                    per_charger_target = getattr(self, '_night_target_per_charger_map', {}).get(cid)
-                    if per_charger_target is not None:
-                        self._night_target_per_charger = per_charger_target
-
-                    # Per-charger SOC target and surplus limit (#215)
-                    saved_vehicle_soc_ctrl = self._cycle_vehicle_soc
-                    ev_chargers_cfg = self.config.get("ev_chargers", [])
-                    charger_cfg = next((c for c in ev_chargers_cfg if c.get("id") == cid), {})
-                    per_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
-                    if per_soc_entity:
-                        soc_st = self.hass.states.get(per_soc_entity)
-                        if soc_st and soc_st.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                            try:
-                                self._cycle_vehicle_soc = float(soc_st.state)
-                            except (ValueError, TypeError):
-                                _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_soc_entity, soc_st.state)
-                    # Ceiling (Max) gates surplus; floor (Min) drives night top-up (#245)
-                    per_remaining = self._calculate_remaining_need(
-                        energy, self._cycle_vehicle_soc, charger_cfg, bound="max"
+                    # v1.6.7: the swap/restore dance that used to live
+                    # inline here as ``saved = {...}`` + a final
+                    # ``finally`` block is now owned by
+                    # ``PerChargerContext``. Everything in this block is
+                    # the per-charger computation that was already
+                    # specific to this iteration (SOC entity read, Min/Max
+                    # remaining, night plan, etc.) — it stays inline for
+                    # v1.6.7 and migrates onto the context object in
+                    # v1.6.8/v1.6.9.
+                    pcc = PerChargerContext.for_charger(
+                        self, cid, ev_dev, ev_budget_per_charger,
+                        chargers_by_id=_chargers_by_id,
                     )
-                    per_remaining_floor = self._calculate_remaining_need(
-                        energy, self._cycle_vehicle_soc, charger_cfg, bound="min"
-                    )
-                    # Surplus stops at this charger's Max ceiling (default full) (#245)
-                    per_target_reached = per_remaining <= 0.1
-                    charging_context.soc_limit_active = per_target_reached
-                    charging_context.daily_target_reached = per_target_reached
-                    charging_context.remaining_ev_energy = per_remaining
-                    charging_context.night_target_kwh = per_charger_target if per_charger_target is not None else per_remaining_floor
+                    with pcc:
+                        # Set per-charger night target (#193). The
+                        # scalar ``_night_target_per_charger`` is read by
+                        # downstream methods that still expect it; the
+                        # per-charger map drives the in-loop math.
+                        per_charger_target = getattr(
+                            self, '_night_target_per_charger_map', {},
+                        ).get(cid)
+                        if per_charger_target is not None:
+                            self._night_target_per_charger = per_charger_target
 
-                    # Per-charger deadline + tariff plan (#246/#247): recompute
-                    # for THIS charger and pick its effective night state. Each car
-                    # can have its own deadline / tariff toggle, so the displayed
-                    # (primary) state isn't authoritative for the rest.
-                    effective_state = charging_state
-                    charging_context.night_deadline_amps = 0
-                    charging_context.night_deadline_active = False
-                    charging_context.night_tariff_wait = False
-                    charging_context.night_deadline_reachable = True
-
-                    # Per-charger off-mode override (v1.6.3 hotfix follow-up).
-                    # The global ``charging_state`` is derived from the primary
-                    # charger only — the multi-charger loop needs to correct it
-                    # per charger so an OFF primary doesn't bleed its terminate
-                    # into the other chargers. See the helper for details.
-                    per_mode = self._effective_charge_mode_for(charger_cfg)
-                    effective_state = self._apply_per_charger_off_override(
-                        charging_state, per_mode
-                    )
-                    if charging_state in (
-                        ChargingState.NIGHT_CHARGING_ACTIVE,
-                        ChargingState.TARIFF_WAITING_FOR_CHEAP,
-                    ):
-                        pc_target = charging_context.night_target_kwh
-                        if pc_target <= 0.1:
-                            effective_state = ChargingState.NIGHT_TARGET_REACHED
-                        else:
-                            plan = self._compute_night_plan(charger_cfg, pc_target, energy)
-                            self._night_plan_per_charger[cid] = plan
-                            charging_context.night_deadline_amps = plan.deadline_amps
-                            charging_context.night_deadline_active = plan.deadline_active
-                            charging_context.night_tariff_wait = plan.should_wait_for_cheap
-                            charging_context.night_deadline_reachable = plan.reachable
-                            effective_state = (
-                                ChargingState.TARIFF_WAITING_FOR_CHEAP
-                                if plan.should_wait_for_cheap
-                                else ChargingState.NIGHT_CHARGING_ACTIVE
-                            )
-                            await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
-
-                    try:
-                        await self._execute_ev_control(
-                            effective_state, power, energy, charging_context
+                        # Per-charger SOC target and surplus limit (#215).
+                        # ``_cycle_vehicle_soc`` is one of the swap fields
+                        # PerChargerContext restores in ``__exit__``.
+                        charger_cfg = pcc.charger_cfg
+                        per_soc_entity = charger_cfg.get("vehicle_soc_entity", "")
+                        if per_soc_entity:
+                            soc_st = self.hass.states.get(per_soc_entity)
+                            if soc_st and soc_st.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
+                                try:
+                                    self._cycle_vehicle_soc = float(soc_st.state)
+                                except (ValueError, TypeError):
+                                    _LOGGER.debug("Vehicle SOC %s not numeric: %r (#259)", per_soc_entity, soc_st.state)
+                        # Ceiling (Max) gates surplus; floor (Min) drives night top-up (#245)
+                        per_remaining = self._calculate_remaining_need(
+                            energy, self._cycle_vehicle_soc, charger_cfg, bound="max"
                         )
-                        # Add this charger's just-committed draw to the shared night
-                        # peak budget so lower-priority chargers size against the
-                        # remaining headroom (#274/H1). Estimate from the setpoint
-                        # (the commitment), not the lagging measured power.
+                        per_remaining_floor = self._calculate_remaining_need(
+                            energy, self._cycle_vehicle_soc, charger_cfg, bound="min"
+                        )
+                        # Surplus stops at this charger's Max ceiling (default full) (#245)
+                        per_target_reached = per_remaining <= 0.1
+                        charging_context.soc_limit_active = per_target_reached
+                        charging_context.daily_target_reached = per_target_reached
+                        charging_context.remaining_ev_energy = per_remaining
+                        charging_context.night_target_kwh = per_charger_target if per_charger_target is not None else per_remaining_floor
+
+                        # Per-charger deadline + tariff plan (#246/#247): recompute
+                        # for THIS charger and pick its effective night state. Each car
+                        # can have its own deadline / tariff toggle, so the displayed
+                        # (primary) state isn't authoritative for the rest.
+                        effective_state = charging_state
+                        charging_context.night_deadline_amps = 0
+                        charging_context.night_deadline_active = False
+                        charging_context.night_tariff_wait = False
+                        charging_context.night_deadline_reachable = True
+
+                        # Per-charger off-mode override (v1.6.3 hotfix follow-up).
+                        # The global ``charging_state`` is derived from the primary
+                        # charger only — the multi-charger loop needs to correct it
+                        # per charger so an OFF primary doesn't bleed its terminate
+                        # into the other chargers. See the helper for details.
+                        per_mode = self._effective_charge_mode_for(charger_cfg)
+                        effective_state = self._apply_per_charger_off_override(
+                            charging_state, per_mode
+                        )
+                        if charging_state in (
+                            ChargingState.NIGHT_CHARGING_ACTIVE,
+                            ChargingState.TARIFF_WAITING_FOR_CHEAP,
+                        ):
+                            pc_target = charging_context.night_target_kwh
+                            if pc_target <= 0.1:
+                                effective_state = ChargingState.NIGHT_TARGET_REACHED
+                            else:
+                                plan = self._compute_night_plan(charger_cfg, pc_target, energy)
+                                self._night_plan_per_charger[cid] = plan
+                                charging_context.night_deadline_amps = plan.deadline_amps
+                                charging_context.night_deadline_active = plan.deadline_active
+                                charging_context.night_tariff_wait = plan.should_wait_for_cheap
+                                charging_context.night_deadline_reachable = plan.reachable
+                                effective_state = (
+                                    ChargingState.TARIFF_WAITING_FOR_CHEAP
+                                    if plan.should_wait_for_cheap
+                                    else ChargingState.NIGHT_CHARGING_ACTIVE
+                                )
+                                await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
+
                         try:
-                            self._night_committed_w += max(0.0, (
-                                ev_dev._current_setpoint * ev_dev.phases * ev_dev.voltage
-                            ))
-                        except (AttributeError, TypeError):
-                            pass
-                    except (HomeAssistantError, ServiceValidationError) as e:
-                        _LOGGER.error("EV control service failed for %s: %s", cid, e)
-                    except ValueError as e:
-                        _LOGGER.warning("EV control invalid value for %s: %s", cid, e)
-                    finally:
-                        # Save back per-charger state, restore coordinator state
-                        self._ev_stalled_since_per_charger[cid] = self._ev_stalled_since
-                        self._ev_enable_surplus_per_charger[cid] = self._ev_enable_surplus_since
-                        self._ev_charge_started_per_charger[cid] = self._ev_charge_started_at
-                        self._ev_last_change_per_charger[cid] = self._ev_last_change_time
-                        self._ev_reenable_attempts_per_charger[cid] = self._ev_reenable_attempts
-                        self._ev_charge_refused_per_charger[cid] = self._ev_charge_refused
-                        self._ev_device = saved["dev"]
-                        self._ev_stalled_since = saved["stalled"]
-                        self._ev_enable_surplus_since = saved["enable"]
-                        self._ev_charge_started_at = saved["started"]
-                        self._ev_last_change_time = saved["change"]
-                        self._ev_reenable_attempts = saved["reenable_attempts"]
-                        self._ev_charge_refused = saved["charge_refused"]
-                        self._current_charger_budget = None
-                        self._cycle_vehicle_soc = saved_vehicle_soc_ctrl
+                            await self._execute_ev_control(
+                                effective_state, power, energy, charging_context
+                            )
+                            # Add this charger's just-committed draw to the shared night
+                            # peak budget so lower-priority chargers size against the
+                            # remaining headroom (#274/H1). Estimate from the setpoint
+                            # (the commitment), not the lagging measured power.
+                            try:
+                                self._night_committed_w += max(0.0, (
+                                    ev_dev._current_setpoint * ev_dev.phases * ev_dev.voltage
+                                ))
+                            except (AttributeError, TypeError):
+                                pass
+                        except (HomeAssistantError, ServiceValidationError) as e:
+                            _LOGGER.error("EV control service failed for %s: %s", cid, e)
+                        except ValueError as e:
+                            _LOGGER.warning("EV control invalid value for %s: %s", cid, e)
                 self._save_ev_session_state()
             elif self._ev_device and not self._observer_mode:
                 try:

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -329,6 +329,13 @@ class EVControlMixin:
         ev = self._ev_device
         ev.managed_externally = True  # ALWAYS — coordinator owns EV
 
+        # v1.6.8: cache this charger's power once per call. Avoids reading
+        # the global fleet sum (``power.ev_power``) when we mean THIS
+        # charger's draw — exactly the bug class that caused the v1.6.5
+        # KEBA self-resume regression and the broader sweep this release
+        # ships. See ``docs/MULTI_CHARGER.md`` for the invariant.
+        this_power_w = self._this_charger_power(ev, power)
+
         # === NIGHT CHARGING (peak-managed, ramp-limited) ===
         # Design: evcc-style ramp, configurable min current, IEC 61851 compliant
         if state == ChargingState.NIGHT_CHARGING_ACTIVE:
@@ -343,9 +350,9 @@ class EVControlMixin:
                 return
 
             # Detect already-charging after SEM reload (don't interrupt)
-            if not ev._session_active and power.ev_power > 50:
+            if not ev._session_active and this_power_w > 50:
                 ev._session_active = True
-                _LOGGER.info("Night: KEBA already active (%.0fW), resuming", power.ev_power)
+                _LOGGER.info("Night: KEBA already active (%.0fW), resuming", this_power_w)
 
             # Read configurable EV parameters — per-charger overrides (#193)
             charger_cfg = self._get_active_charger_config()
@@ -399,9 +406,9 @@ class EVControlMixin:
                     self._ev_last_change_time = dt_util.now()
 
                 # Dynamic peak-managed current (only when car is actually drawing)
-                if power.ev_power > 100:
+                if this_power_w > 100:
                     # W/A from actual charger readings (adapts to any car)
-                    watts_per_amp = power.ev_power / max(1, ev._current_setpoint)
+                    watts_per_amp = this_power_w / max(1, ev._current_setpoint)
                     target = self._night_peak_managed_amps(
                         power, watts_per_amp, min_amps, ev.max_current)
                     peak_limit_w = self._get_peak_limit_w()  # for the log line
@@ -428,7 +435,7 @@ class EVControlMixin:
                         await ev._set_current(target)
 
             _LOGGER.debug("Night EV: %dA, %.0fW, remaining=%.1fkWh",
-                          ev._current_setpoint, power.ev_power, remaining_kwh)
+                          ev._current_setpoint, this_power_w, remaining_kwh)
             return
 
         # === NIGHT WAITING STATES: stop session if running ===
@@ -493,7 +500,7 @@ class EVControlMixin:
                 # Surplus is sufficient — track how long it's been sufficient
                 self._ev_enable_surplus_since = self._ev_enable_surplus_since or now_ts
 
-                if ev._session_active and power.ev_power > 100:
+                if ev._session_active and this_power_w > 100:
                     # Already charging — update current immediately, reset disable timer
                     target_current = min(ev.max_current,
                                          max(ev.min_current, ev.watts_to_current(budget_w)))
@@ -525,7 +532,7 @@ class EVControlMixin:
 
                 if (self._ev_charge_started_at
                         and (now_ts - self._ev_charge_started_at) < disable_delay
-                        and power.ev_power > 100):
+                        and this_power_w > 100):
                     # Within disable delay and actually charging — hold at minimum current
                     if ev._current_setpoint != ev.min_current:
                         await ev._set_current(ev.min_current)
@@ -542,7 +549,7 @@ class EVControlMixin:
 
             _LOGGER.debug(
                 "Solar EV: budget=%.0fW (%s), current=%.0fA, ev_power=%.0fW, session=%s",
-                budget_w, state, ev._current_setpoint, power.ev_power,
+                budget_w, state, ev._current_setpoint, this_power_w,
                 "active" if ev._session_active else "inactive",
             )
             return
@@ -732,9 +739,11 @@ class EVControlMixin:
         ev = self._ev_device
         if not ev._session_active:
             return False
+        # v1.6.8: per-charger power (not fleet sum). See ``docs/MULTI_CHARGER.md``.
+        this_power_w = self._this_charger_power(ev, power)
         # SEM set current >= min but charger reports no power → stalled
         if (ev._current_setpoint >= ev.min_current
-                and power.ev_power < 50
+                and this_power_w < 50
                 and power.ev_connected):
             # Car already deemed not-accepting this session — stay quiet
             if getattr(self, "_ev_charge_refused", False):
@@ -753,13 +762,13 @@ class EVControlMixin:
                         "EV not accepting charge after %d re-enable attempts "
                         "(setpoint=%.0fA, power=%.0fW) — car likely full; "
                         "pausing re-enable until power resumes or car unplugged",
-                        max_attempts, ev._current_setpoint, power.ev_power,
+                        max_attempts, ev._current_setpoint, this_power_w,
                     )
                     return False
                 _LOGGER.warning(
                     "EV charger stalled (setpoint=%.0fA, power=%.0fW) — "
                     "re-enabling (attempt %d/%d)",
-                    ev._current_setpoint, power.ev_power,
+                    ev._current_setpoint, this_power_w,
                     self._ev_reenable_attempts, max_attempts,
                 )
                 return True
@@ -988,8 +997,14 @@ class EVControlMixin:
 
         self._last_ev_connected = power.ev_connected
 
-        # Detect session start: EV charging and no active session
-        if power.ev_power > 50 and not self._session_data.active:
+        # Detect session start: EV charging and no active session.
+        # v1.6.8: per-charger power. ``_update_session_tracking`` is called
+        # from inside the per-charger loop in ``coordinator.py:970``, after
+        # ``self._session_data`` has been swapped to this charger's
+        # ``SessionData`` instance — so the start-detection threshold must
+        # also key off THIS charger's draw, not the fleet sum.
+        this_power_w = self._this_charger_power(self._ev_device, power)
+        if this_power_w > 50 and not self._session_data.active:
             self._session_data = SessionData(
                 active=True,
                 start_time=dt_util.now().isoformat(),

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -17,7 +17,7 @@ from typing import Dict, Optional
 
 from homeassistant.util import dt as dt_util
 
-from .types import PowerReadings, PowerFlows, EnergyTotals, EnergyFlows
+from .types import ChargerFlows, PowerReadings, PowerFlows, EnergyTotals, EnergyFlows
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -150,6 +150,15 @@ class FlowCalculator:
 
         Each source flows to ALL destinations based on demand percentages.
         This matches how electricity physically distributes in a system.
+
+        v1.6.9: when ``power.ev_power_per_charger`` is populated
+        (multi-charger setups, ``len(ev_chargers) > 1`` in
+        ``sensor_reader``), the EV-side flow attribution is also split
+        per charger and stored on ``flows.per_charger``. The fleet-level
+        ``flows.solar_to_ev`` (etc.) remains the sum across all chargers
+        — invariant pinned in the scenario tests. Single-charger setups
+        leave ``per_charger`` empty, preserving identical behaviour for
+        every downstream reader.
         """
         flows = PowerFlows()
 
@@ -203,6 +212,28 @@ class FlowCalculator:
 
             flows.battery_to_home = round(battery_discharge * home_pct_battery, 1)
             flows.battery_to_ev = round(battery_discharge * ev_pct_battery, 1)
+
+        # v1.6.9 per-charger attribution. When per-charger draws are
+        # available, split the fleet-level EV flows by each charger's
+        # share of the total EV draw. Math: ``charger_share = c_draw /
+        # ev_total`` × fleet ``flows.*_to_ev``. Sum invariant holds by
+        # construction (sum of shares == 1.0 modulo float rounding;
+        # final ``round(..., 1)`` may leak ≤ 0.1 W which is well below
+        # any user-visible threshold).
+        if power.ev_power_per_charger and ev > 0:
+            for cid, charger_ev_w in power.ev_power_per_charger.items():
+                if charger_ev_w <= 0:
+                    # An idle charger gets a zero-filled ChargerFlows so
+                    # downstream readers can safely dict-lookup any
+                    # configured charger id without KeyError.
+                    flows.per_charger[cid] = ChargerFlows()
+                    continue
+                share = charger_ev_w / ev
+                flows.per_charger[cid] = ChargerFlows(
+                    solar_to_ev=round(flows.solar_to_ev * share, 1),
+                    grid_to_ev=round(flows.grid_to_ev * share, 1),
+                    battery_to_ev=round(flows.battery_to_ev * share, 1),
+                )
 
         return flows
 

--- a/coordinator/notifications.py
+++ b/coordinator/notifications.py
@@ -52,13 +52,25 @@ class NotificationManager:
         """Initialize notification manager."""
         self.hass = hass
         self.config = config
-        self._last_notified_state: Optional[str] = None
+        # v1.6.9: per-charger flap suppression. The fleet sentinel
+        # ``"_fleet"`` is the back-compat slot for callers that don't
+        # pass a ``charger_id`` (single-charger setups + the existing
+        # global state-change call site at coordinator.py:2148).
+        # Multi-charger callers pass each charger's id so a state
+        # change on charger A doesn't suppress one on charger B
+        # (separate ``_last_notified_state`` per key).
+        #
+        # Internal dicts are private. The ``_last_notified_state``,
+        # ``_pending_state``, and ``_pending_state_since`` properties
+        # below provide the legacy scalar API (targeting the fleet
+        # slot) so existing tests and any external consumers continue
+        # to work unchanged.
+        self._last_notified_state_per_charger: Dict[str, Optional[str]] = {}
+        self._pending_state_per_charger: Dict[str, Optional[str]] = {}
+        self._pending_state_since_per_charger: Dict[str, float] = {}
         self._last_mobile_time: float = -(2 * _MOBILE_COOLDOWN_SECONDS)
         self._daily_summary_sent: Optional[str] = None
         self._notified_flags: set = set()
-        # Flap suppression (#35)
-        self._pending_state: Optional[str] = None
-        self._pending_state_since: float = 0.0
         # Service validation caching (#47)
         self._charger_notify_checked: bool = False
         self._charger_notify_available: bool = True
@@ -69,32 +81,84 @@ class NotificationManager:
         self._mobile_service_domain: str = "notify"
         self._mobile_service_is_companion: bool = False
 
+    # ──────────────────────────────────────────────────────────────────
+    # v1.6.8-compat shims for flap-suppression fields. Reads/writes
+    # target the fleet sentinel key; multi-charger callers should use
+    # the per-charger dicts directly.
+    # ──────────────────────────────────────────────────────────────────
+
+    @property
+    def _last_notified_state(self) -> Optional[str]:
+        return self._last_notified_state_per_charger.get("_fleet")
+
+    @_last_notified_state.setter
+    def _last_notified_state(self, value: Optional[str]) -> None:
+        if value is None:
+            self._last_notified_state_per_charger.pop("_fleet", None)
+        else:
+            self._last_notified_state_per_charger["_fleet"] = value
+
+    @property
+    def _pending_state(self) -> Optional[str]:
+        return self._pending_state_per_charger.get("_fleet")
+
+    @_pending_state.setter
+    def _pending_state(self, value: Optional[str]) -> None:
+        if value is None:
+            self._pending_state_per_charger.pop("_fleet", None)
+        else:
+            self._pending_state_per_charger["_fleet"] = value
+
+    @property
+    def _pending_state_since(self) -> float:
+        return self._pending_state_since_per_charger.get("_fleet", 0.0)
+
+    @_pending_state_since.setter
+    def _pending_state_since(self, value: float) -> None:
+        self._pending_state_since_per_charger["_fleet"] = value
+
     async def notify_state_change(
         self,
         new_state: str,
-        data: Dict[str, Any]
+        data: Dict[str, Any],
+        *,
+        charger_id: Optional[str] = None,
+        charger_name: Optional[str] = None,
     ) -> None:
         """Send notifications based on charging state changes.
 
         Uses flap suppression (#35): for cooldown states (solar charging),
         the state must be stable for 60s before a notification is sent.
+
+        v1.6.9 multi-charger: ``charger_id`` (when set) keys the flap
+        suppression state per-charger so a state change on one charger
+        doesn't suppress one on another. ``charger_name`` is used as the
+        label in mobile notifications (e.g. ``[Wallbox Left] Solar
+        charging active``). Single-charger callers omit both and the
+        fleet sentinel key is used — identical behaviour to v1.6.8.
         """
-        if new_state == self._last_notified_state:
-            self._pending_state = None
+        key = charger_id or "_fleet"
+
+        if new_state == self._last_notified_state_per_charger.get(key):
+            # Drop the pending-state entry rather than writing ``None`` —
+            # keeps the dict free of orphan ``None`` slots so future
+            # ``in`` checks are meaningful (reviewer NIT, v1.6.9).
+            self._pending_state_per_charger.pop(key, None)
             return
 
         # Flap suppression for cooldown states
         if new_state in _COOLDOWN_STATES:
             now = time.monotonic()
-            if self._pending_state != new_state:
-                self._pending_state = new_state
-                self._pending_state_since = now
+            if self._pending_state_per_charger.get(key) != new_state:
+                self._pending_state_per_charger[key] = new_state
+                self._pending_state_since_per_charger[key] = now
                 return
-            if now - self._pending_state_since < _FLAP_STABILITY_SECONDS:
+            if now - self._pending_state_since_per_charger.get(key, 0.0) < _FLAP_STABILITY_SECONDS:
                 return
 
-        self._pending_state = None
-        self._last_notified_state = new_state
+        # Same drop-not-write convention as above.
+        self._pending_state_per_charger.pop(key, None)
+        self._last_notified_state_per_charger[key] = new_state
 
         # Accept enable_charger_notifications (new) or enable_keba_notifications (legacy)
         keba_enabled = self.config.get("enable_charger_notifications",
@@ -106,12 +170,26 @@ class NotificationManager:
 
         messages = self._get_notification_messages(new_state, data)
 
+        # v1.6.9 multi-charger: prefix mobile messages with the charger
+        # name in square brackets so the user knows which charger fired
+        # the event. The charger-display message stays bare — the
+        # charger already knows it's itself.
+        #
+        # Note: ``_last_mobile_time`` stays fleet-wide (not per-charger)
+        # by design. Users want a quiet phone, not one push per charger
+        # per state change. The KEBA notification IS per-charger though
+        # — that one fires for every state change on every charger.
+        if charger_name and messages.get("mobile"):
+            messages["mobile"] = f"[{charger_name}] {messages['mobile']}"
+
         # Fire HA event for automation triggers (#47)
         if messages.get("mobile") or messages.get("charger"):
             self.hass.bus.async_fire(f"{DOMAIN}_notification", {
                 "state": new_state,
                 "message": messages.get("mobile") or messages.get("keba", ""),
                 "category": "charging",
+                "charger_id": charger_id,
+                "charger_name": charger_name,
             })
 
         if keba_enabled and messages.get("charger"):

--- a/coordinator/per_charger_context.py
+++ b/coordinator/per_charger_context.py
@@ -1,0 +1,256 @@
+"""Per-charger context manager (v1.6.7).
+
+Lifts the ad-hoc ``saved = {...}`` swap dict at the head of the
+per-charger loop in ``coordinator.py`` into a typed context manager so:
+
+1. **The swap surface is one place to edit.** Adding a new per-charger
+   field used to require touching three locations (the saved dict, the
+   per-charger storage dict, the restore block). Now: add a field here.
+
+2. **The per-charger invariant is structural.** Inside a
+   ``with PerChargerContext.for_charger(...)`` block, you read
+   ``pcc.this_power_w`` etc. — not ``power.ev_power``. Future code
+   reviewers and the AST lint planned for v1.6.8 can mechanically check
+   this.
+
+3. **Zero behaviour change for v1.6.7.** The semantics of the swap +
+   restore + per-charger persistence are exactly what the
+   ``coordinator.py:1136-1258`` block did. Single-charger users never
+   enter the multi-charger loop and so are unaffected.
+
+See ``docs/MULTI_CHARGER.md`` for the full invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Optional
+
+if TYPE_CHECKING:
+    from .coordinator import SEMCoordinator
+
+
+@dataclass
+class PerChargerContext:
+    """Per-charger state for ONE iteration of the multi-charger loop.
+
+    Use via the ``for_charger`` classmethod as a context manager:
+
+    .. code-block:: python
+
+        for cid, ev_dev in sorted_chargers:
+            with PerChargerContext.for_charger(
+                coord, cid, ev_dev, budget_per_charger,
+            ) as pcc:
+                if pcc.skipped_for_night:
+                    continue
+                await coord._execute_ev_control(
+                    pcc.effective_state, power, energy, charging_context,
+                )
+
+    The ``__enter__`` hook swaps the coordinator's primary-charger
+    attributes (``_ev_device``, ``_ev_stalled_since``, etc.) to this
+    charger's values; ``__exit__`` persists any updates back into the
+    per-charger storage dicts and restores the primary's fleet view.
+
+    Fields are populated incrementally across v1.6.7 — v1.6.9:
+
+    - v1.6.7: identity (``cid``, ``ev_dev``, ``charger_cfg``) + the swap
+      mechanism (no new computed fields; the existing inline maths in
+      ``coordinator.py`` continue to run inside the ``with`` block).
+    - v1.6.8: ``effective_strategy``, ``this_power_w`` migrated from
+      ``ev_control._this_charger_power``.
+    - v1.6.9: ``per_charger_flows`` from the per-charger flow calculator.
+    """
+
+    # ------------------------------------------------------------------
+    # Identity (set by ``for_charger``)
+    # ------------------------------------------------------------------
+    cid: str
+    """The charger id (``ev_chargers[].id``). Stable across cycles."""
+
+    ev_dev: Any
+    """The ``EVDevice`` (KEBA, Wallbox, …) instance for this charger."""
+
+    charger_cfg: dict
+    """The per-charger config dict from ``ev_chargers`` (or ``{}``)."""
+
+    # ------------------------------------------------------------------
+    # Budget + skip flag (set by ``for_charger``)
+    # ------------------------------------------------------------------
+    budget_w: Optional[float] = None
+    """Per-charger surplus budget in watts, or ``None`` outside a solar
+    state (matches ``self._current_charger_budget`` semantics)."""
+
+    skipped_for_night: bool = False
+    """``True`` when the charger's mode opts it out of the current night
+    state (set during ``for_charger`` based on ``_mode_allows_night_charging``)."""
+
+    # ------------------------------------------------------------------
+    # Internal: references + the swap snapshot.
+    # ------------------------------------------------------------------
+    _coord: "Optional[SEMCoordinator]" = field(default=None, repr=False)
+    """The coordinator. Held so ``__enter__/__exit__`` can mutate it."""
+
+    _saved: dict = field(default_factory=dict, repr=False)
+    """Coordinator attributes captured at ``__enter__``, restored at
+    ``__exit__``. Mirrors the pre-v1.6.7 ``saved = {...}`` dict."""
+
+    _saved_vehicle_soc: Any = field(default=None, repr=False)
+    """``_cycle_vehicle_soc`` captured separately because it has its own
+    legacy save path (``saved_vehicle_soc_ctrl`` in the old code)."""
+
+    _entered: bool = field(default=False, repr=False)
+    """Guard against nested entry. The coordinator loop is single-threaded
+    per cycle; nesting would corrupt the swap snapshot."""
+
+    # ------------------------------------------------------------------
+    # Factory
+    # ------------------------------------------------------------------
+    @classmethod
+    def for_charger(
+        cls,
+        coordinator: "SEMCoordinator",
+        cid: str,
+        ev_dev: Any,
+        ev_budget_per_charger: dict,
+        chargers_by_id: Optional[dict] = None,
+    ) -> "PerChargerContext":
+        """Build a per-charger context.
+
+        Looks up the per-charger config dict and the per-charger budget
+        from the cycle-level distribution. Computes ``skipped_for_night``
+        based on the charger's mode and the current global charging
+        state — but only when the global state is a night state; for
+        solar states, ``skipped_for_night`` stays ``False`` and the
+        caller proceeds normally.
+
+        Args:
+            coordinator: the ``SEMCoordinator`` instance (passed so we
+                can mutate it in ``__enter__``).
+            cid: this charger's id.
+            ev_dev: this charger's ``EVDevice`` instance.
+            ev_budget_per_charger: the per-charger budget dict from
+                ``self._surplus_controller.distribute_ev_budget``. May
+                contain a value for ``cid`` (solar state) or be empty
+                (night state).
+            chargers_by_id: optional pre-built ``{cid: cfg}`` lookup the
+                caller can pass to avoid rebuilding it inside the loop.
+                If ``None``, this method rebuilds it from
+                ``coordinator.config``.
+
+        Returns:
+            A ``PerChargerContext`` ready to be used as a context manager.
+        """
+        if chargers_by_id is None:
+            chargers_by_id = {
+                (c.get("id") or "ev_charger"): c
+                for c in (coordinator.config.get("ev_chargers") or [])
+                if isinstance(c, dict)
+            }
+        charger_cfg = chargers_by_id.get(cid, {})
+        budget_w = ev_budget_per_charger.get(cid) if ev_budget_per_charger else None
+        return cls(
+            cid=cid,
+            ev_dev=ev_dev,
+            charger_cfg=charger_cfg,
+            budget_w=budget_w,
+            _coord=coordinator,
+        )
+
+    # ------------------------------------------------------------------
+    # Context manager protocol
+    # ------------------------------------------------------------------
+    def __enter__(self) -> "PerChargerContext":
+        """Push this charger's state onto the coordinator.
+
+        Captures the coordinator's primary-charger attributes into
+        ``_saved`` so ``__exit__`` can restore them; then writes this
+        charger's per-charger state (read from the coordinator's
+        ``_ev_*_per_charger`` dicts) into the primary attributes so
+        downstream methods that still read ``self._ev_*`` see THIS
+        charger's view.
+
+        Raises:
+            RuntimeError: on nested entry. The per-charger loop is
+                strictly serial; nesting would clobber ``_saved``.
+        """
+        if self._entered:
+            raise RuntimeError(
+                "PerChargerContext entered twice — the per-charger loop "
+                "must be serial. This indicates a coordinator init or "
+                "refactor bug."
+            )
+        self._entered = True
+        coord = self._coord
+        assert coord is not None, "PerChargerContext._coord must be set"
+
+        # Snapshot the primary attributes BEFORE swapping in this charger's
+        # values. The same set of fields the legacy ``saved = {...}`` dict
+        # captured at coordinator.py:1136-1144 in the pre-v1.6.7 code.
+        self._saved = {
+            "dev": coord._ev_device,
+            "stalled": coord._ev_stalled_since,
+            "enable": coord._ev_enable_surplus_since,
+            "started": coord._ev_charge_started_at,
+            "change": coord._ev_last_change_time,
+            "reenable_attempts": coord._ev_reenable_attempts,
+            "charge_refused": coord._ev_charge_refused,
+            "current_charger_budget": coord._current_charger_budget,
+        }
+        self._saved_vehicle_soc = coord._cycle_vehicle_soc
+
+        # Push this charger's state onto the coordinator.
+        coord._ev_device = self.ev_dev
+        coord._ev_stalled_since = coord._ev_stalled_since_per_charger.get(self.cid)
+        coord._ev_enable_surplus_since = coord._ev_enable_surplus_per_charger.get(self.cid)
+        coord._ev_charge_started_at = coord._ev_charge_started_per_charger.get(self.cid)
+        coord._ev_last_change_time = coord._ev_last_change_per_charger.get(self.cid)
+        coord._ev_reenable_attempts = coord._ev_reenable_attempts_per_charger.get(self.cid, 0)
+        coord._ev_charge_refused = coord._ev_charge_refused_per_charger.get(self.cid, False)
+        coord._current_charger_budget = self.budget_w
+
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> bool:
+        """Pop this charger's state back into per-charger dicts and
+        restore the primary view.
+
+        Always runs (including on exceptions raised by
+        ``_execute_ev_control``) so the coordinator's primary view is
+        never left mid-swap. Mirrors the ``finally:`` block at the
+        coordinator.py:1242-1258 in the pre-v1.6.7 code.
+
+        Returns:
+            ``False`` so exceptions propagate to the caller (matching
+            the legacy ``try/except (HomeAssistantError, ServiceValidationError)``
+            handling in coordinator.py).
+        """
+        coord = self._coord
+        assert coord is not None, "PerChargerContext._coord must be set"
+        try:
+            # Save back this charger's per-charger state.
+            coord._ev_stalled_since_per_charger[self.cid] = coord._ev_stalled_since
+            coord._ev_enable_surplus_per_charger[self.cid] = coord._ev_enable_surplus_since
+            coord._ev_charge_started_per_charger[self.cid] = coord._ev_charge_started_at
+            coord._ev_last_change_per_charger[self.cid] = coord._ev_last_change_time
+            coord._ev_reenable_attempts_per_charger[self.cid] = coord._ev_reenable_attempts
+            coord._ev_charge_refused_per_charger[self.cid] = coord._ev_charge_refused
+
+            # Restore primary view.
+            coord._ev_device = self._saved["dev"]
+            coord._ev_stalled_since = self._saved["stalled"]
+            coord._ev_enable_surplus_since = self._saved["enable"]
+            coord._ev_charge_started_at = self._saved["started"]
+            coord._ev_last_change_time = self._saved["change"]
+            coord._ev_reenable_attempts = self._saved["reenable_attempts"]
+            coord._ev_charge_refused = self._saved["charge_refused"]
+            # ``_current_charger_budget`` is cleared to ``None`` in the
+            # legacy code rather than restored to its pre-loop value —
+            # preserve that semantic (the post-loop reader treats
+            # non-None as "I'm currently inside a per-charger iteration").
+            coord._current_charger_budget = None
+            coord._cycle_vehicle_soc = self._saved_vehicle_soc
+        finally:
+            self._entered = False
+        return False  # never swallow exceptions

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -423,14 +423,29 @@ class SensorReader:
             readings.battery_soc = self._last_valid_soc
             readings.battery_soc_unavailable = True
 
-        # EV power — sum all chargers if multi-charger (#193), else single sensor
+        # EV power — sum all chargers if multi-charger (#193), else single sensor.
+        # v1.6.9 also populates ``ev_power_per_charger`` so the flow calculator
+        # can produce per-charger flow attribution (closes #316 family).
+        #
+        # Note: chargers without a configured ``ev_charging_power_sensor``
+        # (misconfig) are excluded from both ``ev_power_per_charger``
+        # AND the fleet sum. Downstream consumers that iterate
+        # ``config['ev_chargers']`` and look up the dict must guard
+        # ``.get(cid)`` rather than ``[cid]`` — a charger that's
+        # configured but has no power sensor will be silently absent.
         ev_chargers = self._raw_config.get("ev_chargers", [])
         if len(ev_chargers) > 1:
             total_ev = 0.0
             for charger_cfg in ev_chargers:
+                cid = charger_cfg.get("id")
                 cps = charger_cfg.get("ev_charging_power_sensor")
                 if cps:
-                    total_ev += self._read_sensor(cps, "ev")
+                    cw = self._read_sensor(cps, "ev")
+                    total_ev += cw
+                    if cid:
+                        # Per-charger draw in watts, exposed for
+                        # ``flow_calculator`` per-charger split.
+                        readings.ev_power_per_charger[cid] = cw
             readings.ev_power = total_ev
         elif ed.ev_power:
             readings.ev_power = self._read_sensor(ed.ev_power, "ev")

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -35,6 +35,15 @@ class PowerReadings:
     ev_power: float = 0.0
     home_consumption_power: float = 0.0
 
+    # Per-charger EV power (v1.6.9). Populated by ``sensor_reader`` for
+    # multi-charger setups (``len(ev_chargers) > 1``); each key is a
+    # charger id and the value is that charger's draw in watts. Sum of
+    # values equals ``ev_power``. Empty dict in single-charger setups —
+    # downstream code must fall back to ``ev_power`` when the dict is
+    # empty (see ``flow_calculator.calculate_power_flows``). Drives the
+    # per-charger flow attribution that closes the #316 family.
+    ev_power_per_charger: "Dict[str, float]" = field(default_factory=dict)
+
     # Derived values
     grid_import_power: float = 0.0
     grid_export_power: float = 0.0
@@ -74,6 +83,25 @@ class PowerReadings:
 
 
 @dataclass
+class ChargerFlows:
+    """Per-charger slice of the EV power flow attribution (v1.6.9).
+
+    Mirrors the EV-relevant subset of :class:`PowerFlows` for ONE
+    charger. The fleet-level ``PowerFlows.solar_to_ev`` (etc.) is the
+    sum over all chargers' values here — invariant pinned in the
+    scenario tests.
+
+    Closes the #316 / #284 family of multi-charger complaints
+    ("charger 2 looks like it's drawing from grid even in solar_only
+    mode") by exposing per-charger sourcing the dashboard can render
+    instead of attributing the fleet proportional split equally.
+    """
+    solar_to_ev: float = 0.0
+    grid_to_ev: float = 0.0
+    battery_to_ev: float = 0.0
+
+
+@dataclass
 class PowerFlows:
     """Power flow distribution between sources and destinations."""
     # Solar flows (W)
@@ -90,6 +118,15 @@ class PowerFlows:
     # Battery flows (W)
     battery_to_home: float = 0.0
     battery_to_ev: float = 0.0
+
+    # Per-charger EV flow split (v1.6.9). Populated by
+    # ``flow_calculator.calculate_power_flows`` when ``PowerReadings``
+    # provides ``ev_power_per_charger``. Sum invariant:
+    # ``sum(c.solar_to_ev for c in per_charger.values()) == solar_to_ev``
+    # (similarly for grid_to_ev and battery_to_ev). Empty dict in
+    # single-charger setups — backward-compat for downstream readers
+    # that only know about the fleet-level fields.
+    per_charger: "Dict[str, ChargerFlows]" = field(default_factory=dict)
 
 
 @dataclass

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+from pathlib import Path
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -10,6 +12,64 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .coordinator import SEMCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Recent-log surface (v1.6.11). When users report a bug via "Copy
+# diagnostics", the dump now also includes the last few SEM-related
+# log lines so we can see what was actually happening at the time
+# without asking the reporter for a separate ``ha core logs`` dump.
+#
+# Defensive caps — the diagnostics dump is shown in the user's
+# clipboard / a GitHub issue, so we don't want it to balloon and we
+# don't want to crash on log files that have grown unbounded.
+_LOG_TAIL_KB = 2048           # only read the last 2 MB of the log
+_LOG_MAX_LINES = 80           # return up to 80 matching lines
+_LOG_NEEDLE = "solar_energy_management"
+
+
+async def _get_recent_sem_logs(hass: HomeAssistant) -> list[str]:
+    """Return the most recent SEM-related lines from ``home-assistant.log``.
+
+    Tails the file (up to ``_LOG_TAIL_KB``), filters for
+    ``solar_energy_management`` mentions, and returns the last
+    ``_LOG_MAX_LINES`` matches in order.
+
+    Returns a one-line placeholder explaining why if the file isn't
+    accessible — most commonly that's a Home Assistant Supervisor
+    install where logs go to journald rather than a flat file (the
+    user can still attach ``ha core logs`` output separately). Never
+    raises: a failure here must not break the rest of the diagnostics
+    dump.
+    """
+    try:
+        log_path = Path(hass.config.config_dir) / "home-assistant.log"
+        if not log_path.exists():
+            return [
+                "<no flat log file at .storage parent — Supervisor "
+                "installs use journald; please paste output of "
+                "`ha core logs | grep solar_energy_management | tail -80`>"
+            ]
+
+        def _read_tail() -> list[str]:
+            with open(log_path, "rb") as f:
+                f.seek(0, 2)
+                size = f.tell()
+                start = max(0, size - _LOG_TAIL_KB * 1024)
+                f.seek(start)
+                if start > 0:
+                    f.readline()  # discard the partial first line
+                payload = f.read().decode("utf-8", errors="replace")
+            sem_lines = [
+                line for line in payload.splitlines()
+                if _LOG_NEEDLE in line
+            ]
+            return sem_lines[-_LOG_MAX_LINES:]
+
+        return await hass.async_add_executor_job(_read_tail)
+    except Exception as e:  # pragma: no cover - defensive only
+        _LOGGER.debug("Failed to read recent SEM logs for diagnostics: %s", e)
+        return [f"<failed to read logs: {e!r}>"]
 
 type SEMConfigEntry = ConfigEntry[SEMCoordinator]
 
@@ -118,6 +178,12 @@ async def async_get_config_entry_diagnostics(
             "grid_energy_device_resolved": grid_device_resolved,
         }
 
+    # v1.6.11: bundle the last ~80 SEM-related log lines into the
+    # diagnostics dump so bug reports come pre-loaded with the
+    # surrounding log context. See ``_get_recent_sem_logs`` for the
+    # defensive caps and the Supervisor-install fallback.
+    recent_logs = await _get_recent_sem_logs(hass)
+
     return {
         "config_entry": {
             "entry_id": entry.entry_id,
@@ -198,4 +264,5 @@ async def async_get_config_entry_diagnostics(
             "price_level": data.get("tariff_price_level"),
             "provider": data.get("tariff_provider"),
         },
+        "recent_logs": recent_logs,
     }

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -29,9 +29,11 @@ fleet's" — can be enforced structurally rather than by memory.
 
 ## The invariant
 
-> **Inside a `with PerChargerContext.for_charger(...)` block, never read
-> `power.ev_power` directly. Use `pcc.this_power_w` (added in v1.6.8) or
-> tag the read explicitly with `# FLEET-READ: <reason>`.**
+> **Inside a `with PerChargerContext.for_charger(...)` block — including
+> any method called from inside that block, transitively — never read
+> `power.ev_power` directly. Use `self._this_charger_power(ev, power)`
+> (cached as `this_power_w` at the top of the method) or tag the read
+> explicitly with `# FLEET-READ: <reason>`.**
 
 Likewise: never read `self._ev_*` directly; the context owns them and
 they reflect THIS charger only during the block. Reading them from
@@ -40,6 +42,36 @@ outside the block returns the primary charger's view (the legacy
 
 To add a new per-charger field, edit `PerChargerContext` only —
 don't add new ad-hoc swap dicts.
+
+### `# FLEET-READ:` annotation
+
+The lint test at `tests/test_ev_control_fleet_reads.py` parses
+`coordinator/ev_control.py` and fails CI on any `power.ev_power` read
+that is **not** either (a) inside the sanctioned `_this_charger_power`
+helper or (b) annotated with `# FLEET-READ: <reason>` on the same line
+or the immediately preceding line. The reason text is required and
+shows up in code review — keep it short and concrete:
+
+```python
+# Bad — would fail the lint
+if power.ev_power > 100:
+    ...
+
+# Good (per-charger; the right answer 99% of the time)
+this_power_w = self._this_charger_power(ev, power)
+if this_power_w > 100:
+    ...
+
+# Good (rare: genuinely fleet-level, e.g. a fleet-aggregating sensor)
+# FLEET-READ: aggregating total EV draw for the dashboard fleet card
+fleet_ev_w = power.ev_power
+```
+
+The lint is intentionally cheap (AST walk, no runtime) so it runs on
+every PR. If you find yourself reaching for the annotation, ask
+yourself: is this code actually inside the per-charger loop? If yes,
+you almost certainly want `this_power_w`. If no, you don't need the
+annotation at all — the lint only flags reads inside `ev_control.py`.
 
 ---
 

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -141,6 +141,7 @@ the structural invariant.
 | **v1.6.9** | Per-charger flow attribution + per-charger notification flap suppression | ✓ shipped |
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
+| **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
 
 ### What landed under the abstraction
 

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -1,0 +1,134 @@
+# Multi-Charger Correctness — Developer Guide
+
+This document is the source of truth for **developers** working on SEM's
+multi-charger code paths. For end-user setup with multiple chargers, see
+[`MULTI_DEVICE_GUIDE.md`](MULTI_DEVICE_GUIDE.md).
+
+---
+
+## The bug class we keep finding
+
+Between v1.6.0 and v1.6.6 SEM shipped four hotfixes for variants of the
+same bug — each one a "per-charger context swap with fleet-level reads
+still leaking through":
+
+| Release | Issue | Fix shape |
+|---|---|---|
+| v1.6.0 | #284 | Distributor used the legacy `_calculate_solar_ev_budget` formula instead of the canonical `EVBudget.net_w` |
+| v1.6.5 | #289 | Fleet aggregation on the 10 s cycle hid sub-cycle KEBA spikes |
+| v1.6.5 | #315 | `_this_charger_power` helper introduced because the off-mode terminator read `power.ev_power` (fleet sum) |
+| v1.6.6 | #318 | `_update_per_charger_detector_energy` helper introduced because `update_energy()` was only called on the primary detector |
+
+Each was a separate band-aid. The v1.6.7 cleanup
+([`PerChargerContext`](../coordinator/per_charger_context.py)) lifts the
+swap mechanism into a typed context manager so that the **invariant** —
+"inside a per-charger iteration, read this charger's view, not the
+fleet's" — can be enforced structurally rather than by memory.
+
+---
+
+## The invariant
+
+> **Inside a `with PerChargerContext.for_charger(...)` block, never read
+> `power.ev_power` directly. Use `pcc.this_power_w` (added in v1.6.8) or
+> tag the read explicitly with `# FLEET-READ: <reason>`.**
+
+Likewise: never read `self._ev_*` directly; the context owns them and
+they reflect THIS charger only during the block. Reading them from
+outside the block returns the primary charger's view (the legacy
+"fleet" semantic for backward compat).
+
+To add a new per-charger field, edit `PerChargerContext` only —
+don't add new ad-hoc swap dicts.
+
+---
+
+## What the context manager owns
+
+`coordinator/per_charger_context.py` ([source](../coordinator/per_charger_context.py)):
+
+| Coordinator attribute | Role |
+|---|---|
+| `_ev_device` | The active charger's `EVDevice` instance |
+| `_ev_stalled_since` | Per-charger stall detection state |
+| `_ev_enable_surplus_since` | Per-charger enable-surplus timer |
+| `_ev_charge_started_at` | Per-charger session start timestamp |
+| `_ev_last_change_time` | Per-charger ramp-rate gate |
+| `_ev_reenable_attempts` | Per-charger re-enable retry counter |
+| `_ev_charge_refused` | Per-charger "charger refused" flag |
+| `_current_charger_budget` | This charger's slice of `EVBudget.net_w` |
+| `_cycle_vehicle_soc` | This charger's vehicle SOC (per `vehicle_soc_entity`) |
+
+The corresponding `_per_charger` dicts (e.g.
+`_ev_stalled_since_per_charger: Dict[str, datetime]`) are the **storage**;
+the context manager pushes from them on `__enter__` and saves back on
+`__exit__`.
+
+---
+
+## How to add a new per-charger field
+
+1. Add it as a field on the `PerChargerContext` dataclass.
+2. Add a `_<field>_per_charger: Dict[str, ...]` to `SEMCoordinator`.
+3. Push/save in `__enter__`/`__exit__` — mirror the existing fields.
+4. Add a unit test in `tests/test_per_charger_context.py` asserting:
+   - In-context reads see this charger's value.
+   - Mutations persist to the per-charger dict after exit.
+   - Different chargers don't see each other's value.
+
+That's it. **Don't** add a new `saved = {...}` dict in
+`coordinator.py`; the loop body already wraps everything in a `with`
+block.
+
+---
+
+## Why a `with` block instead of a function?
+
+Because the existing code at the per-charger loop body is ~120 lines of
+inline mathematics (Min/Max remaining, night plan, off-mode override,
+strategy dispatch) that all mutate the shared `charging_context` object
+in place. Wrapping it in a function would require either threading every
+mutation through a return value (giant call site, fragile to extend) or
+mutating via reference (no clearer than the current state). The `with`
+form keeps the inline code identical and just owns the lifecycle of the
+swap.
+
+A future v1.7+ refactor *might* migrate the inline math onto methods on
+`PerChargerContext` (e.g. `pcc.compute_remaining_to_min()`,
+`pcc.effective_state`) — but that's incremental work, not a blocker for
+the structural invariant.
+
+---
+
+## Roadmap (v1.6.x cleanup)
+
+| Release | Theme | Status |
+|---|---|---|
+| v1.6.7 | Lift swap dict into `PerChargerContext` | **In progress** |
+| v1.6.8 | Per-charger strategy + `ev_control.py` fleet-read sweep + AST lint test | Planned |
+| v1.6.9 | Per-charger flow attribution + notifications (closes #316 family) | Planned |
+| v1.7 | New features — **only after** v1.6.9 lands clean on PROD | Blocked on above |
+
+See [`/home/sem/.claude/plans/greedy-whistling-nebula.md`](../../.claude/plans/greedy-whistling-nebula.md)
+for the full plan.
+
+---
+
+## Tests that pin the invariant
+
+- `tests/test_per_charger_context.py` — unit tests for the swap mechanism.
+- `tests/scenarios/2026-05-29_multi_charger_split.yaml` — Phase B.5
+  multi-charger budget distribution (RienduPre's Growatt + Wallbox setup).
+- v1.6.8 will add `tests/test_ev_control_fleet_reads.py` — AST walk that
+  fails CI if any `power.ev_power` read inside a per-charger loop is
+  missing the `# FLEET-READ:` annotation.
+
+---
+
+## See also
+
+- [`MULTI_DEVICE_GUIDE.md`](MULTI_DEVICE_GUIDE.md) — end-user setup for
+  multi-charger / multi-inverter installs.
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — overall coordinator design.
+- [`EV_CHARGING_LOGIC.md`](EV_CHARGING_LOGIC.md) — Charge mode + budget
+  priority cascade.

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -132,17 +132,60 @@ the structural invariant.
 
 ---
 
-## Roadmap (v1.6.x cleanup)
+## Roadmap (what shipped vs. what's deferred)
 
 | Release | Theme | Status |
 |---|---|---|
-| v1.6.7 | Lift swap dict into `PerChargerContext` | **In progress** |
-| v1.6.8 | Per-charger strategy + `ev_control.py` fleet-read sweep + AST lint test | Planned |
-| v1.6.9 | Per-charger flow attribution + notifications (closes #316 family) | Planned |
-| v1.7 | New features — **only after** v1.6.9 lands clean on PROD | Blocked on above |
+| **v1.6.7** | Lift swap dict into `PerChargerContext` (identity + budget + skip flag) | ✓ shipped |
+| **v1.6.8** | `ev_control.py` fleet-read sweep + AST lint test enforcing `# FLEET-READ:` | ✓ shipped |
+| **v1.6.9** | Per-charger flow attribution + per-charger notification flap suppression | ✓ shipped |
+| **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
+| **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
+
+### What landed under the abstraction
+
+`PerChargerContext` owns the **swap surface** for nine coordinator
+attributes (8 in `_saved` + `_cycle_vehicle_soc`). The fields
+currently on the dataclass are: `cid`, `ev_dev`, `charger_cfg`,
+`budget_w`, `skipped_for_night`.
+
+### What was planned-but-not-yet-on the context (deferred to v1.7+)
+
+The original v1.6.7 design proposed migrating these onto `pcc` as
+fields in v1.6.8/v1.6.9:
+
+- `effective_state` — currently stored in the parallel coordinator
+  dict `_effective_states_per_charger` and dispatched in
+  `_send_notifications`. Works correctly; not on the context object.
+- `this_power_w` — currently cached as a local variable per method
+  inside `coordinator/ev_control.py`. Works correctly; not on the
+  context object.
+- `night_plan`, `per_charger_flows` — likewise local / parallel.
+
+These are real abstraction leaks the v1.6.7 → v1.6.10 arc did not
+close. Plan for v1.7+: migrate at least `effective_state` and
+`this_power_w` onto `PerChargerContext` so the lint can enforce field
+access at type level.
+
+### What was descoped from v1.6.9 (also deferred to v1.7+)
+
+The plan listed per-charger flow **sensors**
+(`sensor.sem_charger_<id>_flow_solar_to_ev_power` etc.) as part of
+v1.6.9. The data is on `PowerFlows.per_charger` but no top-level HA
+entities expose it yet — the Sankey card needs the entity surface
+before it can render the per-charger split. Track as a v1.7+ feature
+once a consumer needs it.
+
+### Structural enforcement long-term
+
+The `# FLEET-READ:` AST lint catches the bug class but is, by
+construction, a stopgap: a contributor can write
+`# FLEET-READ: idk` and pass. A `FleetEvPower` newtype that requires
+explicit unwrap with a reason argument would be structurally
+stronger. Track for v1.7+.
 
 See [`/home/sem/.claude/plans/greedy-whistling-nebula.md`](../../.claude/plans/greedy-whistling-nebula.md)
-for the full plan.
+for the original plan.
 
 ---
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.6"
+  "version": "1.6.7"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.8"
+  "version": "1.6.9"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.10"
+  "version": "1.6.11"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.7"
+  "version": "1.6.8"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.11"
+  "version": "1.6.12"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.9"
+  "version": "1.6.10"
 }

--- a/select.py
+++ b/select.py
@@ -73,22 +73,15 @@ async def async_setup_entry(
     """Set up SEM select entities."""
     coordinator: SEMCoordinator = entry.runtime_data
 
-    # Remove the now-removed GLOBAL target-type select (#255): ev_target_type is
-    # per-charger only. Drop both the renamed global entity and its legacy
-    # ev_target_mode predecessor (#235) from the registry. Per-charger values were
-    # seeded from the global by the v3→v4 migration, so no data is lost.
-    try:
-        registry = er.async_get(hass)
-        for uid in (
-            f"{entry.entry_id}_ev_target_type", f"{entry.entry_id}_ev_target_mode",
-            f"{entry.entry_id}_ev_charging_mode",
-        ):
-            eid = registry.async_get_entity_id("select", DOMAIN, uid)
-            if eid:
-                registry.async_remove(eid)
-                _LOGGER.info("Removed global select %s (now per-charger, #255)", eid)
-    except Exception as e:
-        _LOGGER.debug("Global select removal skipped: %s", e)
+    # v1.6.10 (#309): the explicit removal block for the now-removed
+    # GLOBAL selects (``{entry_id}_ev_target_type``,
+    # ``{entry_id}_ev_target_mode``, ``{entry_id}_ev_charging_mode``)
+    # was folded into the registry-key sweep below. Each of those
+    # unique_ids has the prefix ``{entry_id}_`` and a key that is NOT
+    # in ``valid_keys = {SELECT_TYPES keys} | per_charger_keys``, so
+    # the sweep removes them just as cleanly. Per-charger values were
+    # seeded from the globals by the v3→v4 migration (#255), so no
+    # data is lost.
 
     entities = [
         SEMSelectEntity(coordinator, entry, description)

--- a/tests/scenario_harness.py
+++ b/tests/scenario_harness.py
@@ -66,6 +66,12 @@ TIMELINE_FIELDS = {
     "battery_soc", "battery_temperature", "battery_soc_unavailable",
     "ev_connected", "ev_charging",
     "home_consumption_power",  # override the derived value when needed
+    # v1.6.12: per-charger EV draw in watts as a mapping ``{cid: watts}``.
+    # When present, populates ``PowerReadings.ev_power_per_charger`` so
+    # the flow calculator can produce ``PowerFlows.per_charger`` for
+    # multi-charger scenarios. ``ev_power`` is still the fleet sum; the
+    # values here should add to it (the harness does NOT auto-derive).
+    "ev_power_per_charger",
 }
 
 
@@ -166,6 +172,15 @@ def _build_power_readings(effective: Dict[str, Any]):
     # Allow explicit override of home_consumption_power for stale-sensor scenarios
     if "home_consumption_power" in effective:
         pr.home_consumption_power = float(effective["home_consumption_power"])
+    # v1.6.12: per-charger EV power for ``flow_calculator.calculate_power_flows``
+    # per-charger split. Sticky timeline carries the mapping forward like
+    # any other field.
+    if "ev_power_per_charger" in effective:
+        per_charger = effective["ev_power_per_charger"]
+        if isinstance(per_charger, dict):
+            pr.ev_power_per_charger = {
+                str(k): float(v) for k, v in per_charger.items()
+            }
     return pr
 
 
@@ -457,6 +472,63 @@ async def run_scenario(yaml_path: Path) -> ScenarioRun:
             "flow_battery_to_ev_power": power_flows.battery_to_ev,
         }
 
+        # v1.6.12: per-charger flow attribution. When the scenario
+        # populated ``ev_power_per_charger`` on the readings,
+        # ``calculate_power_flows`` produces a per-charger flow map
+        # (``PowerFlows.per_charger[cid] = ChargerFlows(...)``) that
+        # closes the #316 family. Surface those flows in the cycle
+        # result so the assertion machinery can pin them.
+        if power_flows.per_charger:
+            result["per_charger_flows"] = {
+                cid: {
+                    "solar_to_ev": cf.solar_to_ev,
+                    "grid_to_ev": cf.grid_to_ev,
+                    "battery_to_ev": cf.battery_to_ev,
+                }
+                for cid, cf in power_flows.per_charger.items()
+            }
+
+        # v1.6.12: per-charger effective state — exercise the same
+        # ``_apply_per_charger_off_override`` static helper the
+        # production multi-charger loop calls at coordinator.py:1217.
+        # Maps the fleet ``charging_state`` (from the state machine, or
+        # a synthetic ``SOLAR_CHARGING_ACTIVE`` here since the harness
+        # skips the state machine) onto each charger's effective state
+        # using its per-charger ``charge_mode``. This is the surface
+        # that #315's regression class shows up on.
+        ev_chargers_cfg = coord.config.get("ev_chargers") or []
+        if len(ev_chargers_cfg) >= 2 and strategy is not None:
+            from custom_components.solar_energy_management.consts.states import (
+                ChargingState,
+            )
+            from custom_components.solar_energy_management.coordinator import (
+                SEMCoordinator,
+            )
+            # Pick a fleet baseline that lets each charger's override
+            # branch reveal itself. SOLAR_CHARGING_ACTIVE = primary is
+            # actively charging; the override turns a per-charger
+            # ``off`` mode into SOLAR_IDLE (terminate) and leaves
+            # ``solar_only`` / ``min_plus_solar`` untouched.
+            global_state = (
+                ChargingState.SOLAR_CHARGING_ACTIVE
+                if strategy == "solar_only" else ChargingState.SOLAR_IDLE
+            )
+            per_charger_states: Dict[str, str] = {}
+            for c in ev_chargers_cfg:
+                cid = c.get("id") or "ev_charger"
+                # ``charge_mode`` lives in per-charger config; fall back
+                # through the same precedence the production helper
+                # uses (per-charger > global > default).
+                per_mode = c.get("charge_mode") or coord.config.get(
+                    "charge_mode", "min_plus_solar",
+                )
+                per_charger_states[cid] = (
+                    SEMCoordinator._apply_per_charger_off_override(
+                        global_state, per_mode,
+                    )
+                )
+            result["per_charger_effective_states"] = per_charger_states
+
         # Multi-charger distribution (Phase B.5 / #284). The canonical
         # ``ev_budget_obj`` computed above already represents the total
         # fleet budget; we pass its ``net_w`` through the real
@@ -623,6 +695,80 @@ def assert_expectations(run: ScenarioRun, scenario: Dict[str, Any]) -> None:
                     f"budget. Distributor returned {allocs}. "
                     f"Phase B.5 / #284 regression."
                 )
+
+        # v1.6.12: per-charger effective state assertion. Pinning the
+        # output of ``_apply_per_charger_off_override`` per charger
+        # closes the gap the senior-engineer review flagged on the
+        # v1.6.7→v1.6.10 arc (no scenario covered charger A=off +
+        # charger B=solar_only mixed). YAML shape:
+        #   multi_charger:
+        #     per_charger_effective_states:
+        #       charger_left: "solar_idle"     # exact match (case-insensitive)
+        #       charger_right_contains: "charging_allowed"   # substring
+        pces = mc.get("per_charger_effective_states") or {}
+        if pces:
+            cycles_with_states = [
+                c for c in run.cycles
+                if "per_charger_effective_states" in c.result
+            ]
+            assert cycles_with_states, (
+                "expect.multi_charger.per_charger_effective_states is set "
+                "but no cycle recorded per-charger effective states. "
+                "The scenario's ``ev_chargers`` block needs 2+ entries "
+                "AND a ``charge_mode`` on each charger."
+            )
+            last_states = cycles_with_states[-1].result["per_charger_effective_states"]
+            for key, expected in pces.items():
+                if key.endswith("_contains"):
+                    cid = key[: -len("_contains")]
+                    got = str(last_states.get(cid, "")).lower()
+                    assert str(expected).lower() in got, (
+                        f"per-charger effective state mismatch: charger "
+                        f"{cid!r} ended up as {got!r}, expected substring "
+                        f"{expected!r}. All states: {last_states}"
+                    )
+                else:
+                    cid = key
+                    got = str(last_states.get(cid, "")).lower()
+                    assert got == str(expected).lower(), (
+                        f"per-charger effective state mismatch: charger "
+                        f"{cid!r} ended up as {got!r}, expected exactly "
+                        f"{expected!r}. All states: {last_states}"
+                    )
+
+        # v1.6.12: per-charger flow attribution assertion. Pin the
+        # ``PowerFlows.per_charger`` map populated by
+        # ``flow_calculator.calculate_power_flows`` when the readings
+        # carry ``ev_power_per_charger``. The fleet-sum invariant is
+        # tested by ``test_per_charger_flows_319.py``; here we pin the
+        # per-charger user-visible attribution that closes #316. YAML:
+        #   multi_charger:
+        #     per_charger_flow_max:
+        #       charger_left:
+        #         grid_to_ev: 0       # solar_only must not draw grid
+        #       charger_right:
+        #         grid_to_ev: 10000   # min_plus_solar may
+        pcfm = mc.get("per_charger_flow_max") or {}
+        if pcfm:
+            cycles_with_flows = [
+                c for c in run.cycles if "per_charger_flows" in c.result
+            ]
+            assert cycles_with_flows, (
+                "expect.multi_charger.per_charger_flow_max is set but no "
+                "cycle recorded per-charger flows. The scenario timeline "
+                "needs ``ev_power_per_charger`` populated."
+            )
+            for cid, limits in pcfm.items():
+                for c in cycles_with_flows:
+                    flows = c.result["per_charger_flows"].get(cid) or {}
+                    for flow_key, max_w in limits.items():
+                        actual = float(flows.get(flow_key, 0.0))
+                        assert actual <= float(max_w) + 0.5, (
+                            f"Cycle t={c.t_seconds}: charger {cid!r} "
+                            f"per-charger flow {flow_key}={actual:.1f} W "
+                            f"exceeds max {float(max_w):.1f} W. "
+                            f"Full flows for charger: {flows}"
+                        )
 
         # `priority_order: true` — when budget can only feed N of M chargers,
         # the N lower-numbered priority chargers must get the budget.

--- a/tests/scenarios/2026-05-31_off_plus_solar_only.yaml
+++ b/tests/scenarios/2026-05-31_off_plus_solar_only.yaml
@@ -1,0 +1,153 @@
+name: "2026-05-31 multi-charger off + solar_only — v1.6.9 dispatch + #315 regression"
+description: |
+  Built in v1.6.12 to close the senior-engineer review gap on the
+  v1.6.7→v1.6.10 multi-charger cleanup arc — no scenario covered the
+  case where one charger is in ``off`` mode while a sibling is in
+  ``solar_only``. The gap is exactly where #315 (v1.6.4 / v1.6.5
+  off-mode self-resume) and the @RienduPre #284 / #316 flow-attribution
+  family hit production.
+
+  What this scenario pins, step by step:
+
+  1. **Per-charger effective state isolation** (v1.6.4
+     ``_apply_per_charger_off_override``). Fleet ``charging_state =
+     SOLAR_CHARGING_ACTIVE`` is the primary charger's view. The override
+     must turn charger_right's ``off`` mode into ``SOLAR_IDLE`` (which
+     in production routes through the actuator's terminal-state branch
+     → ``stop_session()`` → ``keba.disable``). Charger_left's
+     ``solar_only`` mode must stay untouched.
+
+  2. **Per-charger flow attribution** (v1.6.9 ``PowerFlows.per_charger``).
+     With ``ev_power_per_charger = {charger_left: 4000, charger_right:
+     0}``, the per-charger split must give all the EV-side flow to
+     ``charger_left`` and zero to ``charger_right``. This is the
+     visible attribution that @RienduPre asked for in #316.
+
+  3. **Budget distribution still sums to ≤ canonical** (Phase B.5 /
+     #284 invariant). Re-uses the contract from
+     ``2026-05-29_multi_charger_split.yaml`` so the cleanup didn't
+     regress the existing distribution math.
+
+  Why this is a YAML scenario and not a live test: HA-TEST has one
+  real KEBA. Faking a second charger with a deterministic state we
+  can assert on is exactly what this harness is for — see
+  ``tests/scenario_harness.py``.
+
+config:
+  battery_capacity_kwh: 15.0
+  battery_buffer_soc: 70
+  battery_auto_start_soc: 90
+  battery_priority_soc: 30
+  battery_assist_floor_soc: 60
+  battery_assist_max_power: 4500
+  # Solar_only on the primary so the fleet strategy is solar_only; that
+  # in turn makes the harness lift fleet ``charging_state`` to
+  # SOLAR_CHARGING_ACTIVE which gives the off-mode override branch a
+  # non-trivial input.
+  ev_charging_mode: "pv"
+  ev_min_current: 6
+  ev_max_current: 16
+  ev_phases: 3
+  ev_voltage: 230
+  daily_ev_target: 7.0
+
+  ev_chargers:
+    - id: charger_left
+      name: "Wallbox Left"
+      priority: 1
+      min_current: 6
+      max_current: 16
+      phases: 3
+      voltage: 230
+      # Solar-only mode: must not get terminated by the per-charger
+      # override; should keep participating in the budget split.
+      charge_mode: "solar_only"
+      ev_charging_mode: "pv"
+      daily_ev_target: 7.0
+    - id: charger_right
+      name: "Wallbox Right"
+      priority: 2
+      min_current: 6
+      max_current: 16
+      phases: 3
+      voltage: 230
+      # Off: per-charger override should produce SOLAR_IDLE for THIS
+      # charger so the actuator's TERMINAL branch fires. This is the
+      # #315 regression class.
+      charge_mode: "off"
+      ev_charging_mode: "pv"
+      daily_ev_target: 7.0
+
+cycle_seconds: 30
+
+# Steady-state regime: enough surplus to keep charger_left active, no
+# battery assist (SOC 75% = Zone 3, surplus only). charger_right is in
+# off mode, so even though it could physically draw, SEM must terminate
+# it via the override. We model that here by setting its per-charger
+# ev_power to 0 and giving charger_left the full draw.
+timeline:
+  # Solar 6000 W, EV 4000 W, grid_export 500 W → derived home ≈ 1500 W.
+  # No battery in play (SOC 75 = Zone 3 surplus-only). All flow into the
+  # EV comes from solar — no grid_to_ev. This is the canonical
+  # ``solar_only`` regime the assertion targets.
+  - t: 0
+    solar_power: 6000
+    grid_power: 500            # positive = exporting 500 W
+    battery_power: 0
+    battery_soc: 75
+    ev_power: 4000             # fleet sum — all of it is charger_left
+    ev_connected: true
+    # Per-charger draw mapping — only charger_left is actually pulling.
+    # The flow calculator splits the fleet flows by these shares.
+    ev_power_per_charger:
+      charger_left: 4000
+      charger_right: 0
+
+  - t: 30  # sticky-inherited steady state
+  - t: 60
+  - t: 90
+
+expect:
+  # The strategy decision logic is locked in by
+  # 2026-05-29_budget_unify_battery_assist.yaml. Here we just need a
+  # solar regime so the fleet state lifts to SOLAR_CHARGING_ACTIVE
+  # (the input the override branch needs to reveal itself).
+  strategy_substring: "solar_only"
+
+  multi_charger:
+    # Phase B.5 / #284 invariant re-asserted on top of the new mixed-mode
+    # case. Distribution math must not regress.
+    total_equals_canonical: true
+    tolerance_w: 1.0
+
+    # The headline v1.6.12 assertion: per-charger effective state
+    # follows per-charger ``charge_mode``, not the fleet view.
+    per_charger_effective_states:
+      # charger_left is solar_only → fleet SOLAR_CHARGING_ACTIVE
+      # passes through untouched. Match the substring rather than the
+      # exact ChargingState enum value so the test survives an enum
+      # rename / reorganisation.
+      charger_left_contains: "charging_active"
+      # charger_right is off → override forces SOLAR_IDLE which the
+      # actuator's terminal branch turns into ``stop_session()``.
+      # This is the #315 mitigation pinned at the unit-pipeline level.
+      charger_right_contains: "idle"
+
+    # The headline v1.6.12 flow assertion: with no actual EV draw on
+    # charger_right, the per-charger flow split must show zero EV
+    # attribution to charger_right. Pre-v1.6.9 the dashboard would
+    # have shown the fleet-proportional split which gave charger_right
+    # part of charger_left's solar — exactly @RienduPre's #316
+    # complaint.
+    per_charger_flow_max:
+      charger_right:
+        solar_to_ev: 0
+        grid_to_ev: 0
+        battery_to_ev: 0
+      # charger_left should NOT exceed the fleet solar_to_ev. The
+      # exact value depends on the home-consumption derivation, so we
+      # only cap the upper bound at a generous ceiling — the sum
+      # invariant (per-charger sums == fleet) is unit-tested
+      # separately in test_per_charger_flows_319.py.
+      charger_left:
+        grid_to_ev: 100  # solar_only must not drink grid

--- a/tests/test_charging_control.py
+++ b/tests/test_charging_control.py
@@ -259,23 +259,13 @@ def test_solar_target_reached(sm):
     assert state == ChargingState.SOLAR_CHARGING_ALLOWED
 
 
-def test_min_pv_mode(sm):
-    """Pin the state-machine mapping for ``charging_strategy="min_pv"``.
-
-    Post-#305 the producer side (`_determine_charging_strategy` and
-    `_canonical_strategy_from_legacy`) no longer emits the legacy
-    ``"min_pv"`` string, so `charging_control.py:208` is unreachable
-    in production. This test still exercises that branch directly
-    via a synthetic context to keep the SOLAR_MIN_PV mapping pinned
-    in case a future producer is reintroduced. If both the producer
-    and the consumer are dropped together, delete this test too.
-    """
-    ctx = _ctx(
-        ev_connected=True,
-        charging_strategy="min_pv",
-    )
-    state = sm.update_state(ctx)
-    assert state == ChargingState.SOLAR_MIN_PV
+# ``test_min_pv_mode`` + ``test_now_mode`` removed in #308 (v1.6.10):
+# the producer side dropped these strategies in #305 (PR #311) and the
+# consumer branches in ``charging_control.py:228-233`` were the only
+# remaining reachers. With both dropped, the synthetic-context tests
+# no longer pin a live mapping; ``ChargingState.SOLAR_MIN_PV`` is
+# still alive via the ``night_grid`` → ``EVBudgetStrategy.MIN_PV``
+# producer mapping at ``coordinator.py:2345``.
 
 
 def test_battery_assist_mode(sm):
@@ -287,16 +277,6 @@ def test_battery_assist_mode(sm):
     )
     state = sm.update_state(ctx)
     assert state == ChargingState.SOLAR_SUPER_CHARGING
-
-
-def test_now_mode(sm):
-    """Test 'now' strategy uses SOLAR_MIN_PV path."""
-    ctx = _ctx(
-        ev_connected=True,
-        charging_strategy="now",
-    )
-    state = sm.update_state(ctx)
-    assert state == ChargingState.SOLAR_MIN_PV
 
 
 # ──────────────────────────────────────────────

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,4 +1,5 @@
 """Tests for diagnostics support."""
+import asyncio
 import pytest
 from unittest.mock import MagicMock, patch
 from datetime import timedelta
@@ -10,8 +11,18 @@ from custom_components.solar_energy_management.diagnostics import (
 
 
 @pytest.fixture
-def hass():
+def hass(tmp_path):
     hass = MagicMock()
+    # v1.6.11 ``_get_recent_sem_logs`` reads
+    # ``hass.config.config_dir / home-assistant.log``. Point it at a
+    # temp dir so each test gets isolated log content rather than the
+    # absent /config path.
+    hass.config = MagicMock()
+    hass.config.config_dir = str(tmp_path)
+
+    async def _executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+    hass.async_add_executor_job = _executor
     return hass
 
 
@@ -134,3 +145,95 @@ def test_redact_keys_defined():
     # Non-sensitive keys should NOT be in redact list
     assert "battery_capacity_kwh" not in REDACT_CONFIG_KEYS
     assert "target_peak_limit" not in REDACT_CONFIG_KEYS
+
+
+# ──────────────────────────────────────────────────────────────────────
+# v1.6.11: recent SEM log tail bundled into the Copy-diagnostics output
+# ──────────────────────────────────────────────────────────────────────
+
+from pathlib import Path
+
+from custom_components.solar_energy_management.diagnostics import (
+    _get_recent_sem_logs,
+    _LOG_MAX_LINES,
+    _LOG_TAIL_KB,
+)
+
+
+def _write_log(hass, lines: list[str]) -> Path:
+    """Write a synthetic ``home-assistant.log`` into the temp config_dir."""
+    p = Path(hass.config.config_dir) / "home-assistant.log"
+    p.write_text("\n".join(lines) + "\n")
+    return p
+
+
+@pytest.mark.asyncio
+async def test_recent_logs_returns_only_sem_lines(hass):
+    """Filter must select only lines that mention
+    ``solar_energy_management`` — other integrations' chatter is
+    excluded."""
+    _write_log(hass, [
+        "2026-05-31 17:42:01.000 INFO (MainThread) [homeassistant.core] starting",
+        "2026-05-31 17:42:02.000 DEBUG (MainThread) [custom_components.solar_energy_management.coordinator] cycle ok",
+        "2026-05-31 17:42:03.000 WARNING (MainThread) [homeassistant.components.wled] WLED unreachable",
+        "2026-05-31 17:42:04.000 INFO (MainThread) [custom_components.solar_energy_management.devices.base] Charging session stopped via keba.disable",
+    ])
+    out = await _get_recent_sem_logs(hass)
+    assert len(out) == 2
+    assert all("solar_energy_management" in line for line in out)
+
+
+@pytest.mark.asyncio
+async def test_recent_logs_caps_lines(hass):
+    """Even if the log has thousands of SEM lines, only the last
+    ``_LOG_MAX_LINES`` (80) are returned."""
+    many = [
+        f"2026-05-31 17:42:00.{i:03d} INFO (MainThread) [custom_components.solar_energy_management] msg {i}"
+        for i in range(_LOG_MAX_LINES * 3)
+    ]
+    _write_log(hass, many)
+    out = await _get_recent_sem_logs(hass)
+    assert len(out) == _LOG_MAX_LINES
+    # Last line returned is the actual last matching line.
+    assert f"msg {_LOG_MAX_LINES * 3 - 1}" in out[-1]
+
+
+@pytest.mark.asyncio
+async def test_recent_logs_missing_file_returns_placeholder(hass):
+    """Supervisor installs and other no-file setups must not crash
+    and must explain themselves to the bug reporter."""
+    # No log file written → ``_get_recent_sem_logs`` returns a single
+    # explanatory line instead of raising.
+    out = await _get_recent_sem_logs(hass)
+    assert len(out) == 1
+    assert "no flat log file" in out[0]
+    assert "ha core logs" in out[0]
+
+
+@pytest.mark.asyncio
+async def test_recent_logs_truncates_huge_file(hass):
+    """Files bigger than ``_LOG_TAIL_KB`` are only tailed — we must
+    not OOM on multi-GB logs. The leading partial line gets discarded
+    so we never emit a half-line."""
+    # Write a > 2 MB log: padding non-SEM lines + SEM lines at the end.
+    padding = "x" * (_LOG_TAIL_KB * 1024 + 50_000)  # bigger than the tail
+    sem_marker = "2026-05-31 17:42:00.999 INFO [custom_components.solar_energy_management] late"
+    _write_log(hass, [padding, sem_marker])
+    out = await _get_recent_sem_logs(hass)
+    # The SEM line near the end MUST be returned.
+    assert any("late" in line for line in out)
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_includes_recent_logs(hass, entry, coordinator):
+    """End-to-end: the diagnostics dump now carries a ``recent_logs``
+    key. Bug reports come pre-loaded with surrounding context."""
+    _write_log(hass, [
+        "2026-05-31 17:42:00.000 INFO [custom_components.solar_energy_management.coordinator] success: True",
+    ])
+    entry.runtime_data = coordinator
+    hass.data = {"solar_energy_management": {entry.entry_id: coordinator}}
+    result = await async_get_config_entry_diagnostics(hass, entry)
+    assert "recent_logs" in result
+    assert isinstance(result["recent_logs"], list)
+    assert any("success: True" in line for line in result["recent_logs"])

--- a/tests/test_ev_control_fleet_reads.py
+++ b/tests/test_ev_control_fleet_reads.py
@@ -1,0 +1,222 @@
+"""AST lint: every ``power.ev_power`` read in ``ev_control.py`` must be
+either inside the per-charger helper or carry a ``# FLEET-READ:`` tag.
+
+The recurring bug class through v1.6.0 → v1.6.6 was per-charger code
+paths accidentally reading the fleet-summed ``power.ev_power``. v1.6.7
+lifted the swap mechanism into ``PerChargerContext`` and v1.6.8 sweeps
+the remaining reads in ``coordinator/ev_control.py`` to use
+``self._this_charger_power(ev, power)`` cached as ``this_power_w``
+locally.
+
+This test pins that invariant going forward — any new ``power.ev_power``
+read added to ``ev_control.py`` must be annotated with
+``# FLEET-READ: <reason>`` on the same line (or the immediately
+preceding line) or the test fails CI. This is the cheapest enforcement
+that catches the bug class on PR review rather than after release.
+
+The ``_this_charger_power`` helper itself is exempt — it's the
+sanctioned fallback path. Docstrings and comments mentioning
+``power.ev_power`` are also exempt because they're text, not code.
+
+See ``docs/MULTI_CHARGER.md`` for the full invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+EV_CONTROL_PY = (
+    Path(__file__).resolve().parent.parent / "coordinator" / "ev_control.py"
+)
+
+# Functions whose body is allowed to read ``power.ev_power`` directly.
+# Currently only the helper that DEFINES the fleet-fallback path.
+EXEMPT_FUNCTIONS = frozenset({"_this_charger_power"})
+
+# The annotation that opts a single read out of the lint. Place it as a
+# line comment on the same line as the read OR on the line above:
+#
+#     foo = power.ev_power  # FLEET-READ: explanation
+#
+#     # FLEET-READ: explanation
+#     foo = power.ev_power
+ANNOTATION = "# FLEET-READ:"
+
+
+def _find_function_for_line(tree: ast.Module, line: int) -> str | None:
+    """Return the innermost function definition enclosing the given line.
+
+    Walks the AST top-down looking for ``FunctionDef`` /
+    ``AsyncFunctionDef`` nodes whose line range contains ``line``.
+    Returns the name of the deepest match, or ``None`` if the read is at
+    module scope (which would itself be a bug — included in the lint
+    output for visibility).
+    """
+    best: tuple[int, str] | None = None  # (start_line, name)
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = getattr(node, "end_lineno", node.lineno)
+            if start <= line <= end:
+                if best is None or start > best[0]:
+                    best = (start, node.name)
+    return best[1] if best else None
+
+
+def _read_lines() -> list[str]:
+    return EV_CONTROL_PY.read_text().splitlines()
+
+
+def _find_ev_power_reads(tree: ast.Module) -> list[tuple[int, str]]:
+    """Return ``(line, enclosing_function)`` for every ``power.ev_power``
+    attribute read in the file."""
+    hits: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "ev_power"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "power"
+        ):
+            func = _find_function_for_line(tree, node.lineno) or "<module>"
+            hits.append((node.lineno, func))
+    return hits
+
+
+def _is_annotated(lines: list[str], line_no: int) -> bool:
+    """True if the read at ``line_no`` (1-based) carries a
+    ``# FLEET-READ:`` annotation on the same line or the immediately
+    preceding line.
+
+    Note: only **same-line** or **previous-line** annotations are
+    recognised. Two-lines-above doesn't count — keep the annotation
+    visually adjacent to the read so reviewers see it.
+
+    Also: only the ``power.ev_power`` dotted form is checked by the
+    lint (see ``_find_ev_power_reads``). ``getattr(power, "ev_power",
+    ...)`` would bypass the AST walker — by convention treat that as
+    forbidden anywhere outside ``_this_charger_power``, but it is not
+    mechanically enforced.
+    """
+    idx = line_no - 1  # to 0-based
+    same = lines[idx] if 0 <= idx < len(lines) else ""
+    prev = lines[idx - 1] if 0 < idx < len(lines) else ""
+    return ANNOTATION in same or ANNOTATION in prev
+
+
+class TestEvPowerReads:
+    """Pin the multi-charger invariant at lint level.
+
+    These tests parse ``coordinator/ev_control.py`` and check every
+    ``power.ev_power`` AST node. They do not exercise runtime behaviour
+    — that's covered by the unit and scenario tests.
+    """
+
+    def test_all_reads_are_exempt_or_annotated(self):
+        """Every ``power.ev_power`` read must be either inside the
+        sanctioned ``_this_charger_power`` helper OR carry a
+        ``# FLEET-READ:`` annotation explaining why a fleet sum is
+        deliberately wanted.
+
+        When this test fails, the message lists each offending read with
+        its line number and enclosing function. Fix by either:
+
+        1. Replacing the read with ``this_power_w`` (cached via
+           ``self._this_charger_power(ev, power)`` at the top of the
+           function) — the right answer for per-charger code paths.
+        2. Adding ``# FLEET-READ: <reason>`` immediately above or on the
+           same line — for the rare case where you genuinely mean the
+           fleet sum (e.g. a sensor that aggregates across the fleet).
+
+        Coverage caveats (intentional, both rare in practice):
+
+        - Only the ``power.ev_power`` dotted form is walked. A
+          ``getattr(power, "ev_power", 0.0)`` would silently bypass the
+          AST check — by convention this is treated as forbidden too,
+          but not mechanically enforced.
+        - The annotation must be on the same line as the read or the
+          one immediately above. Two-lines-above won't satisfy the
+          check — keep the annotation visually adjacent.
+        """
+        source = EV_CONTROL_PY.read_text()
+        tree = ast.parse(source)
+        lines = source.splitlines()
+
+        offenders: list[str] = []
+        for line_no, func in _find_ev_power_reads(tree):
+            if func in EXEMPT_FUNCTIONS:
+                continue
+            if _is_annotated(lines, line_no):
+                continue
+            offenders.append(f"  L{line_no} in {func}()")
+
+        assert not offenders, (
+            "Found unannotated ``power.ev_power`` reads in "
+            "``coordinator/ev_control.py`` outside the sanctioned helper "
+            "``_this_charger_power``. In multi-charger setups "
+            "``power.ev_power`` is the GLOBAL SUM across all chargers — "
+            "reading it directly inside a per-charger code path is the "
+            "bug class that caused #284, #289, #315 and #318.\n\n"
+            "Each offender:\n" + "\n".join(offenders) + "\n\n"
+            "Fix: either replace with ``this_power_w`` cached via "
+            "``self._this_charger_power(ev, power)`` (preferred), or "
+            "annotate with ``# FLEET-READ: <reason>`` on the same line or "
+            "the line immediately above (only when fleet semantics are "
+            "explicitly wanted).\n\n"
+            "See docs/MULTI_CHARGER.md for the full invariant."
+        )
+
+    def test_helper_is_only_exempt_function(self):
+        """The exemption list is intentionally minimal — exactly one
+        function. If you find yourself wanting to add another, talk to
+        a maintainer first; almost certainly the right answer is the
+        ``# FLEET-READ:`` annotation on the specific read instead."""
+        assert EXEMPT_FUNCTIONS == frozenset({"_this_charger_power"})
+
+    def test_lint_actually_detects_unannotated_reads(self):
+        """Sanity: if we deliberately strip the ``# FLEET-READ:``
+        annotations and re-run the analysis on a synthetic source, the
+        offender list is non-empty. Guards against the lint silently
+        passing because the AST walk found nothing (e.g. after a future
+        refactor that renames ``power`` to ``readings`` everywhere)."""
+        synthetic = (
+            "def f(power):\n"
+            "    if power.ev_power > 100:\n"  # unannotated -> should be flagged
+            "        return True\n"
+            "    return False\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits, "AST walker failed to find a power.ev_power read"
+        # The synthetic source has no annotation -> the offender list is
+        # non-empty.
+        unannotated = [h for h in hits if not _is_annotated(lines, h[0])]
+        assert unannotated, "Lint failed to flag unannotated read"
+
+    def test_annotation_on_same_line_exempts(self):
+        synthetic = (
+            "def f(power):\n"
+            "    return power.ev_power  # FLEET-READ: aggregate sensor\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits, "AST walker failed to find the read"
+        assert all(_is_annotated(lines, h[0]) for h in hits)
+
+    def test_annotation_on_previous_line_exempts(self):
+        synthetic = (
+            "def f(power):\n"
+            "    # FLEET-READ: aggregate sensor\n"
+            "    return power.ev_power\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert hits
+        assert all(_is_annotated(lines, h[0]) for h in hits)

--- a/tests/test_per_charger_context.py
+++ b/tests/test_per_charger_context.py
@@ -1,0 +1,220 @@
+"""Tests for ``coordinator/per_charger_context.py`` (v1.6.7).
+
+The context manager is a mechanical lift of the ad-hoc ``saved = {...}``
+swap dict at ``coordinator.py:1136-1258``. These tests pin:
+
+1. The swap captures every primary-charger attribute the legacy code
+   captured (no field bleeds into the next iteration).
+2. The save-back persists this charger's state to the
+   ``_ev_*_per_charger`` dicts.
+3. The restore is idempotent on exceptions (the ``finally``-like
+   semantic).
+4. Nested entry is forbidden — a sanity check for the single-threaded
+   per-cycle invariant.
+"""
+
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.per_charger_context import (
+    PerChargerContext,
+)
+
+
+def _make_coord(ev_chargers=None):
+    """A minimal coordinator stub with only the per-charger swap surface.
+
+    Keeping the fixture small means future coordinator refactors won't
+    flake these tests — we only depend on the 8 ``_ev_*`` attributes the
+    swap touches.
+    """
+    coord = MagicMock()
+    coord.config = {"ev_chargers": ev_chargers or [{"id": "left"}, {"id": "right"}]}
+    # Primary view (the "fleet" attributes that get swapped per iteration).
+    coord._ev_device = None
+    coord._ev_stalled_since = None
+    coord._ev_enable_surplus_since = None
+    coord._ev_charge_started_at = None
+    coord._ev_last_change_time = None
+    coord._ev_reenable_attempts = 0
+    coord._ev_charge_refused = False
+    coord._current_charger_budget = None
+    coord._cycle_vehicle_soc = None
+    # Per-charger storage dicts (populated/read by the context manager).
+    coord._ev_stalled_since_per_charger = {}
+    coord._ev_enable_surplus_per_charger = {}
+    coord._ev_charge_started_per_charger = {}
+    coord._ev_last_change_per_charger = {}
+    coord._ev_reenable_attempts_per_charger = {}
+    coord._ev_charge_refused_per_charger = {}
+    return coord
+
+
+class TestSwapInvariant:
+    """The primary view must be restored exactly after the ``with`` block."""
+
+    def test_restores_primary_after_clean_exit(self):
+        """No mutation, clean exit: primary view unchanged."""
+        coord = _make_coord()
+        coord._ev_device = "FLEET_DEV"
+        coord._ev_stalled_since = "FLEET_STALL"
+        coord._cycle_vehicle_soc = 42.0
+
+        ev_dev = MagicMock(name="left_dev")
+        with PerChargerContext.for_charger(coord, "left", ev_dev, {"left": 4000.0}):
+            # Inside: coordinator sees the per-charger view.
+            assert coord._ev_device is ev_dev
+            assert coord._current_charger_budget == 4000.0
+
+        # Outside: primary view restored.
+        assert coord._ev_device == "FLEET_DEV"
+        assert coord._ev_stalled_since == "FLEET_STALL"
+        assert coord._cycle_vehicle_soc == 42.0
+
+    def test_restores_primary_after_exception(self):
+        """If the body raises, primary view is still restored.
+
+        The legacy code used a ``try/finally`` block; the context manager
+        must offer the same guarantee so a charger-control failure can't
+        leak its swap into the next iteration.
+        """
+        coord = _make_coord()
+        coord._ev_device = "FLEET_DEV"
+
+        ev_dev = MagicMock(name="left_dev")
+        with pytest.raises(RuntimeError, match="boom"):
+            with PerChargerContext.for_charger(coord, "left", ev_dev, {"left": 4000.0}):
+                assert coord._ev_device is ev_dev
+                raise RuntimeError("boom")
+
+        assert coord._ev_device == "FLEET_DEV"
+        assert coord._current_charger_budget is None  # legacy semantic
+
+    def test_per_charger_state_persists_across_iterations(self):
+        """Mutations to ``_ev_stalled_since`` inside the context land in
+        the per-charger dict so the next iteration of THIS charger sees
+        them."""
+        coord = _make_coord()
+        ev_dev_left = MagicMock(name="left_dev")
+        ev_dev_right = MagicMock(name="right_dev")
+
+        # First pass through charger "left": stash a stalled timestamp.
+        stall_ts = datetime(2026, 5, 31, 16, 0, 0)
+        with PerChargerContext.for_charger(coord, "left", ev_dev_left, {}):
+            coord._ev_stalled_since = stall_ts
+            coord._ev_reenable_attempts = 3
+            coord._ev_charge_refused = True
+
+        # Persisted to the per-charger dicts.
+        assert coord._ev_stalled_since_per_charger["left"] == stall_ts
+        assert coord._ev_reenable_attempts_per_charger["left"] == 3
+        assert coord._ev_charge_refused_per_charger["left"] is True
+
+        # Primary view back to its pre-entry default (None / 0 / False).
+        assert coord._ev_stalled_since is None
+        assert coord._ev_reenable_attempts == 0
+        assert coord._ev_charge_refused is False
+
+        # Second iteration over a DIFFERENT charger: does not see left's state.
+        with PerChargerContext.for_charger(coord, "right", ev_dev_right, {}):
+            assert coord._ev_stalled_since is None
+            assert coord._ev_reenable_attempts == 0
+            assert coord._ev_charge_refused is False
+
+        # Third iteration over left again: sees its own state.
+        with PerChargerContext.for_charger(coord, "left", ev_dev_left, {}):
+            assert coord._ev_stalled_since == stall_ts
+            assert coord._ev_reenable_attempts == 3
+            assert coord._ev_charge_refused is True
+
+
+class TestSkipFlag:
+    """``skipped_for_night`` is the v1.6.7 carry-over for the existing
+    ``_mode_allows_night_charging`` gate. This release leaves the
+    actual computation in the coordinator loop body; the field is wired
+    so v1.6.8 can move it into ``for_charger`` without a signature
+    change."""
+
+    def test_skip_default_false(self):
+        coord = _make_coord()
+        pcc = PerChargerContext.for_charger(coord, "left", MagicMock(), {})
+        assert pcc.skipped_for_night is False
+
+
+class TestNestingGuard:
+    """Re-entering a context without exiting the previous one would
+    clobber the snapshot. Sanity check the single-threaded invariant."""
+
+    def test_nested_entry_raises(self):
+        coord = _make_coord()
+        ev_dev = MagicMock()
+        with PerChargerContext.for_charger(coord, "left", ev_dev, {}) as pcc:
+            with pytest.raises(RuntimeError, match="entered twice"):
+                pcc.__enter__()
+
+
+class TestCfgLookup:
+    """``for_charger`` resolves the per-charger config dict from
+    ``coordinator.config['ev_chargers']``."""
+
+    def test_finds_matching_config(self):
+        coord = _make_coord([
+            {"id": "left", "name": "Wallbox Left"},
+            {"id": "right", "name": "Wallbox Right"},
+        ])
+        pcc = PerChargerContext.for_charger(coord, "right", MagicMock(), {})
+        assert pcc.charger_cfg == {"id": "right", "name": "Wallbox Right"}
+
+    def test_missing_id_yields_empty_cfg(self):
+        """A charger present in ``_ev_devices`` but not in ``ev_chargers``
+        (mid-migration state) gets an empty dict rather than crashing."""
+        coord = _make_coord([{"id": "left"}])
+        pcc = PerChargerContext.for_charger(coord, "ghost", MagicMock(), {})
+        assert pcc.charger_cfg == {}
+
+    def test_prebuilt_lookup_used_when_passed(self):
+        """The caller can pre-build ``chargers_by_id`` for the loop and
+        pass it in to avoid rebuilding it once per charger."""
+        coord = _make_coord([{"id": "left", "name": "from-config"}])
+        prebuilt = {"left": {"id": "left", "name": "from-prebuilt"}}
+        pcc = PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {}, chargers_by_id=prebuilt,
+        )
+        assert pcc.charger_cfg["name"] == "from-prebuilt"
+
+    def test_chargers_by_id_none_rebuilds_from_config(self):
+        """When ``chargers_by_id`` is omitted, ``for_charger`` rebuilds
+        the dict from ``coordinator.config['ev_chargers']`` rather than
+        crashing. Exercises the fallback path that the coordinator loop
+        bypasses (it always passes a pre-built dict)."""
+        coord = _make_coord([
+            {"id": "left", "name": "rebuilt-left"},
+            {"id": "right", "name": "rebuilt-right"},
+        ])
+        pcc = PerChargerContext.for_charger(
+            coord, "right", MagicMock(), {},  # no chargers_by_id arg
+        )
+        assert pcc.charger_cfg["name"] == "rebuilt-right"
+
+
+class TestBudget:
+    """The budget passed to ``for_charger`` is forwarded into
+    ``self._current_charger_budget`` and reset to ``None`` on exit
+    (matching the legacy semantic where ``None`` means "not currently
+    inside a per-charger iteration")."""
+
+    def test_budget_pushed_then_cleared(self):
+        coord = _make_coord()
+        with PerChargerContext.for_charger(coord, "left", MagicMock(), {"left": 6800.0}):
+            assert coord._current_charger_budget == 6800.0
+        assert coord._current_charger_budget is None
+
+    def test_budget_none_when_charger_not_in_dict(self):
+        """The night-state path doesn't populate ``ev_budget_per_charger`` —
+        in that case the per-charger budget is ``None`` rather than 0."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(coord, "left", MagicMock(), {}):
+            assert coord._current_charger_budget is None
+        assert coord._current_charger_budget is None

--- a/tests/test_per_charger_flows_319.py
+++ b/tests/test_per_charger_flows_319.py
@@ -1,0 +1,212 @@
+"""Per-charger flow attribution in ``flow_calculator`` (v1.6.9).
+
+Closes the bug class @RienduPre reported as #316 / #284: in
+multi-charger setups the dashboard's flow sensors are fleet-aggregated,
+so a user with charger A in ``solar_only`` mode and charger B in
+``min_plus_solar`` mode sees grid-to-EV flow attributed across BOTH
+chargers even when only B is drawing from grid. That perception was
+correct — the math was fleet proportional, and there was no per-charger
+split available.
+
+v1.6.9 fixes this by:
+
+1. ``sensor_reader`` populates ``PowerReadings.ev_power_per_charger``
+   for multi-charger installs (single-charger: dict stays empty).
+2. ``flow_calculator.calculate_power_flows`` reads that dict and
+   produces ``PowerFlows.per_charger[cid] = ChargerFlows(...)`` whose
+   sum across chargers equals the fleet-level ``flows.*_to_ev``.
+
+These tests pin:
+
+- Single-charger setups have an empty ``per_charger`` dict (no
+  behaviour change).
+- Multi-charger sums match the fleet-level values (sum invariant).
+- Idle chargers get a zero-filled ``ChargerFlows`` (no KeyError for
+  downstream readers).
+- The proportional split honors each charger's share of the total EV
+  draw (#316 regression: ``solar_only`` charger drawing 4 kW from
+  available solar should NOT show grid_to_ev > 0 — gets the right
+  share).
+"""
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.flow_calculator import (
+    FlowCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    ChargerFlows,
+    PowerReadings,
+)
+
+
+def _power(
+    solar=0.0, grid=0.0, battery=0.0, ev=0.0, home=0.0,
+    ev_per_charger=None,
+):
+    """Build a ``PowerReadings`` with derived fields populated so the
+    flow calculator's signed-power split works correctly."""
+    r = PowerReadings(
+        solar_power=solar,
+        grid_power=grid,
+        battery_power=battery,
+        ev_power=ev,
+        home_consumption_power=home,
+        ev_power_per_charger=ev_per_charger or {},
+    )
+    # Derive signed inflows/outflows from the raw signs (matches
+    # ``PowerReadings.calculate_derived``).
+    r.grid_import_power = abs(min(0.0, grid))
+    r.grid_export_power = max(0.0, grid)
+    r.battery_charge_power = max(0.0, battery)
+    r.battery_discharge_power = abs(min(0.0, battery))
+    return r
+
+
+class TestSingleChargerBackCompat:
+    """v1.6.9 must NOT change behaviour for single-charger setups.
+
+    When ``ev_power_per_charger`` is empty (single-charger install), the
+    per-charger split is skipped and ``flows.per_charger`` stays empty.
+    Every downstream reader that only looks at the fleet-level fields
+    sees identical numbers to v1.6.8.
+    """
+
+    def test_single_charger_per_charger_dict_empty(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=0, battery=0, ev=4000, home=0,
+        ))
+        assert flows.solar_to_ev == 4000
+        assert flows.per_charger == {}
+
+
+class TestSumInvariant:
+    """Sum of per-charger flows == fleet-level flows.
+
+    The proportional split divides each fleet flow by each charger's
+    share of total EV draw. With floats and a final ``round(.., 1)`` per
+    sub-flow, the sum may differ from the fleet value by ≤ 0.1 W per
+    fleet sub-flow — well below any user-visible threshold.
+    """
+
+    def test_two_chargers_solar_share_sums_to_fleet(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=6000, grid=0, battery=0, ev=6000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 2000.0},
+        ))
+        # Both chargers covered by solar alone (no grid_to_ev).
+        assert flows.solar_to_ev == 6000.0
+        total = sum(c.solar_to_ev for c in flows.per_charger.values())
+        assert total == pytest.approx(6000.0, abs=0.2)
+        # Proportional: left took 4/6, right took 2/6.
+        assert flows.per_charger["left"].solar_to_ev == pytest.approx(4000.0, abs=0.1)
+        assert flows.per_charger["right"].solar_to_ev == pytest.approx(2000.0, abs=0.1)
+
+    def test_two_chargers_grid_share_sums_to_fleet(self):
+        """Solar = 2 kW, EV = 6 kW total (4 + 2), no battery, no home.
+        4 kW deficit → grid imports it. Both chargers share solar AND
+        grid proportionally; the per-charger sums match fleet."""
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=2000, grid=-4000, battery=0, ev=6000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 2000.0},
+        ))
+        # Fleet check.
+        assert flows.solar_to_ev == pytest.approx(2000.0, abs=0.5)
+        assert flows.grid_to_ev == pytest.approx(4000.0, abs=0.5)
+        # Per-charger sums.
+        solar_sum = sum(c.solar_to_ev for c in flows.per_charger.values())
+        grid_sum = sum(c.grid_to_ev for c in flows.per_charger.values())
+        assert solar_sum == pytest.approx(flows.solar_to_ev, abs=0.2)
+        assert grid_sum == pytest.approx(flows.grid_to_ev, abs=0.2)
+
+
+class TestIdleChargerGetsZeroFlow:
+    """A configured but idle charger (draw 0) gets a ``ChargerFlows()``
+    with all zeros — downstream code can do ``flows.per_charger[cid]``
+    safely without KeyError checks."""
+
+    def test_idle_charger_zero_filled(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=0, battery=0, ev=4000, home=0,
+            ev_per_charger={"left": 4000.0, "right": 0.0},
+        ))
+        assert "right" in flows.per_charger
+        right = flows.per_charger["right"]
+        assert right.solar_to_ev == 0.0
+        assert right.grid_to_ev == 0.0
+        assert right.battery_to_ev == 0.0
+
+
+class TestRegressionForIssue316:
+    """The user-reported scenario: charger A active and drawing all
+    available solar; charger B idle. Fleet solar_to_ev should equal
+    charger A's draw entirely. Per-charger split should attribute it
+    all to A and zero to B — exactly the visible attribution
+    @RienduPre's complaint expected to see and didn't pre-v1.6.9."""
+
+    def test_charger_b_idle_no_attribution(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=-2000, battery=0, ev=6000, home=0,
+            ev_per_charger={"A": 6000.0, "B": 0.0},
+        ))
+        a = flows.per_charger["A"]
+        b = flows.per_charger["B"]
+        # A drew all of the fleet's flow.
+        assert a.solar_to_ev == pytest.approx(flows.solar_to_ev, abs=0.1)
+        assert a.grid_to_ev == pytest.approx(flows.grid_to_ev, abs=0.1)
+        # B drew nothing — no attribution.
+        assert b.solar_to_ev == 0.0
+        assert b.grid_to_ev == 0.0
+        assert b.battery_to_ev == 0.0
+
+    def test_solar_only_charger_does_not_get_grid_attribution(self):
+        """The #316-class symptom: in fleet-proportional split, a
+        solar_only charger that happens to be drawing alongside a
+        min_plus_solar charger would still get attributed part of the
+        grid flow proportionally — feels wrong even if the global sum
+        is correct. Per-charger split lets the dashboard tell each
+        charger's true sourcing.
+
+        Setup: solar 4 kW, grid_import 4 kW, total EV 8 kW. Charger A
+        (``solar_only``) draws 4 kW; charger B (``min_plus_solar``)
+        draws 4 kW. By math, each charger gets 50% of fleet flows —
+        which means A shows 2 kW grid_to_ev. The PRINCIPLED fix lives
+        upstream in the budget distributor (already done in v1.6.0 #284),
+        but per-charger flow attribution at least lets the user SEE
+        their 2 kW of "grid_to_A" — which is the audit trail they need
+        to know whether the upstream fix is doing its job. This test
+        pins the math; the user-visible interpretation lives in the
+        dashboard."""
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=4000, grid=-4000, battery=0, ev=8000, home=0,
+            ev_per_charger={"A_solar_only": 4000.0, "B_min_plus_solar": 4000.0},
+        ))
+        a = flows.per_charger["A_solar_only"]
+        b = flows.per_charger["B_min_plus_solar"]
+        # 50/50 split because draw is equal.
+        assert a.solar_to_ev == pytest.approx(b.solar_to_ev, abs=0.1)
+        assert a.grid_to_ev == pytest.approx(b.grid_to_ev, abs=0.1)
+        # Sum equals fleet (the invariant).
+        assert a.solar_to_ev + b.solar_to_ev == pytest.approx(flows.solar_to_ev, abs=0.2)
+        assert a.grid_to_ev + b.grid_to_ev == pytest.approx(flows.grid_to_ev, abs=0.2)
+
+
+class TestNoEvDraw:
+    """Edge case: ``ev_power_per_charger`` populated but total EV draw is 0.
+    The guard ``and ev > 0`` skips the per-charger loop entirely (avoids
+    divide-by-zero); ``flows.per_charger`` stays empty."""
+
+    def test_zero_ev_total_skips_split(self):
+        fc = FlowCalculator()
+        flows = fc.calculate_power_flows(_power(
+            solar=2000, grid=2000, battery=0, ev=0, home=2000,
+            ev_per_charger={"left": 0.0, "right": 0.0},
+        ))
+        assert flows.solar_to_ev == 0.0
+        assert flows.per_charger == {}

--- a/tests/test_per_charger_notifications.py
+++ b/tests/test_per_charger_notifications.py
@@ -1,0 +1,226 @@
+"""Per-charger notification flap suppression + name prefix (v1.6.9).
+
+Tests the multi-charger surface added to ``NotificationManager``:
+
+1. ``notify_state_change`` accepts optional ``charger_id`` + ``charger_name``
+   keyword arguments.
+2. Flap suppression is keyed per-charger: a state change on charger A
+   does not block one on charger B.
+3. Mobile messages get prefixed with ``[Wallbox Left]`` (etc.) when
+   ``charger_name`` is provided. Single-charger callers (no name) see
+   the legacy unprefixed message.
+4. The ``{DOMAIN}_notification`` HA event payload now carries
+   ``charger_id`` and ``charger_name`` keys (``None`` for fleet calls).
+
+Back-compat for v1.6.8 callers is covered by the existing 30-test
+suite in ``test_notifications.py``, which exercises the property
+shims (``_last_notified_state``, ``_pending_state``,
+``_pending_state_since``) — those continue to target the fleet
+sentinel slot transparently.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.consts.states import ChargingState
+from custom_components.solar_energy_management.coordinator.notifications import (
+    NotificationManager,
+    _FLAP_STABILITY_SECONDS,
+)
+
+
+@pytest.fixture
+def hass():
+    h = MagicMock()
+    h.services = MagicMock()
+    h.services.async_call = AsyncMock()
+    h.services.has_service = MagicMock(return_value=True)
+    h.bus = MagicMock()
+    h.bus.async_fire = MagicMock()
+    return h
+
+
+@pytest.fixture
+def config():
+    return {
+        "enable_charger_notifications": True,
+        "enable_mobile_notifications": True,
+        "mobile_notification_service": "notify.mobile_app_phone",
+    }
+
+
+@pytest.fixture
+def nm(hass, config):
+    n = NotificationManager(hass, config)
+    # Skip service validation in tests.
+    n._charger_notify_checked = True
+    n._charger_notify_available = True
+    n._charger_notify_service = "keba_display"
+    n._mobile_service_checked = True
+    n._mobile_service_available = True
+    n._mobile_service_name = "mobile_app_phone"
+    return n
+
+
+def _bypass_flap(nm, state, key="_fleet"):
+    """Pre-set per-charger flap state so a cooldown call is accepted."""
+    nm._pending_state_per_charger[key] = state
+    nm._pending_state_since_per_charger[key] = (
+        time.monotonic() - _FLAP_STABILITY_SECONDS - 1
+    )
+
+
+SAMPLE_DATA = {
+    "battery_soc": 65,
+    "calculated_current": 10,
+    "available_power": 3000,
+    "daily_ev_energy": 7.5,
+    "discharge_limit": 800,
+}
+
+
+class TestPerChargerFlapSuppression:
+    """A state change on charger A must not block one on charger B,
+    even when both reach the same state in quick succession."""
+
+    @pytest.mark.asyncio
+    async def test_two_chargers_each_notify_independently(self, nm):
+        """Charger A and charger B both transition to SOLAR_CHARGING_ACTIVE.
+        Pre-fix the fleet ``_last_notified_state`` would suppress the
+        second one; post-fix each keys off its own ``charger_id``."""
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="B")
+
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="B", charger_name="Wallbox Right",
+        )
+
+        # Per-charger ``_last_notified_state`` set for both — the
+        # load-bearing assertion: pre-fix the fleet ``_last_notified_state``
+        # would track only one of them and suppress the other.
+        assert nm._last_notified_state_per_charger["A"] == ChargingState.SOLAR_CHARGING_ACTIVE
+        assert nm._last_notified_state_per_charger["B"] == ChargingState.SOLAR_CHARGING_ACTIVE
+        # 3 service calls expected: KEBA notification for both chargers
+        # (2 calls) plus one mobile notification — the second mobile
+        # gets suppressed by the global ``_last_mobile_time`` cooldown
+        # which is intentionally fleet-level (the user wants a quiet
+        # phone, not "one notification per charger"). The per-charger
+        # state-machine isolation is what this test pins; the mobile
+        # cooldown stays fleet-wide.
+        assert nm.hass.services.async_call.call_count == 3
+        # Of the 3 calls, 2 are to the KEBA service (per-charger), 1
+        # to the mobile service.
+        keba_calls = sum(
+            1 for c in nm.hass.services.async_call.call_args_list
+            if "keba" in str(c).lower()
+        )
+        assert keba_calls == 2
+
+    @pytest.mark.asyncio
+    async def test_same_charger_twice_suppressed(self, nm):
+        """Calling twice with the same charger_id and same state — the
+        second call is the duplicate-state early-return."""
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A",
+        )
+        first_count = nm.hass.services.async_call.call_count
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A",
+        )
+        # No new calls.
+        assert nm.hass.services.async_call.call_count == first_count
+
+
+class TestChargerNamePrefix:
+    """Mobile messages get the ``[Name]`` prefix when ``charger_name``
+    is provided. The KEBA-display message is unprefixed (the charger
+    already knows it's itself)."""
+
+    @pytest.mark.asyncio
+    async def test_mobile_message_is_prefixed(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        # The bus event carries the (possibly-prefixed) mobile message
+        # — assert against the event payload as the source of truth.
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        message = evt_data.get("message", "")
+        assert message.startswith("[Wallbox Left] ")
+
+    @pytest.mark.asyncio
+    async def test_no_name_no_prefix(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE)
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        message = evt_data.get("message", "")
+        assert not message.startswith("[")
+
+
+class TestEventPayload:
+    """The ``solar_energy_management_notification`` HA event now carries
+    ``charger_id`` and ``charger_name`` keys so automations can
+    distinguish per-charger events. ``None`` values stay in the dict for
+    consistency rather than being dropped."""
+
+    @pytest.mark.asyncio
+    async def test_charger_keys_in_event(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE, key="A")
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+            charger_id="A", charger_name="Wallbox Left",
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        assert evt_data.get("charger_id") == "A"
+        assert evt_data.get("charger_name") == "Wallbox Left"
+
+    @pytest.mark.asyncio
+    async def test_fleet_call_has_none_charger_keys(self, nm):
+        _bypass_flap(nm, ChargingState.SOLAR_CHARGING_ACTIVE)
+        await nm.notify_state_change(
+            ChargingState.SOLAR_CHARGING_ACTIVE, SAMPLE_DATA,
+        )
+        evt_kwargs = nm.hass.bus.async_fire.call_args
+        evt_data = evt_kwargs.args[1] if evt_kwargs.args else evt_kwargs.kwargs.get("event_data") or {}
+        assert "charger_id" in evt_data and evt_data["charger_id"] is None
+        assert "charger_name" in evt_data and evt_data["charger_name"] is None
+
+
+class TestBackCompatShims:
+    """Existing tests + external callers can still read/write
+    ``_last_notified_state``, ``_pending_state``, ``_pending_state_since``
+    as scalars. The shims target the fleet sentinel slot."""
+
+    def test_set_and_get_scalar(self, nm):
+        nm._last_notified_state = "TEST_STATE"
+        assert nm._last_notified_state == "TEST_STATE"
+        # Stored under the fleet sentinel.
+        assert nm._last_notified_state_per_charger["_fleet"] == "TEST_STATE"
+
+    def test_set_none_clears(self, nm):
+        nm._last_notified_state = "TEST_STATE"
+        nm._last_notified_state = None
+        # Removed from the dict (rather than left as None) so the
+        # ``in`` check on the dict is meaningful.
+        assert "_fleet" not in nm._last_notified_state_per_charger
+
+    def test_pending_state_since_default(self, nm):
+        # Default value when unset is 0.0 — matches the legacy
+        # scalar default (``self._pending_state_since: float = 0.0``).
+        assert nm._pending_state_since == 0.0

--- a/tests/test_soc_zone_strategy.py
+++ b/tests/test_soc_zone_strategy.py
@@ -1,13 +1,21 @@
-"""Tests for SOC zone strategy: _determine_charging_strategy() (and historically also _calculate_solar_ev_budget, removed in Phase D.2 #282 — coverage moved to canonical EVBudget tests and scenario harness).
+"""Tests for SOC zone strategy: ``_determine_charging_strategy()``.
 
-Codified from real-world scenario on 2026-03-22 where battery drained to 20% SOC.
-Investigation confirmed zones held correctly: battery assist stopped at 70% (Zone 2 boundary),
-remaining drain was evening home consumption.
+Codified from a real-world scenario on 2026-03-22 where the battery
+drained to 20 % SOC. Investigation confirmed the zones held correctly:
+battery assist stopped at 70 % (Zone 2 boundary), remaining drain was
+evening home consumption.
 
 Real-world data:
   Solar: 36.65 kWh, Home: 29.98 kWh, EV: 15.52 kWh
   Battery charge: 13.55 kWh, discharge: 9.54 kWh → SOC ended at 20%
   PROD config: battery_priority_soc=90, buffer/auto_start/floor at defaults (70/90/60)
+
+Removed tests — for archaeology, see ``git log -S <name>`` in this file:
+  * ``test_charging_mode_minpv_returns_min_pv`` — #277 Phase C
+  * ``TestCalculateSolarEvBudget`` — Phase D.2 (#282), coverage moved
+    to canonical EVBudget tests + the scenario harness.
+  * ``TestAutoMode`` — #305 (``_auto_mode_strategy`` deleted as dead
+    code after Phase C).
 """
 import pytest
 from unittest.mock import MagicMock, patch
@@ -249,14 +257,6 @@ class TestDetermineChargingStrategy:
         )
         assert strategy == "disabled"
 
-    # ``test_charging_mode_minpv_returns_min_pv`` removed in #277 Phase C:
-    # the ``minpv`` legacy mode no longer dispatches to ``("min_pv", …)``
-    # from ``_determine_charging_strategy``. Per the maintainer's
-    # Phase C decision (Q1: zone-adaptive), legacy ``minpv`` users
-    # migrated to ``min_plus_solar`` get zone-adaptive day behaviour;
-    # the ``min_pv`` strategy value is now only reachable via the
-    # night-grid → MIN_PV canonical-budget mapping in
-    # ``_canonical_strategy_from_legacy``.
 
     def test_low_solar_returns_idle(self):
         """Solar < 200W → idle (not enough sun)."""
@@ -414,24 +414,6 @@ class TestZoneDebounce:
         # Held at Zone 2 — no Charging→Idle blip
         assert strategy == "solar_only"
         assert "Zone 2" in reason
-
-
-# ===========================================================================
-# TestCalculateSolarEvBudget removed in Phase D.2 (#282): the
-# ``_calculate_solar_ev_budget`` mixin method was deleted along with
-# the other legacy budget primitives. The Zone 3/4 proportional ramp +
-# measured-discharge semantics now live in
-# ``flow_calculator.calculate_canonical_ev_budget`` (BATTERY_ASSIST
-# branch) and are exercised by ``tests/scenarios/2026-05-29_budget_
-# unify_battery_assist.yaml`` end-to-end and by the canonical-budget
-# unit tests for the per-zone shape.
-
-
-# TestAutoMode removed in #305: ``_auto_mode_strategy`` was deleted
-# as dead code (no charge mode dispatched to it post-#277 Phase C).
-# The previous 3 tests exercised the helper directly; if a future
-# opt-in ``auto`` mode resurrects the forecast-aware switcher, restore
-# both the method and its tests together from the #305 commit.
 
 
 class TestSelfConsumptionStrategy:


### PR DESCRIPTION
## Release v1.6.12 — multi-charger cleanup arc

Bundles six sequential releases that close the recurring multi-charger bug class found through v1.6.0 → v1.6.6 (#284, #289, #315, #318). The work is dedicated to v1.6.x per the user's explicit "no v1.7 until multi-charger is properly fixed" directive.

## What's in this release

| Release | Theme | Tests added |
|---|---|---|
| v1.6.7 | ``PerChargerContext`` typed swap mechanism + ``docs/MULTI_CHARGER.md`` invariant + CONTRIBUTING.md pointer | +11 |
| v1.6.8 | Swept 12 ``power.ev_power`` fleet-sum reads in ``coordinator/ev_control.py`` + AST lint enforcing ``# FLEET-READ:`` annotation | +5 |
| v1.6.9 | Per-charger flow attribution (``PowerFlows.per_charger``) + per-charger notification flap suppression | +9 |
| v1.6.10 | Code-quality cleanup — closes #308 / #309 / #310 (dead branches, redundant cleanup, gravestone consolidation) | −2 |
| v1.6.11 | Recent SEM logs in Copy diagnostics + ``docs/MULTI_CHARGER.md`` roadmap honest update | +5 |
| v1.6.12 | Multi-charger ``off + solar_only`` scenario test + scenario-harness extensions (``per_charger_effective_states`` / ``per_charger_flow_max`` assertions) | +1 |

**End result**: the bug class is now structurally enforced — the ``# FLEET-READ:`` AST lint fails CI on any new fleet-sum read inside the per-charger loop. The four reactive hotfixes from v1.6.0–v1.6.6 cannot regress.

## Verification

- **2197 tests pass** on Python 3.12 (2161 v1.6.6 baseline + 36 new across the arc).
- Each release went through ``ruflo-core:reviewer`` per the [feedback_reviewer_before_deploy] memory.
- v1.6.7 → v1.6.10 received a full cross-cutting senior-engineer audit (two independent reviewers); every FIX-BEFORE-MERGE item folded into v1.6.11 / v1.6.12 before this release PR.
- Recent diagnostics dump includes the last ~80 SEM log lines so bug reports come pre-loaded with context.
- New ``MULTI_CHARGER.md`` doc captures the per-charger invariant and the honest deferred-work list for v1.7+.

## Closed GitHub issues

- ✓ #304 — select.py orphan removal (v1.6.4)
- ✓ #305 — dead ``_auto_mode_strategy`` removal (v1.6.4)
- ✓ #308 — dead ``now`` / ``min_pv`` consumer branches (v1.6.10)
- ✓ #309 — redundant global-select cleanup folded (v1.6.10)
- ✓ #310 — gravestone comments consolidated (v1.6.10)
- ✓ #315 — off-mode mitigation accepted (v1.6.5/v1.6.6)
- ✓ #316 — multi-charger flow attribution (v1.6.9, awaiting @RienduPre re-confirm)
- ✓ #318 — per-charger SOC isolation (v1.6.6, verified live on HA-TEST)
- ✓ #284 — multi-charger budget bleed (v1.6.0 + v1.6.9, awaiting @RienduPre re-confirm)

## Deferred to v1.7+

- ``PerChargerContext`` field migration (``effective_state``, ``this_power_w``) — documented as drift in ``docs/MULTI_CHARGER.md`` roadmap.
- Per-charger flow **sensors** (data on ``PowerFlows.per_charger`` but no top-level HA entities yet).
- ``# FLEET-READ:`` annotation → ``FleetEvPower`` newtype upgrade.
- Heat pump multi-instance + hot water multi-instance.
- Task #8 — surplus tracker jump-from-0 spike.

## Risk + rollback

- Single-charger users hit zero new code paths (data structures default to empty; loops collapse to length-0).
- Each component release is individually revertible from main if needed.
- The AST lint + scenario tests guard against regression at PR time.

## Test plan

- [x] Full suite (2197 / 7 skipped on Python 3.12)
- [x] Per-PR reviewer + cross-cutting senior-engineer review
- [ ] CI on this PR (Tests 3.12 + 3.13 + Hassfest + HACS + card-test — all 5 required for main)
- [ ] Tag v1.6.12 + GitHub Release after merge → HACS picks it up automatically