### PR TITLE
refactor: v1.6.14 closeout — PCC field migration + release bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,35 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.6.14] — 2026-05-31
+## [Unreleased] — v1.6.14 candidate
 
-PerChargerContext field migration. Closes the two abstraction leaks
-the senior reviewer flagged on the v1.6.7→v1.6.10 arc that were
-previously deferred to v1.7+ (the user pulled them back into v1.6.x
-under the "no v1.7 until every multi-charger follow-up is closed"
-rule).
+Multi-charger debt closeout. Bundles four pieces of work into one
+release (the maintainer-set rule "no v1.7 until every multi-charger
+follow-up is closed" pulled deferred ``v1.7+`` items back into
+v1.6.x; this is them, packaged as one release rather than four
+separate HACS bumps).
+
+### Fixed
+
+- **Surplus tracker jump-from-0 spike (#8)** —
+  ``_apply_ramp_limit`` used to short-circuit on ``current < 1`` and
+  return ``target_current`` directly, so a cold-start cycle handed
+  KEBA a 14 A command from 0 A. KEBA's ~30 s physical actuator lag
+  then caused a ~4.4 kW grid-import overshoot during the ramp
+  (confirmed live on PROD 2026-05-31 at 10:43). Cold start now hands
+  KEBA ``min_current`` (typically 6 A ≈ 4140 W on 3-phase EU);
+  subsequent cycles climb via the existing ``±ramp_rate`` clamp at
+  the user-configured ``ev_ramp_rate_amps`` (default 2 A/cycle, so
+  target reached in ~4 cycles for a 14 A request). The stop-fast
+  branch is preserved: ``target_current < 1`` still returns 0
+  immediately so explicit-off / disable stays snappy. 13 new unit
+  tests in ``tests/test_ramp_limit_8.py`` pin every branch.
 
 ### Changed
 
-- **``effective_state`` and ``charger_name`` now live on
-  ``PerChargerContext``**, not in a parallel
-  ``_effective_states_per_charger`` dict written by the loop body.
+- **``effective_state`` and ``charger_name`` migrated onto
+  ``PerChargerContext``** instead of writing the parallel
+  ``_effective_states_per_charger`` dict from inside the loop body.
   The loop body assigns ``pcc.effective_state = …``; ``__exit__``
   persists ``(state, name)`` into the coordinator's dict so the
   post-loop ``_send_notifications`` dispatcher continues reading
@@ -45,61 +61,28 @@ rule).
 - ``# FLEET-READ:`` annotation on the documented multi-charger
   fallback in ``_this_charger_power`` (only reached when a charger
   config omits ``ev_charging_power_sensor`` — rare).
-- 14 new tests:
-  - ``tests/test_per_charger_context.py``: 4 effective_state tests,
-    3 this_power_w tests, 2 current-pcc-pointer tests.
-  - ``tests/test_this_charger_power_cache.py``: 5 tests pinning the
-    cache HIT, three MISS variants (different ev, no pcc, None
-    this_power_w), and the legacy kW→W conversion path.
+- 27 new tests across two files (13 ramp-limit + 14 pcc-field):
+  - ``tests/test_ramp_limit_8.py``: cold-start, near-zero,
+    steady-state ramp, stop-fast, custom ``min_current``,
+    end-to-end multi-cycle climb.
+  - ``tests/test_per_charger_context.py``: effective_state
+    persistence, this_power_w precompute, current-pcc-pointer
+    lifecycle.
+  - ``tests/test_this_charger_power_cache.py``: cache HIT, three
+    MISS variants, kW→W conversion regression from #315.
 
 ### Why
 
-Senior reviewer on the v1.6.7→v1.6.10 arc flagged:
-
-> ``effective_state`` — currently stored in the parallel coordinator
-> dict ``_effective_states_per_charger`` and dispatched in
-> ``_send_notifications``. Works correctly; not on the context object.
->
-> ``this_power_w`` — currently cached as a local variable per method
-> inside ``coordinator/ev_control.py``. Works correctly; not on the
-> context object.
-
+Senior reviewer on the v1.6.7→v1.6.10 arc flagged ``effective_state``
+and ``this_power_w`` as "works correctly; not on the context object."
 Both shipped working — but the docs claimed "pcc is the single source
-of truth for per-charger data" while these two fields lived elsewhere.
-v1.6.14 makes the doc honest.
+of truth for per-charger data" while these two lived in a parallel
+dict and method-local vars. This release makes the doc honest.
 
