### PR TITLE
fix(#8): v1.6.13 — surplus tracker jump-from-0 spike

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.13] — 2026-05-31
+
+Closes the long-standing surplus-tracker spike on KEBA (#8). First of
+a four-release closeout pulling deferred ``v1.7+`` items back into
+v1.6.x — per the maintainer's "no v1.7 until multi-charger is properly
+fixed AND every deferred follow-up is closed" rule.
+
+### Fixed
+
+- **Surplus tracker jump-from-0 spike (#8)** — ``_apply_ramp_limit``
+  used to short-circuit on ``current < 1`` and return ``target_current``
+  directly, so a cold-start cycle handed KEBA a 14 A command from 0 A.
+  KEBA's ~30 s physical actuator lag then caused a ~4.4 kW grid-import
+  overshoot during the ramp (confirmed live on PROD 2026-05-31 at
+  10:43). Cold start now hands KEBA ``min_current`` (typically 6 A ≈
+  4140 W on 3-phase EU); subsequent cycles climb via the existing
+  ``±ramp_rate`` clamp at the user-configured ``ev_ramp_rate_amps``
+  (default 2 A/cycle, so target reached in ~4 cycles for a 14 A
+  request).
+
+  The stop-fast branch is preserved: ``target_current < 1`` still
+  returns 0 immediately (no gentle ramp-down) so the explicit-off /
+  disable path stays snappy.
+
+  13 new unit tests in ``tests/test_ramp_limit_8.py`` pin: cold
+  start → ``min_current``, near-zero current → cold-start treatment,
+  steady-state ``±ramp_rate`` unchanged, stop-fast preserved, custom
+  ``min_current`` per charger honoured, end-to-end multi-cycle climb
+  to target.
+
 ## [1.6.12] — 2026-05-31
 
 Closes the last open senior-reviewer item on the v1.6.7 → v1.6.11

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -938,12 +938,30 @@ class EVControlMixin:
     def _apply_ramp_limit(self, target_current: float) -> float:
         """Limit current changes to ±ramp_rate per cycle during solar charging.
 
-        Prevents sudden jumps that stress inverter/grid. Starting from 0A jumps
-        directly (can't ramp below min_current). Stopping drops immediately.
-        Config: ev_ramp_rate_amps (default 2).
+        Prevents sudden jumps that stress inverter/grid. Stopping drops
+        immediately. Config: ``ev_ramp_rate_amps`` (default 2).
+
+        v1.6.13 / #8: cold start (current < 1) now climbs from
+        ``min_current`` rather than jumping directly to target.
+        Pre-fix the "starting from 0" branch returned ``target_current``
+        unchanged — KEBA's ~30 s physical actuator lag then caused the
+        observed grid-import overshoot. Confirmed on PROD 2026-05-31
+        at 10:43: SEM commanded 14 A from a cold 0 A, KEBA's ramp
+        overshot, ~4.4 kW of grid was imported for the duration of the
+        ramp. With this fix the first command is ``min_current``
+        (typically 6 A ≈ 4140 W on 3-phase EU); subsequent cycles
+        climb via the existing ``±ramp_rate`` clamp below.
+
+        ``target_current`` arriving here is already clamped to
+        ``[min_current, max_current]`` at the call site (see
+        ``ev_control.py:495-501``), so we don't need to bound
+        ``min_current`` to it. The ``target_current < 1`` stop-fast
+        branch stays — that path is for the explicit-off / disable
+        case where we want an immediate drop, not a gentle decline.
 
         Args:
-            target_current: Desired current in amps.
+            target_current: Desired current in amps (≥ ``ev.min_current``
+                or 0 when stopping).
 
         Returns:
             Ramp-limited current in amps.
@@ -952,10 +970,14 @@ class EVControlMixin:
         current = ev._current_setpoint
         ramp = self.config.get("ev_ramp_rate_amps", 2)
 
-        if current < 1.0:       # Starting from 0 → jump directly
-            return target_current
         if target_current < 1.0:  # Stopping → drop immediately
             return 0
+        if current < 1.0:
+            # Cold start: hand KEBA the gentle ``min_current`` first.
+            # Next cycle's ``current`` will be non-zero and the
+            # standard clamp below will climb toward target at
+            # ``ramp_rate``.
+            return ev.min_current
 
         return max(current - ramp, min(current + ramp, target_current))
 

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -142,6 +142,7 @@ the structural invariant.
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
 | **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
+| **v1.6.13** | Surplus tracker jump-from-0 spike fix (#8) — cold start hands KEBA `min_current` first, not direct-jump to target | ✓ shipped |
 
 ### What landed under the abstraction
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.12"
+  "version": "1.6.13"
 }

--- a/tests/test_ramp_limit_8.py
+++ b/tests/test_ramp_limit_8.py
@@ -1,0 +1,159 @@
+"""Unit tests for ``_apply_ramp_limit`` (#8, v1.6.13).
+
+Closes the long-standing PROD-observed bug: ``_apply_ramp_limit`` used
+to short-circuit on ``current < 1`` and return ``target_current``
+directly, so a cold-start cycle commanded e.g. 14 A to a KEBA sitting
+at 0 A — the charger's ~30 s physical actuator lag then caused a
+~4.4 kW grid-import overshoot.
+
+These tests pin the v1.6.13 semantic:
+
+1. Cold start (current=0) → command ``min_current`` (gentle ramp-up).
+2. Steady-state ramp UP capped at ``±ramp_rate``.
+3. Steady-state ramp DOWN capped at ``±ramp_rate``.
+4. Stop-fast (target < 1) → immediate drop to 0, regardless of current.
+5. End-to-end: cold start → next-cycle climb → target.
+
+The harness mocks ``EVControlMixin._ev_device`` + ``self.config`` —
+only the attributes the method reads. Keeps the fixture small so
+unrelated coordinator refactors don't flake these tests.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.ev_control import (
+    EVControlMixin,
+)
+
+
+def _make_mixin(current_setpoint: float, min_current: float = 6.0,
+                ramp_rate: int = 2):
+    """Build a minimal stub that exposes the surface ``_apply_ramp_limit``
+    reads: ``self._ev_device._current_setpoint``,
+    ``self._ev_device.min_current``, ``self.config[...]``."""
+    mixin = EVControlMixin.__new__(EVControlMixin)
+    mixin._ev_device = MagicMock()
+    mixin._ev_device._current_setpoint = current_setpoint
+    mixin._ev_device.min_current = min_current
+    mixin.config = {"ev_ramp_rate_amps": ramp_rate}
+    return mixin
+
+
+class TestColdStart:
+    """Cold start (current=0) commands ``min_current``, NOT ``target``.
+
+    This is the load-bearing change in #8 / v1.6.13. Pre-fix the
+    method returned ``target_current`` directly on cold start, which
+    is what caused KEBA to receive a 14 A command from 0 and overshoot
+    during its physical ramp.
+    """
+
+    def test_zero_to_high_target_clamps_to_min(self):
+        mx = _make_mixin(current_setpoint=0.0)
+        out = mx._apply_ramp_limit(target_current=14.0)
+        assert out == 6.0  # min_current, not 14
+
+    def test_zero_to_medium_target_clamps_to_min(self):
+        mx = _make_mixin(current_setpoint=0.0)
+        out = mx._apply_ramp_limit(target_current=8.0)
+        assert out == 6.0
+
+    def test_zero_to_target_equal_to_min_lands_at_min(self):
+        """Cold start with target already at min — return min."""
+        mx = _make_mixin(current_setpoint=0.0)
+        out = mx._apply_ramp_limit(target_current=6.0)
+        assert out == 6.0
+
+    def test_near_zero_current_treated_as_cold_start(self):
+        """``current < 1`` is the cold-start guard (KEBA's handshake
+        idle can pop the setpoint to ~0.5 A briefly — treat that as
+        cold-start for ramp purposes)."""
+        mx = _make_mixin(current_setpoint=0.5)
+        out = mx._apply_ramp_limit(target_current=14.0)
+        assert out == 6.0
+
+
+class TestSteadyStateRamp:
+    """Once current > 1 the standard ``±ramp_rate`` clamp drives the
+    cycle-to-cycle change."""
+
+    def test_ramp_up_by_rate(self):
+        mx = _make_mixin(current_setpoint=6.0, ramp_rate=2)
+        out = mx._apply_ramp_limit(target_current=14.0)
+        assert out == 8.0  # 6 + 2
+
+    def test_ramp_down_by_rate(self):
+        mx = _make_mixin(current_setpoint=14.0, ramp_rate=2)
+        out = mx._apply_ramp_limit(target_current=6.0)
+        assert out == 12.0  # 14 - 2
+
+    def test_target_within_ramp_window_returns_target(self):
+        """When the requested change is within ``±ramp_rate`` the
+        target itself is returned — no over-/under-shoot."""
+        mx = _make_mixin(current_setpoint=10.0, ramp_rate=2)
+        out = mx._apply_ramp_limit(target_current=11.0)
+        assert out == 11.0
+
+
+class TestStopFast:
+    """The stop-fast branch must stay: ``target < 1`` returns 0
+    immediately. Don't gently ramp down to 0 — that would leave KEBA
+    pulling power during the disable_delay window."""
+
+    def test_target_zero_returns_zero_from_high_current(self):
+        mx = _make_mixin(current_setpoint=14.0)
+        out = mx._apply_ramp_limit(target_current=0.0)
+        assert out == 0
+
+    def test_target_zero_returns_zero_from_already_zero(self):
+        mx = _make_mixin(current_setpoint=0.0)
+        out = mx._apply_ramp_limit(target_current=0.0)
+        assert out == 0
+
+
+class TestColdStartSequence:
+    """End-to-end multi-cycle ramp: cold start → next cycle climbs by
+    ``ramp_rate`` → reaches target. Pins the user-visible behaviour:
+    the spike is smaller because the first cycle hands KEBA
+    ``min_current`` rather than ``target``."""
+
+    def test_three_cycle_climb_to_target(self):
+        # Cycle 1: cold start, target 14 → returns 6 (min_current).
+        mx = _make_mixin(current_setpoint=0.0, ramp_rate=2)
+        c1 = mx._apply_ramp_limit(14.0)
+        assert c1 == 6.0
+
+        # Cycle 2: ev._current_setpoint=6 (committed by actuator); 6 → 8.
+        mx._ev_device._current_setpoint = c1
+        c2 = mx._apply_ramp_limit(14.0)
+        assert c2 == 8.0
+
+        # Cycle 3: 8 → 10.
+        mx._ev_device._current_setpoint = c2
+        c3 = mx._apply_ramp_limit(14.0)
+        assert c3 == 10.0
+
+    def test_custom_ramp_rate_climbs_faster(self):
+        mx = _make_mixin(current_setpoint=0.0, ramp_rate=4)
+        # Cycle 1: still min_current — cold-start branch is independent
+        # of ramp_rate (the ramp is for cycle 2+).
+        assert mx._apply_ramp_limit(14.0) == 6.0
+        # Cycle 2: 6 → 10 with ramp_rate=4.
+        mx._ev_device._current_setpoint = 6.0
+        assert mx._apply_ramp_limit(14.0) == 10.0
+
+
+class TestCustomMinCurrent:
+    """``ev.min_current`` is read per call — different chargers may
+    have different minimums and the cold-start return must honour
+    that. Wallbox Pulsar EU is 6 A; Tesla Wall Connector goes down to
+    1 A on some firmware; OpenEVSE config is user-settable."""
+
+    def test_higher_min_current_used(self):
+        mx = _make_mixin(current_setpoint=0.0, min_current=10.0)
+        assert mx._apply_ramp_limit(14.0) == 10.0
+
+    def test_lower_min_current_used(self):
+        mx = _make_mixin(current_setpoint=0.0, min_current=4.0)
+        assert mx._apply_ramp_limit(14.0) == 4.0


### PR DESCRIPTION
Closes #8.

## Summary

- Cold-start branch in ``_apply_ramp_limit`` no longer hands KEBA the full target current. It returns ``ev.min_current`` instead, so the next cycle's ``±ramp_rate`` clamp takes over and climbs to the configured target over ~4 cycles (for the default 2 A/cycle ramp rate).
- Stop-fast branch preserved: ``target_current < 1`` still returns 0 immediately so explicit off / disable stays snappy.
- 13 new unit tests in ``tests/test_ramp_limit_8.py`` pin cold-start, near-zero, steady-state, stop-fast, custom ``min_current``, end-to-end multi-cycle climb.

## Why

Confirmed live on PROD 2026-05-31 10:43: ``_apply_ramp_limit`` short-circuited on ``current < 1`` and returned ``target_current``, handing KEBA a 14 A command from 0. KEBA's ~30 s physical actuator lag then caused a ~4.4 kW grid-import overshoot during the ramp.

## Scope context

First of a four-release closeout pulling deferred ``v1.7+`` items back into v1.6.x — v1.6.14 (PerChargerContext field migration), v1.6.15 (per-charger flow sensors), v1.6.16 (FleetEvPower newtype) to follow. Per the maintainer's "no v1.7 until multi-charger is properly fixed AND every deferred follow-up is closed" rule.

## Test plan

- [x] 13/13 new unit tests pass in isolation
- [x] 2210 / 2197 baseline + 13 new total pass on Python 3.12
- [x] Manifest bumped to 1.6.13
- [x] CHANGELOG entry added
- [x] ``docs/MULTI_CHARGER.md`` roadmap row added
- [ ] CI green (4 checks)
- [ ] HA-PROD soak under solar surplus