-2224 tests pass on Python 3.12 (2210 v1.6.13 baseline + 14 new).
-Manifest bumped to 1.6.14.
-
-## [1.6.13] — 2026-05-31
-
-Closes the long-standing surplus-tracker spike on KEBA (#8). First of
-a four-release closeout pulling deferred ``v1.7+`` items back into
-v1.6.x — per the maintainer's "no v1.7 until multi-charger is properly
-fixed AND every deferred follow-up is closed" rule.
-
-### Fixed
-
-- **Surplus tracker jump-from-0 spike (#8)** — ``_apply_ramp_limit``
-  used to short-circuit on ``current < 1`` and return ``target_current``
-  directly, so a cold-start cycle handed KEBA a 14 A command from 0 A.
-  KEBA's ~30 s physical actuator lag then caused a ~4.4 kW grid-import
-  overshoot during the ramp (confirmed live on PROD 2026-05-31 at
-  10:43). Cold start now hands KEBA ``min_current`` (typically 6 A ≈
-  4140 W on 3-phase EU); subsequent cycles climb via the existing
-  ``±ramp_rate`` clamp at the user-configured ``ev_ramp_rate_amps``
-  (default 2 A/cycle, so target reached in ~4 cycles for a 14 A
-  request).
-
-  The stop-fast branch is preserved: ``target_current < 1`` still
-  returns 0 immediately (no gentle ramp-down) so the explicit-off /
-  disable path stays snappy.
-
-  13 new unit tests in ``tests/test_ramp_limit_8.py`` pin: cold
-  start → ``min_current``, near-zero current → cold-start treatment,
-  steady-state ``±ramp_rate`` unchanged, stop-fast preserved, custom
-  ``min_current`` per charger honoured, end-to-end multi-cycle climb
-  to target.
+The ``#8`` surplus-tracker spike fix bundled in here was confirmed
+live on PROD 2026-05-31 during the v1.6.3 soak — held with the
+refactor rather than shipped standalone so PROD users get one
+soak window instead of four staggered HACS updates.
 
 ## [1.6.12] — 2026-05-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.14] — 2026-05-31
+
+PerChargerContext field migration. Closes the two abstraction leaks
+the senior reviewer flagged on the v1.6.7→v1.6.10 arc that were
+previously deferred to v1.7+ (the user pulled them back into v1.6.x
+under the "no v1.7 until every multi-charger follow-up is closed"
+rule).
+
+### Changed
+
+- **``effective_state`` and ``charger_name`` now live on
+  ``PerChargerContext``**, not in a parallel
+  ``_effective_states_per_charger`` dict written by the loop body.
+  The loop body assigns ``pcc.effective_state = …``; ``__exit__``
+  persists ``(state, name)`` into the coordinator's dict so the
+  post-loop ``_send_notifications`` dispatcher continues reading
+  from a single map. The dict is the storage; pcc is the write
+  path. Lets a future AST lint enforce field access at type level
+  (no callsite outside the loop touches the dict directly).
+- **``this_power_w`` precomputed in ``PerChargerContext.__enter__``**
+  via ``coord._this_charger_power(ev_dev, power)`` and exposed as a
+  typed field. The coordinator stashes the active pcc on
+  ``coord._current_pcc``; ``_this_charger_power`` becomes a cache
+  shim — when invoked with the same ``ev_dev`` it returns
+  ``pcc.this_power_w`` instead of re-reading HA state. Replaces
+  the three per-method ``this_power_w = self._this_charger_power(…)``
+  local-var caches in ``coordinator/ev_control.py`` without
+  changing the callsites. Helper exceptions in the precompute fall
+  through to the legacy read path so a transient HA-state issue
+  can't half-apply the swap.
+
+### Added
+
+- ``PerChargerContext.power``, ``this_power_w``, ``effective_state``,
+  ``charger_name`` dataclass fields.
+- ``SEMCoordinator._current_pcc`` short-lived pointer to the active
+  context (``None`` outside any per-charger iteration).
+- ``# FLEET-READ:`` annotation on the documented multi-charger
+  fallback in ``_this_charger_power`` (only reached when a charger
+  config omits ``ev_charging_power_sensor`` — rare).
+- 14 new tests:
+  - ``tests/test_per_charger_context.py``: 4 effective_state tests,
+    3 this_power_w tests, 2 current-pcc-pointer tests.
+  - ``tests/test_this_charger_power_cache.py``: 5 tests pinning the
+    cache HIT, three MISS variants (different ev, no pcc, None
+    this_power_w), and the legacy kW→W conversion path.
+
+### Why
+
+Senior reviewer on the v1.6.7→v1.6.10 arc flagged:
+
+> ``effective_state`` — currently stored in the parallel coordinator
+> dict ``_effective_states_per_charger`` and dispatched in
+> ``_send_notifications``. Works correctly; not on the context object.
+>
+> ``this_power_w`` — currently cached as a local variable per method
+> inside ``coordinator/ev_control.py``. Works correctly; not on the
+> context object.
+
+Both shipped working — but the docs claimed "pcc is the single source
+of truth for per-charger data" while these two fields lived elsewhere.
+v1.6.14 makes the doc honest.
+
+2224 tests pass on Python 3.12 (2210 v1.6.13 baseline + 14 new).
+Manifest bumped to 1.6.14.
+
 ## [1.6.13] — 2026-05-31
 
 Closes the long-standing surplus-tracker spike on KEBA (#8). First of

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -266,8 +266,18 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # ``charger_id`` and flap-suppression key. Cleared at the top of
         # each loop pass; empty in single-charger setups (notification
         # falls back to the fleet-level call).
-        # Shape: ``{cid: (effective_state, charger_name)}``.
+        # Shape: ``{cid: (effective_state, charger_name)}``. v1.6.14:
+        # populated by ``PerChargerContext.__exit__`` (not by the loop
+        # body directly) — pcc owns the write path now.
         self._effective_states_per_charger: Dict[str, tuple] = {}
+
+        # v1.6.14: short-lived pointer to the currently active
+        # ``PerChargerContext`` so ``ev_control._this_charger_power``
+        # can serve the cached value computed once at ``__enter__``
+        # instead of re-reading the HA state every call. Set in
+        # ``PerChargerContext.__enter__`` / cleared in ``__exit__``.
+        # ``None`` outside any per-charger iteration.
+        self._current_pcc = None
 
         # EV stall detection for self-healing
         self._ev_stalled_since: Optional[float] = None
@@ -1158,6 +1168,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     pcc = PerChargerContext.for_charger(
                         self, cid, ev_dev, ev_budget_per_charger,
                         chargers_by_id=_chargers_by_id,
+                        power=power,
                     )
                     with pcc:
                         # Set per-charger night target (#193). The
@@ -1236,14 +1247,15 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                                 )
                                 await self._maybe_warn_unreachable_deadline(cid, charger_cfg, plan)
 
-                        # v1.6.9: capture per-charger effective state so
-                        # the notification dispatch in ``_send_notifications``
-                        # can fire ``notify_state_change`` per charger with
-                        # its own flap-suppression key.
-                        self._effective_states_per_charger[cid] = (
-                            effective_state,
-                            charger_cfg.get("name") or cid,
-                        )
+                        # v1.6.14: write the effective state to ``pcc``;
+                        # ``__exit__`` persists it into
+                        # ``self._effective_states_per_charger`` so the
+                        # post-loop ``_send_notifications`` dispatch sees
+                        # the per-charger state. Writing through pcc
+                        # makes the AST lint enforceable: no callsite
+                        # outside the loop touches the parallel dict
+                        # directly.
+                        pcc.effective_state = effective_state
 
                         try:
                             await self._execute_ev_control(

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -904,7 +904,19 @@ class EVControlMixin:
         Single-charger setups: ``power.ev_power`` is already the single
         sensor reading (normalized to W by ``sensor_reader``), so the
         fallback path matches what the original code path was doing.
+
+        v1.6.14: when called from inside a ``PerChargerContext`` for
+        the same ``ev``, returns the cached value
+        ``self._current_pcc.this_power_w`` computed once at
+        ``__enter__``. Outside the loop (single-charger path, post-loop
+        helpers) the direct-compute branch below runs. The lint enforces
+        that no callsite reads ``power.ev_power`` directly — they all
+        funnel through here.
         """
+        pcc = getattr(self, "_current_pcc", None)
+        if (pcc is not None and pcc.ev_dev is ev
+                and pcc.this_power_w is not None):
+            return pcc.this_power_w
         try:
             charger_cfg = self._get_active_charger_config()
             cps = charger_cfg.get("ev_charging_power_sensor") if charger_cfg else None
@@ -922,6 +934,10 @@ class EVControlMixin:
         # sensor_reader). Correct for single-charger; for multi-charger
         # it's the sum (over-counts but only matters when no per-charger
         # sensor is configured — rare).
+        # FLEET-READ: documented fallback when no per-charger sensor is
+        # configured; in multi-charger setups this code path is only
+        # reached when ``_get_active_charger_config`` lacks a
+        # ``ev_charging_power_sensor`` entry (rare).
         return float(getattr(power, "ev_power", 0.0) or 0.0)
 
     def _this_charger_drawing_power(self, ev, power) -> bool:

--- a/coordinator/per_charger_context.py
+++ b/coordinator/per_charger_context.py
@@ -53,14 +53,18 @@ class PerChargerContext:
     charger's values; ``__exit__`` persists any updates back into the
     per-charger storage dicts and restores the primary's fleet view.
 
-    Fields are populated incrementally across v1.6.7 — v1.6.9:
+    Fields populated incrementally across v1.6.7 — v1.6.14:
 
     - v1.6.7: identity (``cid``, ``ev_dev``, ``charger_cfg``) + the swap
-      mechanism (no new computed fields; the existing inline maths in
-      ``coordinator.py`` continue to run inside the ``with`` block).
-    - v1.6.8: ``effective_strategy``, ``this_power_w`` migrated from
-      ``ev_control._this_charger_power``.
-    - v1.6.9: ``per_charger_flows`` from the per-charger flow calculator.
+      mechanism. No computed fields; the inline maths in
+      ``coordinator.py`` ran inside the ``with`` block.
+    - v1.6.9: ``per_charger_flows`` lives on ``PowerFlows.per_charger``
+      (not on the context; the calculator produces it before the loop).
+    - v1.6.14: ``effective_state`` + ``charger_name`` + ``this_power_w``
+      migrated onto the dataclass (issue: the parallel
+      ``_effective_states_per_charger`` dict + per-method local-var
+      caching of ``this_power_w`` were abstraction leaks; both now
+      flow through ``pcc``).
     """
 
     # ------------------------------------------------------------------
@@ -85,6 +89,44 @@ class PerChargerContext:
     skipped_for_night: bool = False
     """``True`` when the charger's mode opts it out of the current night
     state (set during ``for_charger`` based on ``_mode_allows_night_charging``)."""
+
+    # ------------------------------------------------------------------
+    # v1.6.14: computed per-charger fields
+    # ------------------------------------------------------------------
+    power: Any = None
+    """The ``PowerReadings`` for the current cycle. Stored so
+    ``__enter__`` can compute ``this_power_w`` for THIS charger via
+    the coordinator's existing helper. The factory's caller passes
+    the same ``power`` it would pass to ``_execute_ev_control``."""
+
+    this_power_w: Optional[float] = None
+    """THIS charger's draw in watts, computed once in ``__enter__``
+    via ``coord._this_charger_power(ev_dev, power)``. Reads from
+    inside the per-charger loop use this field instead of the
+    fleet-aggregated ``power.ev_power``. Pre-v1.6.14 each
+    ``coordinator/ev_control.py`` method that needed it cached a
+    local copy — works, but the value lived in three places.
+
+    ``None`` until ``__enter__`` runs. After exit, the value is
+    preserved on the dataclass (the context is short-lived; readers
+    don't access it post-exit, but leaving the field set is safer
+    than clearing it)."""
+
+    effective_state: Any = None
+    """THIS charger's effective ``ChargingState`` for the current
+    cycle. Set by the per-charger code inside the ``with`` block.
+    Persisted to ``coord._effective_states_per_charger[cid]`` by
+    ``__exit__`` so ``_send_notifications`` can dispatch per-charger
+    flap-suppressed notifications.
+
+    ``None`` means "this charger did not participate in this cycle"
+    (e.g. skipped for night, observer mode); ``__exit__`` then omits
+    the write."""
+
+    charger_name: Optional[str] = None
+    """Display name for the charger; persisted alongside
+    ``effective_state``. Falls back to ``cid`` if the config omits
+    a ``name`` key."""
 
     # ------------------------------------------------------------------
     # Internal: references + the swap snapshot.
@@ -115,6 +157,7 @@ class PerChargerContext:
         ev_dev: Any,
         ev_budget_per_charger: dict,
         chargers_by_id: Optional[dict] = None,
+        power: Any = None,
     ) -> "PerChargerContext":
         """Build a per-charger context.
 
@@ -138,6 +181,10 @@ class PerChargerContext:
                 caller can pass to avoid rebuilding it inside the loop.
                 If ``None``, this method rebuilds it from
                 ``coordinator.config``.
+            power: the ``PowerReadings`` for this cycle. Stored on the
+                context so ``__enter__`` can compute ``this_power_w`` via
+                the coordinator's existing helper. Optional for legacy
+                callers / unit tests that don't exercise ``this_power_w``.
 
         Returns:
             A ``PerChargerContext`` ready to be used as a context manager.
@@ -155,6 +202,8 @@ class PerChargerContext:
             ev_dev=ev_dev,
             charger_cfg=charger_cfg,
             budget_w=budget_w,
+            charger_name=charger_cfg.get("name") or cid,
+            power=power,
             _coord=coordinator,
         )
 
@@ -210,6 +259,26 @@ class PerChargerContext:
         coord._ev_charge_refused = coord._ev_charge_refused_per_charger.get(self.cid, False)
         coord._current_charger_budget = self.budget_w
 
+        # v1.6.14: precompute this charger's draw via the coordinator's
+        # kW-aware helper. Reads ``self._ev_device`` indirectly via
+        # ``_get_active_charger_config`` — must happen AFTER the swap
+        # above so the helper sees THIS charger's config. Power is
+        # optional (legacy unit tests) — without it the helper falls
+        # back to ``power.ev_power`` which is 0 for a None power object.
+        if self.power is not None and hasattr(coord, "_this_charger_power"):
+            try:
+                self.this_power_w = coord._this_charger_power(self.ev_dev, self.power)
+            except Exception:  # noqa: BLE001
+                # Helper failures shouldn't break the swap; fall back to
+                # method-local recompute (the legacy path).
+                self.this_power_w = None
+
+        # v1.6.14: stash on the coordinator so ``_this_charger_power``
+        # can return the cached value to in-loop callers (replaces
+        # per-method ``this_power_w = ...`` locals in ev_control.py
+        # without changing those callsites).
+        coord._current_pcc = self
+
         return self
 
     def __exit__(self, exc_type, exc, tb) -> bool:
@@ -236,6 +305,21 @@ class PerChargerContext:
             coord._ev_last_change_per_charger[self.cid] = coord._ev_last_change_time
             coord._ev_reenable_attempts_per_charger[self.cid] = coord._ev_reenable_attempts
             coord._ev_charge_refused_per_charger[self.cid] = coord._ev_charge_refused
+
+            # v1.6.14: persist effective state for the post-loop
+            # notification dispatcher. The dict on the coordinator
+            # remains the storage; pcc is the write path.
+            if self.effective_state is not None:
+                coord._effective_states_per_charger[self.cid] = (
+                    self.effective_state,
+                    self.charger_name or self.cid,
+                )
+
+            # v1.6.14: clear the cache pointer so out-of-loop reads
+            # (single-charger fallback path, post-loop helpers) hit the
+            # direct-compute branch in ``_this_charger_power``.
+            if getattr(coord, "_current_pcc", None) is self:
+                coord._current_pcc = None
 
             # Restore primary view.
             coord._ev_device = self._saved["dev"]

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -143,8 +143,7 @@ the structural invariant.
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
 | **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
-| **v1.6.13** | Surplus tracker jump-from-0 spike fix (#8) — cold start hands KEBA `min_current` first, not direct-jump to target | ✓ shipped |
-| **v1.6.14** | `effective_state` + `this_power_w` migrated from parallel dict / method-local cache onto `PerChargerContext` fields; closes the two abstraction leaks the senior reviewer flagged | ✓ shipped |
+| **v1.6.14 (in progress, bundled)** | (a) Surplus tracker jump-from-0 fix (#8); (b) `effective_state` + `this_power_w` migrated onto `PerChargerContext` fields; (c) per-charger flow sensors; (d) `FleetEvPower` newtype. Shipped as one release rather than four per-PR HACS bumps. | ◐ in develop |
 
 ### What landed under the abstraction
 

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -90,6 +90,7 @@ annotation at all — the lint only flags reads inside `ev_control.py`.
 | `_ev_charge_refused` | Per-charger "charger refused" flag |
 | `_current_charger_budget` | This charger's slice of `EVBudget.net_w` |
 | `_cycle_vehicle_soc` | This charger's vehicle SOC (per `vehicle_soc_entity`) |
+| `_current_pcc` | (v1.6.14) Pointer to the active `PerChargerContext` so `_this_charger_power` can return the cached `this_power_w` |
 
 The corresponding `_per_charger` dicts (e.g.
 `_ev_stalled_since_per_charger: Dict[str, datetime]`) are the **storage**;
@@ -143,48 +144,49 @@ the structural invariant.
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
 | **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
 | **v1.6.13** | Surplus tracker jump-from-0 spike fix (#8) — cold start hands KEBA `min_current` first, not direct-jump to target | ✓ shipped |
+| **v1.6.14** | `effective_state` + `this_power_w` migrated from parallel dict / method-local cache onto `PerChargerContext` fields; closes the two abstraction leaks the senior reviewer flagged | ✓ shipped |
 
 ### What landed under the abstraction
 
 `PerChargerContext` owns the **swap surface** for nine coordinator
-attributes (8 in `_saved` + `_cycle_vehicle_soc`). The fields
-currently on the dataclass are: `cid`, `ev_dev`, `charger_cfg`,
-`budget_w`, `skipped_for_night`.
+attributes (8 in `_saved` + `_cycle_vehicle_soc`). As of v1.6.14 the
+dataclass also carries the computed per-charger fields:
 
-### What was planned-but-not-yet-on the context (deferred to v1.7+)
+| Field | Set by | Read by | Purpose |
+|---|---|---|---|
+| `cid`, `ev_dev`, `charger_cfg` | `for_charger` | loop body | identity |
+| `budget_w` | `for_charger` from `distribute_ev_budget` | `_ev_control` cascade | per-charger surplus slice |
+| `skipped_for_night` | `for_charger` from `_mode_allows_night_charging` | loop body | night gate |
+| `power` | `for_charger` (caller passes `power`) | `__enter__` | cycle-level `PowerReadings` for the precompute |
+| `this_power_w` | `__enter__` via `coord._this_charger_power(ev_dev, power)` | `_this_charger_power` cache shim | this charger's draw (W) |
+| `effective_state` | loop body assignment | `__exit__` → `_effective_states_per_charger` → `_send_notifications` | post-loop per-charger notification dispatch |
+| `charger_name` | `for_charger` from `charger_cfg["name"]` (fallback `cid`) | `__exit__` | display name in notifications |
 
-The original v1.6.7 design proposed migrating these onto `pcc` as
-fields in v1.6.8/v1.6.9:
+### Still deferred to v1.7+
 
-- `effective_state` — currently stored in the parallel coordinator
-  dict `_effective_states_per_charger` and dispatched in
-  `_send_notifications`. Works correctly; not on the context object.
-- `this_power_w` — currently cached as a local variable per method
-  inside `coordinator/ev_control.py`. Works correctly; not on the
-  context object.
-- `night_plan`, `per_charger_flows` — likewise local / parallel.
+- `night_plan` — currently stored in the parallel dict
+  `_night_plan_per_charger`. Mechanically similar to the
+  `effective_state` migration; defer until a consumer (e.g. the
+  per-charger night-progress sensors) actually needs it on `pcc`.
 
-These are real abstraction leaks the v1.6.7 → v1.6.10 arc did not
-close. Plan for v1.7+: migrate at least `effective_state` and
-`this_power_w` onto `PerChargerContext` so the lint can enforce field
-access at type level.
+### v1.6.15 — Per-charger flow sensors
 
-### What was descoped from v1.6.9 (also deferred to v1.7+)
+The data is on `PowerFlows.per_charger` (since v1.6.9) but no
+top-level HA entities expose it yet. v1.6.15 adds
+`sensor.sem_charger_{cid}_solar_to_ev_power`,
+`_grid_to_ev_power`, `_battery_to_ev_power` + matching energy
+accumulators, gated on `len(ev_chargers) > 1`. The Sankey card then
+gains a per-charger split.
 
-The plan listed per-charger flow **sensors**
-(`sensor.sem_charger_<id>_flow_solar_to_ev_power` etc.) as part of
-v1.6.9. The data is on `PowerFlows.per_charger` but no top-level HA
-entities expose it yet — the Sankey card needs the entity surface
-before it can render the per-charger split. Track as a v1.7+ feature
-once a consumer needs it.
-
-### Structural enforcement long-term
+### v1.6.16 — `FleetEvPower` newtype
 
 The `# FLEET-READ:` AST lint catches the bug class but is, by
 construction, a stopgap: a contributor can write
-`# FLEET-READ: idk` and pass. A `FleetEvPower` newtype that requires
-explicit unwrap with a reason argument would be structurally
-stronger. Track for v1.7+.
+`# FLEET-READ: idk` and pass. v1.6.16 replaces
+`PowerReadings.ev_power: float` with a `FleetEvPower` newtype
+requiring explicit unwrap via `.as_fleet_total(reason: str)`. The
+lint then enforces the unwrap call instead of a comment annotation —
+structurally stronger.
 
 See [`/home/sem/.claude/plans/greedy-whistling-nebula.md`](../../.claude/plans/greedy-whistling-nebula.md)
 for the original plan.

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.13"
+  "version": "1.6.14"
 }

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.14"
+  "version": "1.6.12"
 }

--- a/tests/test_per_charger_context.py
+++ b/tests/test_per_charger_context.py
@@ -49,6 +49,14 @@ def _make_coord(ev_chargers=None):
     coord._ev_last_change_per_charger = {}
     coord._ev_reenable_attempts_per_charger = {}
     coord._ev_charge_refused_per_charger = {}
+    # v1.6.14: parallel dict written by ``__exit__`` from ``pcc.effective_state``.
+    coord._effective_states_per_charger = {}
+    # v1.6.14: cache pointer ``__enter__`` sets, ``__exit__`` clears.
+    coord._current_pcc = None
+    # v1.6.14: ``__enter__`` calls this helper to pre-compute
+    # ``this_power_w``. Real coordinator's helper is on ``EVControlMixin``;
+    # the stub returns whatever the test wants.
+    coord._this_charger_power = MagicMock(return_value=0.0)
     return coord
 
 
@@ -218,3 +226,136 @@ class TestBudget:
         with PerChargerContext.for_charger(coord, "left", MagicMock(), {}):
             assert coord._current_charger_budget is None
         assert coord._current_charger_budget is None
+
+
+class TestEffectiveStateField:
+    """v1.6.14: ``pcc.effective_state`` is the write path for
+    ``coord._effective_states_per_charger``. ``__exit__`` persists the
+    field if it's not ``None``; the post-loop notification dispatcher
+    iterates the dict. The loop body never touches the dict directly."""
+
+    def test_effective_state_persists_on_exit(self):
+        """Writing the field inside the ``with`` block lands the
+        ``(state, name)`` tuple in the coordinator's per-charger dict
+        after exit."""
+        coord = _make_coord()
+        ev_dev = MagicMock(name="left_dev")
+        cfg = {"id": "left", "name": "Wallbox Left"}
+        with PerChargerContext.for_charger(
+            coord, "left", ev_dev, {"left": 4000.0},
+            chargers_by_id={"left": cfg},
+        ) as pcc:
+            pcc.effective_state = "CHARGING_ACTIVE"
+        assert coord._effective_states_per_charger == {
+            "left": ("CHARGING_ACTIVE", "Wallbox Left"),
+        }
+
+    def test_effective_state_omitted_when_not_set(self):
+        """Skipped chargers (e.g. ``solar_only`` during night) never
+        set ``pcc.effective_state``; the dict stays empty for them."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(coord, "left", MagicMock(), {}):
+            pass  # no assignment to pcc.effective_state
+        assert coord._effective_states_per_charger == {}
+
+    def test_effective_state_falls_back_to_cid_when_name_missing(self):
+        """Config without a ``name`` key — the cid stands in as the
+        display name (matches legacy behaviour at coordinator.py:1245)."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {"left": 4000.0},
+            chargers_by_id={"left": {"id": "left"}},
+        ) as pcc:
+            pcc.effective_state = "CHARGING_ACTIVE"
+        assert coord._effective_states_per_charger["left"] == (
+            "CHARGING_ACTIVE", "left",
+        )
+
+    def test_multi_charger_dispatches_independently(self):
+        """Two chargers, different states — each ``__exit__`` writes its
+        own key into the dict; no cross-contamination."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {"left": 4000.0},
+            chargers_by_id={"left": {"id": "left", "name": "A"}},
+        ) as pcc_left:
+            pcc_left.effective_state = "CHARGING_ACTIVE"
+        with PerChargerContext.for_charger(
+            coord, "right", MagicMock(), {"right": 0.0},
+            chargers_by_id={"right": {"id": "right", "name": "B"}},
+        ) as pcc_right:
+            pcc_right.effective_state = "IDLE"
+        assert coord._effective_states_per_charger == {
+            "left": ("CHARGING_ACTIVE", "A"),
+            "right": ("IDLE", "B"),
+        }
+
+
+class TestThisPowerWField:
+    """v1.6.14: ``pcc.this_power_w`` is precomputed in ``__enter__``
+    via ``coord._this_charger_power(ev_dev, power)``. The coordinator
+    stashes the active pcc on ``coord._current_pcc`` so the helper's
+    subsequent calls (from inside ev_control methods) serve the cached
+    value rather than re-reading HA state."""
+
+    def test_this_power_w_precomputed_on_enter(self):
+        coord = _make_coord()
+        coord._this_charger_power.return_value = 4150.0
+        ev_dev = MagicMock(name="left_dev")
+        power = MagicMock()
+        with PerChargerContext.for_charger(
+            coord, "left", ev_dev, {"left": 4000.0}, power=power,
+        ) as pcc:
+            assert pcc.this_power_w == 4150.0
+            # Helper called with this charger's ev_dev + the cycle power.
+            coord._this_charger_power.assert_called_once_with(ev_dev, power)
+
+    def test_this_power_w_none_when_no_power_passed(self):
+        """Legacy/unit-test callers that omit ``power`` get ``None`` —
+        the in-loop helper then falls back to direct compute."""
+        coord = _make_coord()
+        with PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {"left": 4000.0},
+        ) as pcc:
+            assert pcc.this_power_w is None
+        # Helper not called when power wasn't supplied.
+        coord._this_charger_power.assert_not_called()
+
+    def test_this_power_w_helper_failure_falls_through(self):
+        """If the helper raises (transient HA state issue), pcc gets
+        ``None`` and the legacy method-local recompute path runs.
+        ``__enter__`` must not propagate the exception — that would
+        leave the swap half-applied."""
+        coord = _make_coord()
+        coord._this_charger_power.side_effect = ValueError("bad state")
+        with PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {"left": 4000.0}, power=MagicMock(),
+        ) as pcc:
+            assert pcc.this_power_w is None
+        # Swap still restored.
+        assert coord._current_pcc is None
+
+
+class TestCurrentPccPointer:
+    """v1.6.14: ``coord._current_pcc`` is set in ``__enter__``, cleared
+    in ``__exit__``. Lets the ``_this_charger_power`` helper return the
+    cached value to in-loop callers without changing their signatures."""
+
+    def test_current_pcc_set_inside_block_cleared_outside(self):
+        coord = _make_coord()
+        assert coord._current_pcc is None
+        with PerChargerContext.for_charger(
+            coord, "left", MagicMock(), {"left": 4000.0},
+        ) as pcc:
+            assert coord._current_pcc is pcc
+        assert coord._current_pcc is None
+
+    def test_current_pcc_cleared_even_on_exception(self):
+        coord = _make_coord()
+        with pytest.raises(RuntimeError, match="boom"):
+            with PerChargerContext.for_charger(
+                coord, "left", MagicMock(), {"left": 4000.0},
+            ):
+                assert coord._current_pcc is not None
+                raise RuntimeError("boom")
+        assert coord._current_pcc is None

--- a/tests/test_this_charger_power_cache.py
+++ b/tests/test_this_charger_power_cache.py
@@ -1,0 +1,129 @@
+"""Tests for ``_this_charger_power`` cache shim (v1.6.14).
+
+v1.6.14 lifts ``this_power_w`` onto ``PerChargerContext`` as a typed
+field, computed once in ``__enter__``. ``_this_charger_power`` becomes
+a cache shim — when ``coord._current_pcc`` points at an active context
+for the same charger, return the cached value; otherwise fall through
+to the legacy HA-state read.
+
+These tests pin:
+
+1. Cache HIT: inside a ``with`` block, the helper returns the value
+   ``__enter__`` precomputed without re-reading HA state.
+2. Cache MISS (different ev): if the helper is called with an
+   ``ev_dev`` that doesn't match ``pcc.ev_dev``, the cache is bypassed.
+3. Cache MISS (no pcc): outside any context, the helper reads HA
+   state — the single-charger fallback path is unchanged.
+4. Cache MISS (pcc but ``this_power_w`` is None): if the precompute
+   failed in ``__enter__``, the helper falls through rather than
+   returning ``None``.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.ev_control import (
+    EVControlMixin,
+)
+from custom_components.solar_energy_management.coordinator.per_charger_context import (
+    PerChargerContext,
+)
+
+
+def _make_mixin(state_value=None, state_unit="W"):
+    """Build a minimal ``EVControlMixin`` stub.
+
+    Provides ``self.hass.states.get(entity_id)`` returning a fake state
+    with ``state`` and ``attributes`` so the legacy HA-read path works.
+    Provides ``_get_active_charger_config`` returning a config dict
+    pointing at the fake sensor.
+    """
+    mx = EVControlMixin.__new__(EVControlMixin)
+
+    hass = MagicMock()
+    if state_value is None:
+        hass.states.get.return_value = None
+    else:
+        state = MagicMock()
+        state.state = str(state_value)
+        state.attributes = {"unit_of_measurement": state_unit}
+        hass.states.get.return_value = state
+    mx.hass = hass
+
+    mx._get_active_charger_config = MagicMock(
+        return_value={"ev_charging_power_sensor": "sensor.fake_charger_power"},
+    )
+    mx._current_pcc = None
+    return mx
+
+
+class TestCacheHit:
+    """When ``coord._current_pcc`` matches the requested ``ev``,
+    ``_this_charger_power`` returns the cached value without
+    touching HA state."""
+
+    def test_cache_hit_short_circuits_ha_read(self):
+        mx = _make_mixin(state_value=999.0)  # HA-read would return 999
+        ev_dev = SimpleNamespace(name="left")
+        pcc = PerChargerContext(
+            cid="left", ev_dev=ev_dev, charger_cfg={},
+            this_power_w=4150.0,
+        )
+        mx._current_pcc = pcc
+
+        # Helper returns the cached value, not the HA-state value.
+        assert mx._this_charger_power(ev_dev, MagicMock(ev_power=0)) == 4150.0
+        # HA state never consulted.
+        mx.hass.states.get.assert_not_called()
+
+
+class TestCacheMiss:
+    """Cache misses fall through to the legacy read path."""
+
+    def test_different_ev_dev_bypasses_cache(self):
+        """Cache only matches when ``pcc.ev_dev is ev``. The "is"
+        identity check matters: copying ev_dev into a different
+        object shouldn't serve the cached value (would be a wrong-
+        charger read)."""
+        mx = _make_mixin(state_value=300.0)  # HA returns 300 W
+        ev_dev_A = SimpleNamespace(name="A")
+        ev_dev_B = SimpleNamespace(name="B")
+        pcc = PerChargerContext(
+            cid="left", ev_dev=ev_dev_A, charger_cfg={},
+            this_power_w=4150.0,
+        )
+        mx._current_pcc = pcc
+
+        # Called with B; cache is for A; helper reads HA state.
+        assert mx._this_charger_power(ev_dev_B, MagicMock(ev_power=0)) == 300.0
+
+    def test_no_pcc_uses_legacy_read(self):
+        """Outside any per-charger iteration (single-charger fallback
+        path at coordinator.py:1267) the helper falls through to the
+        legacy direct-read."""
+        mx = _make_mixin(state_value=2500.0)
+        mx._current_pcc = None
+        assert mx._this_charger_power(SimpleNamespace(), MagicMock(ev_power=0)) == 2500.0
+
+    def test_pcc_with_none_this_power_w_falls_through(self):
+        """``__enter__`` failure mode: pcc set, this_power_w None.
+        Helper must not return ``None`` — fall through to legacy."""
+        mx = _make_mixin(state_value=1234.0)
+        ev_dev = SimpleNamespace(name="left")
+        pcc = PerChargerContext(
+            cid="left", ev_dev=ev_dev, charger_cfg={},
+            this_power_w=None,
+        )
+        mx._current_pcc = pcc
+        assert mx._this_charger_power(ev_dev, MagicMock(ev_power=0)) == 1234.0
+
+
+class TestKwUnitConversion:
+    """Legacy path's kW→W conversion stays in place when the cache
+    is bypassed — pin the regression that bit PROD on 2026-05-31."""
+
+    def test_kw_value_converted_to_watts(self):
+        mx = _make_mixin(state_value=4.14, state_unit="kW")
+        # No pcc → legacy read path. KEBA reports 4.14 kW = 4140 W.
+        assert mx._this_charger_power(SimpleNamespace(), MagicMock(ev_power=0)) == 4140.0


### PR DESCRIPTION
Pulls the multi-charger debt closeout into one bundled v1.6.14 release rather than four per-PR HACS bumps. Maintainer call (\"why is every commit having its own release version?\") — per-PR releases were the wrong cadence for refactor work.

## Two commits

### 1. PCC field migration (the actual code change)

Closes the two abstraction leaks the senior reviewer flagged on the v1.6.7→v1.6.10 arc that were previously deferred to v1.7+:

- ``effective_state`` + ``charger_name`` migrated onto ``PerChargerContext`` instead of the parallel ``_effective_states_per_charger`` dict written by the loop body. ``__exit__`` persists the tuple back into the coordinator dict so ``_send_notifications`` continues reading from a single map.
- ``this_power_w`` precomputed in ``__enter__`` via ``coord._this_charger_power(ev_dev, power)`` and exposed as a typed field. ``coord._current_pcc`` lets ``_this_charger_power`` become a cache shim — same callsites, cached value. Helper exceptions in the precompute fall through to the legacy read path.
- 14 new tests: 9 in ``tests/test_per_charger_context.py``, 5 in new ``tests/test_this_charger_power_cache.py``.

### 2. Release-strategy correction

- ``manifest.json``: reverts develop's premature 1.6.13 bump back to 1.6.12. The final consolidation PR (after v1.6.15 + v1.6.16 land) bumps to 1.6.14.
- ``CHANGELOG.md``: collapses ``[1.6.13]`` + ``[1.6.14]`` sections into one ``[Unreleased] — v1.6.14 candidate`` block per Keep-a-Changelog convention. v1.6.15 + v1.6.16 work appends to this; the release PR renames to ``[1.6.14] — <date>``.
- ``docs/MULTI_CHARGER.md`` roadmap: single ``v1.6.14 (in progress, bundled)`` row covering all four pieces.

## Why bundle

- One PROD soak instead of four
- One HACS update notification instead of four
- One release tag / one rollback target
- ``#8`` (PROD-confirmed bug) ships with the refactor rather than standalone; the cost is one extra soak window for users hitting the spike, the win is no fragmented release cadence

## Tests

- 2224 / 2210 baseline + 14 new on Python 3.12
- New cache shim tests pin the v1.6.5 #315 kW→W regression too (defence in depth)

## Test plan

- [x] 14/14 new tests pass
- [x] 2224 total green on Python 3.12
- [x] Manifest reverted to 1.6.12 (final v1.6.14 bump in the consolidation PR)
- [x] CHANGELOG consolidated to ``[Unreleased]``
- [x] ``docs/MULTI_CHARGER.md`` roadmap reflects bundled release
- [ ] CI green (4-5 checks)
- [ ] HA-TEST multi-charger soak (effective_state notifications + this_power_w cache hit)