### PR TITLE
feat: v1.6.15 — per-charger flow sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,7 +61,8 @@ separate HACS bumps).
 - ``# FLEET-READ:`` annotation on the documented multi-charger
   fallback in ``_this_charger_power`` (only reached when a charger
   config omits ``ev_charging_power_sensor`` — rare).
-- 27 new tests across two files (13 ramp-limit + 14 pcc-field):
+- 47 new tests across three areas (13 ramp-limit + 14 pcc-field +
+  20 per-charger flow):
   - ``tests/test_ramp_limit_8.py``: cold-start, near-zero,
     steady-state ramp, stop-fast, custom ``min_current``,
     end-to-end multi-cycle climb.
@@ -70,6 +71,34 @@ separate HACS bumps).
     lifecycle.
   - ``tests/test_this_charger_power_cache.py``: cache HIT, three
     MISS variants, kW→W conversion regression from #315.
+  - ``tests/test_per_charger_energy_flows.py``: sum invariant,
+    multi-cycle accumulation, day rollover, persistence
+    round-trip (incl. legacy snapshot back-compat), edge cases
+    (charger appears mid-day, charger idle in cycle,
+    zero-interval), bad-snapshot defence, sensor-description
+    generation gate.
+
+- **Per-charger flow sensors (gated on ``len(ev_chargers) > 1``)**:
+  ``sensor.sem_charger_<id>_flow_solar_to_ev_power``,
+  ``..._grid_to_ev_power``, ``..._battery_to_ev_power`` (W,
+  MEASUREMENT) plus matching ``..._energy`` (kWh, TOTAL, daily-
+  reset). The Sankey card + HA Energy dashboard can now show
+  per-charger EV sourcing instead of a fleet-proportional split —
+  closes the @RienduPre observation on #316. Single-charger setups
+  unchanged (fleet ``sensor.sem_flow_*_to_ev_*`` is authoritative).
+  - ``ChargerEnergyFlows`` dataclass + ``EnergyFlows.per_charger``
+    field.
+  - ``FlowCalculator._per_charger_accumulators`` (kWh) integrated
+    over time alongside the fleet accumulator; sum invariant
+    pinned in tests.
+  - Day rollover clears both fleet AND per-charger accumulators.
+  - Snapshot persistence round-trip: new ``per_charger`` key
+    under the existing snapshot dict; pre-v1.6.15 snapshots
+    (without the key) restore bit-for-bit identical.
+  - Accumulator semantic: once a charger appears, its kWh stays
+    surfaced until the day rollover, even on cycles where the
+    charger is idle (the user-visible counter must not regress
+    to 0 just because the car unplugs).
 
 ### Why
 
@@ -83,6 +112,16 @@ The ``#8`` surplus-tracker spike fix bundled in here was confirmed
 live on PROD 2026-05-31 during the v1.6.3 soak — held with the
 refactor rather than shipped standalone so PROD users get one
 soak window instead of four staggered HACS updates.
+
+@RienduPre's #316 observation ("Sankey shows charger 2 sourcing
+from grid even in solar_only") was the user-visible gap behind the
+flow-sensor work. v1.6.9 fixed the underlying data (proportional
+W-level split was honest); v1.6.15 ships the entity surface so the
+dashboard + Energy dashboard actually render the per-charger split.
+
+2244 tests pass on Python 3.12 (2210 v1.6.13 baseline + 14 v1.6.14
+field migration + 20 v1.6.15 flow sensors). Manifest will bump to
+1.6.14 in the consolidation PR (after v1.6.16 FleetEvPower newtype).
 
 ## [1.6.12] — 2026-05-31
 

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -17,7 +17,14 @@ from typing import Dict, Optional
 
 from homeassistant.util import dt as dt_util
 
-from .types import ChargerFlows, PowerReadings, PowerFlows, EnergyTotals, EnergyFlows
+from .types import (
+    ChargerEnergyFlows,
+    ChargerFlows,
+    EnergyFlows,
+    EnergyTotals,
+    PowerFlows,
+    PowerReadings,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -143,6 +150,12 @@ class FlowCalculator:
         """Initialize flow calculator."""
         # Accumulators for energy flows (reset daily)
         self._flow_accumulators: Dict[str, float] = {}
+        # v1.6.15: per-charger EV flow accumulators (kWh), reset daily
+        # alongside ``_flow_accumulators``. Outer key is the charger id,
+        # inner key is one of ``_PER_CHARGER_ACCUMULATED_ATTRS``. Empty
+        # in single-charger setups (no per-charger PowerFlows entries
+        # arrive at ``integrate_energy_flows``).
+        self._per_charger_accumulators: Dict[str, Dict[str, float]] = {}
         self._current_date: date = dt_util.now().date()
 
     def calculate_power_flows(self, power: PowerReadings) -> PowerFlows:
@@ -245,6 +258,12 @@ class FlowCalculator:
         "battery_to_home", "battery_to_ev",
     )
 
+    # v1.6.15: per-charger EV slice. Only the three EV-side flows
+    # have a per-charger attribution surface — the rest stay fleet-level.
+    _PER_CHARGER_ACCUMULATED_ATTRS = (
+        "solar_to_ev", "grid_to_ev", "battery_to_ev",
+    )
+
     def integrate_energy_flows(
         self, power_flows: PowerFlows, interval_seconds: float,
     ) -> EnergyFlows:
@@ -284,6 +303,7 @@ class FlowCalculator:
         today = dt_util.now().date()
         if today != self._current_date:
             self._flow_accumulators.clear()
+            self._per_charger_accumulators.clear()
             self._current_date = today
 
         hours = max(0.0, interval_seconds) / 3600.0
@@ -296,15 +316,50 @@ class FlowCalculator:
         flows = EnergyFlows()
         for attr in self._ACCUMULATED_ATTRS:
             setattr(flows, attr, round(self._flow_accumulators.get(attr, 0.0), 3))
+
+        # v1.6.15: per-charger EV slice. Integrate ``power_flows.per_charger``
+        # into a parallel dict-of-dicts so each charger has its own kWh
+        # counter. Sum invariant: per_charger totals match the fleet
+        # ``flows.solar_to_ev`` (etc.) modulo rounding (pinned in
+        # ``tests/test_per_charger_energy_flows.py``).
+        if power_flows.per_charger:
+            for cid, cflow in power_flows.per_charger.items():
+                acc = self._per_charger_accumulators.setdefault(cid, {})
+                for attr in self._PER_CHARGER_ACCUMULATED_ATTRS:
+                    watts = getattr(cflow, attr, 0.0) or 0.0
+                    acc[attr] = acc.get(attr, 0.0) + watts * hours / 1000.0
+
+        # Emit every charger ever seen in the accumulator — even those
+        # the current cycle's ``power_flows`` doesn't mention (e.g. car
+        # unplugged mid-day). The user-visible counter must not regress
+        # to 0 just because the charger went idle.
+        for cid, acc in self._per_charger_accumulators.items():
+            flows.per_charger[cid] = ChargerEnergyFlows(
+                solar_to_ev=round(acc.get("solar_to_ev", 0.0), 3),
+                grid_to_ev=round(acc.get("grid_to_ev", 0.0), 3),
+                battery_to_ev=round(acc.get("battery_to_ev", 0.0), 3),
+            )
+
         return flows
 
     def get_flow_accumulator_state(self) -> dict:
         """Snapshot for persistence (#282). Keys + date so restore can
-        detect a stale snapshot from a previous day."""
-        return {
+        detect a stale snapshot from a previous day.
+
+        v1.6.15 adds ``per_charger`` — restored only if non-empty so
+        single-charger storage stays bit-for-bit compatible with the
+        pre-v1.6.15 snapshot format.
+        """
+        snap = {
             "date": self._current_date.isoformat(),
             "accumulators": dict(self._flow_accumulators),
         }
+        if self._per_charger_accumulators:
+            snap["per_charger"] = {
+                cid: dict(acc)
+                for cid, acc in self._per_charger_accumulators.items()
+            }
+        return snap
 
     def restore_flow_accumulator_state(self, state: dict) -> None:
         """Restore on coordinator startup so an HA restart mid-day doesn't
@@ -325,6 +380,19 @@ class FlowCalculator:
                 v = acc.get(k)
                 if isinstance(v, (int, float)):
                     self._flow_accumulators[k] = float(v)
+
+        # v1.6.15: restore per-charger slice if present. Missing key is
+        # the expected case for pre-v1.6.15 snapshots — silently skip.
+        pc = state.get("per_charger")
+        if isinstance(pc, dict):
+            for cid, acc in pc.items():
+                if not isinstance(acc, dict):
+                    continue
+                target = self._per_charger_accumulators.setdefault(str(cid), {})
+                for k in self._PER_CHARGER_ACCUMULATED_ATTRS:
+                    v = acc.get(k)
+                    if isinstance(v, (int, float)):
+                        target[k] = float(v)
 
     def calculate_energy_flows(self, energy: EnergyTotals) -> EnergyFlows:
         """Legacy proportional-allocation energy flows (kept for tests).

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -160,6 +160,24 @@ class EnergyTotals:
 
 
 @dataclass
+class ChargerEnergyFlows:
+    """Per-charger slice of the daily EV energy flow attribution (v1.6.15).
+
+    Mirrors :class:`ChargerFlows` (power, W) at the kWh level, integrated
+    over time by ``FlowCalculator.integrate_energy_flows``. The fleet
+    ``EnergyFlows.solar_to_ev`` (etc.) is the sum across all chargers'
+    values here — invariant pinned in
+    ``tests/test_per_charger_energy_flows.py``.
+
+    Empty / not-populated in single-charger setups; the fleet-level
+    ``EnergyFlows`` fields are authoritative there.
+    """
+    solar_to_ev: float = 0.0
+    grid_to_ev: float = 0.0
+    battery_to_ev: float = 0.0
+
+
+@dataclass
 class EnergyFlows:
     """Daily energy flow distribution (kWh)."""
     # Solar flows
@@ -176,6 +194,15 @@ class EnergyFlows:
     # Battery flows
     battery_to_home: float = 0.0
     battery_to_ev: float = 0.0
+
+    # Per-charger EV energy split (v1.6.15). Populated by
+    # ``FlowCalculator.integrate_energy_flows`` when
+    # ``PowerFlows.per_charger`` is non-empty (multi-charger setups).
+    # Empty dict in single-charger setups — readers fall back to the
+    # fleet fields above. Invariant:
+    # ``sum(c.solar_to_ev for c in per_charger.values()) == solar_to_ev``
+    # within rounding tolerance.
+    per_charger: "Dict[str, ChargerEnergyFlows]" = field(default_factory=dict)
 
 
 @dataclass
@@ -542,6 +569,35 @@ class SEMData:
             "flow_grid_to_battery_energy": self.energy_flows.grid_to_battery,
             "flow_battery_to_home_energy": self.energy_flows.battery_to_home,
             "flow_battery_to_ev_energy": self.energy_flows.battery_to_ev,
+
+            # Per-charger flow surface (v1.6.15). Emit only when the
+            # multi-charger pipeline has populated these maps; in
+            # single-charger setups the dicts are empty and the keys
+            # are skipped, so the fleet sensors stay authoritative.
+            **{
+                f"charger_{cid}_flow_solar_to_ev_power": cf.solar_to_ev
+                for cid, cf in (self.power_flows.per_charger or {}).items()
+            },
+            **{
+                f"charger_{cid}_flow_grid_to_ev_power": cf.grid_to_ev
+                for cid, cf in (self.power_flows.per_charger or {}).items()
+            },
+            **{
+                f"charger_{cid}_flow_battery_to_ev_power": cf.battery_to_ev
+                for cid, cf in (self.power_flows.per_charger or {}).items()
+            },
+            **{
+                f"charger_{cid}_flow_solar_to_ev_energy": cef.solar_to_ev
+                for cid, cef in (self.energy_flows.per_charger or {}).items()
+            },
+            **{
+                f"charger_{cid}_flow_grid_to_ev_energy": cef.grid_to_ev
+                for cid, cef in (self.energy_flows.per_charger or {}).items()
+            },
+            **{
+                f"charger_{cid}_flow_battery_to_ev_energy": cef.battery_to_ev
+                for cid, cef in (self.energy_flows.per_charger or {}).items()
+            },
 
             # Costs
             "daily_costs": self.costs.daily_costs,

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -143,7 +143,7 @@ the structural invariant.
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
 | **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
-| **v1.6.14 (in progress, bundled)** | (a) Surplus tracker jump-from-0 fix (#8); (b) `effective_state` + `this_power_w` migrated onto `PerChargerContext` fields; (c) per-charger flow sensors; (d) `FleetEvPower` newtype. Shipped as one release rather than four per-PR HACS bumps. | ◐ in develop |
+| **v1.6.14 (in progress, bundled)** | (a) ✓ Surplus tracker jump-from-0 fix (#8); (b) ✓ `effective_state` + `this_power_w` migrated onto `PerChargerContext` fields; (c) ✓ per-charger flow sensors (`sensor.sem_charger_<id>_flow_*_to_ev_*` gated on `len(ev_chargers) > 1`); (d) ◻ `FleetEvPower` newtype. Shipping as one release rather than four per-PR HACS bumps. | ◐ in develop |
 
 ### What landed under the abstraction
 

--- a/sensor.py
+++ b/sensor.py
@@ -1630,6 +1630,70 @@ async def async_setup_entry(
             ),
         ])
 
+    # v1.6.15: per-charger flow attribution sensors. Gated on
+    # ``len(ev_chargers) > 1`` — for single-charger setups the fleet
+    # ``sensor.sem_flow_*_to_ev_*`` entities are authoritative (each
+    # fleet sensor IS the single charger's flow) and adding duplicates
+    # would just clutter the entity registry. The dashboard generator's
+    # Sankey card per-charger split (also v1.6.15) reads these entities.
+    if len(ev_chargers) > 1:
+        for charger_cfg in ev_chargers:
+            cid = charger_cfg.get("id", "ev_charger")
+            cname = charger_cfg.get("name", "EV Charger")
+            per_charger_descriptions.extend([
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_solar_to_ev_power",
+                    name=f"{cname} Solar → EV Power",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    native_unit_of_measurement=UnitOfPower.WATT,
+                    suggested_display_precision=0,
+                ),
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_grid_to_ev_power",
+                    name=f"{cname} Grid → EV Power",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    native_unit_of_measurement=UnitOfPower.WATT,
+                    suggested_display_precision=0,
+                ),
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_battery_to_ev_power",
+                    name=f"{cname} Battery → EV Power",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    native_unit_of_measurement=UnitOfPower.WATT,
+                    suggested_display_precision=0,
+                ),
+                # Energy counters — integrated by ``FlowCalculator.integrate_energy_flows``
+                # daily-resetting, surfaced as TOTAL so HA Energy
+                # dashboard can use them in the EV-source breakdown.
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_solar_to_ev_energy",
+                    name=f"{cname} Solar → EV Energy",
+                    device_class=SensorDeviceClass.ENERGY,
+                    state_class=SensorStateClass.TOTAL,
+                    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                    suggested_display_precision=2,
+                ),
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_grid_to_ev_energy",
+                    name=f"{cname} Grid → EV Energy",
+                    device_class=SensorDeviceClass.ENERGY,
+                    state_class=SensorStateClass.TOTAL,
+                    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                    suggested_display_precision=2,
+                ),
+                SensorEntityDescription(
+                    key=f"charger_{cid}_flow_battery_to_ev_energy",
+                    name=f"{cname} Battery → EV Energy",
+                    device_class=SensorDeviceClass.ENERGY,
+                    state_class=SensorStateClass.TOTAL,
+                    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                    suggested_display_precision=2,
+                ),
+            ])
+
     for desc in per_charger_descriptions:
         sensors.append(SEMSolarSensor(coordinator, desc, entry.entry_id))
 

--- a/tests/test_per_charger_energy_flows.py
+++ b/tests/test_per_charger_energy_flows.py
@@ -1,0 +1,410 @@
+"""Per-charger energy flow integration tests (v1.6.15).
+
+v1.6.9 added the per-charger POWER attribution surface
+``PowerFlows.per_charger``. v1.6.15 adds the matching ENERGY
+accumulator surface ``EnergyFlows.per_charger`` plus the integration
+inside ``FlowCalculator.integrate_energy_flows``. These tests pin:
+
+1. Single-charger setups remain identical (empty
+   ``EnergyFlows.per_charger`` dict, fleet fields unchanged).
+2. Multi-charger setups accumulate per-charger kWh that match the
+   fleet ``solar_to_ev`` / ``grid_to_ev`` / ``battery_to_ev`` sum
+   within float rounding.
+3. Day rollover clears both the fleet and the per-charger
+   accumulators.
+4. Persistence round-trip preserves per-charger state across an HA
+   restart mid-day.
+5. Pre-v1.6.15 snapshots (no ``per_charger`` key) restore cleanly.
+"""
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.flow_calculator import (
+    FlowCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    ChargerFlows,
+    EnergyFlows,
+    PowerFlows,
+)
+
+
+def _integrate(fc: FlowCalculator, **per_charger_flows) -> EnergyFlows:
+    """Integrate a single cycle. ``per_charger_flows`` is
+    ``{cid: (solar_w, grid_w, battery_w)}``. Fleet fields are the sums."""
+    flows = PowerFlows()
+    for cid, (s, g, b) in per_charger_flows.items():
+        flows.solar_to_ev += s
+        flows.grid_to_ev += g
+        flows.battery_to_ev += b
+        flows.per_charger[cid] = ChargerFlows(
+            solar_to_ev=s, grid_to_ev=g, battery_to_ev=b,
+        )
+    # Integrate over 1 hour so kWh equals input W / 1000 (easy to assert).
+    return fc.integrate_energy_flows(flows, interval_seconds=3600)
+
+
+class TestSingleChargerBackCompat:
+    """Single-charger / no per-charger data: existing fleet behaviour
+    is unchanged, and the ``per_charger`` dict on the result stays
+    empty so downstream readers that don't know about it keep working."""
+
+    def test_no_per_charger_data_yields_empty_dict(self):
+        fc = FlowCalculator()
+        flows = PowerFlows()
+        flows.solar_to_ev = 4000.0  # 1 charger, fleet view only
+        result = fc.integrate_energy_flows(flows, interval_seconds=3600)
+        # Fleet integrated correctly.
+        assert result.solar_to_ev == pytest.approx(4.0, rel=1e-3)
+        # Per-charger dict remains empty.
+        assert result.per_charger == {}
+
+
+class TestMultiChargerSumInvariant:
+    """Sum-of-per-charger == fleet within rounding. Mirrors the
+    invariant ``calculate_power_flows`` pins at the W level."""
+
+    def test_two_chargers_split_solar(self):
+        fc = FlowCalculator()
+        # Two chargers, one drawing 2000 W solar, one drawing 3000 W solar.
+        # One full hour → 2 kWh and 3 kWh respectively, fleet = 5 kWh.
+        result = _integrate(fc, left=(2000.0, 0.0, 0.0), right=(3000.0, 0.0, 0.0))
+        assert result.solar_to_ev == pytest.approx(5.0, rel=1e-3)
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(2.0)
+        assert result.per_charger["right"].solar_to_ev == pytest.approx(3.0)
+        # Sum invariant.
+        per_charger_sum = sum(
+            cef.solar_to_ev for cef in result.per_charger.values()
+        )
+        assert per_charger_sum == pytest.approx(result.solar_to_ev, abs=0.01)
+
+    def test_mixed_sources_per_charger(self):
+        """Charger A pulls from solar; charger B pulls from grid. Per-
+        charger sourcing differs; fleet is the sum of both."""
+        fc = FlowCalculator()
+        result = _integrate(fc, left=(4000.0, 0.0, 0.0), right=(0.0, 4000.0, 0.0))
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(4.0)
+        assert result.per_charger["left"].grid_to_ev == 0.0
+        assert result.per_charger["right"].solar_to_ev == 0.0
+        assert result.per_charger["right"].grid_to_ev == pytest.approx(4.0)
+        # Fleet sees both.
+        assert result.solar_to_ev == pytest.approx(4.0)
+        assert result.grid_to_ev == pytest.approx(4.0)
+
+
+class TestMultiCycleAccumulation:
+    """Across multiple cycles the per-charger accumulator grows like
+    the fleet one — pins integration, not snapshotting."""
+
+    def test_two_cycles_accumulate(self):
+        fc = FlowCalculator()
+        # Two 30-min cycles at 4000 W each → total 4 kWh.
+        for _ in range(2):
+            flows = PowerFlows()
+            flows.solar_to_ev = 4000.0
+            flows.per_charger["left"] = ChargerFlows(solar_to_ev=4000.0)
+            result = fc.integrate_energy_flows(flows, interval_seconds=1800)
+        assert result.solar_to_ev == pytest.approx(4.0, rel=1e-3)
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(4.0, rel=1e-3)
+
+
+class TestDayRollover:
+    """Both fleet AND per-charger accumulators clear at local midnight."""
+
+    def test_rollover_clears_per_charger(self):
+        fc = FlowCalculator()
+        _integrate(fc, left=(4000.0, 0.0, 0.0))
+        assert fc._per_charger_accumulators["left"]["solar_to_ev"] > 0
+
+        # Simulate next day.
+        with patch(
+            "custom_components.solar_energy_management.coordinator.flow_calculator.dt_util.now"
+        ) as mocked:
+            tomorrow = date.today() + timedelta(days=1)
+            mocked.return_value.date.return_value = tomorrow
+            mocked.return_value.isoformat.return_value = tomorrow.isoformat()
+            flows = PowerFlows()
+            flows.solar_to_ev = 1000.0
+            flows.per_charger["left"] = ChargerFlows(solar_to_ev=1000.0)
+            result = fc.integrate_energy_flows(flows, interval_seconds=3600)
+            # Today's slate: 1 kWh, NOT 1+4.
+            assert result.solar_to_ev == pytest.approx(1.0, rel=1e-3)
+            assert result.per_charger["left"].solar_to_ev == pytest.approx(1.0, rel=1e-3)
+
+
+class TestPersistenceRoundTrip:
+    """``get_flow_accumulator_state`` / ``restore_flow_accumulator_state``
+    round-trip preserves per-charger kWh across an HA restart mid-day."""
+
+    def test_snapshot_includes_per_charger_when_populated(self):
+        fc = FlowCalculator()
+        _integrate(fc, left=(4000.0, 0.0, 0.0), right=(0.0, 4000.0, 0.0))
+        snap = fc.get_flow_accumulator_state()
+        assert "per_charger" in snap
+        assert "left" in snap["per_charger"]
+        assert snap["per_charger"]["left"]["solar_to_ev"] == pytest.approx(4.0)
+        assert snap["per_charger"]["right"]["grid_to_ev"] == pytest.approx(4.0)
+
+    def test_snapshot_omits_per_charger_when_empty(self):
+        """Single-charger / no per-charger data → snapshot stays
+        bit-for-bit compatible with the pre-v1.6.15 format."""
+        fc = FlowCalculator()
+        flows = PowerFlows()
+        flows.solar_to_ev = 4000.0
+        fc.integrate_energy_flows(flows, interval_seconds=3600)
+        snap = fc.get_flow_accumulator_state()
+        assert "per_charger" not in snap
+
+    def test_restore_round_trip(self):
+        # Source FC: integrate, then snapshot.
+        src = FlowCalculator()
+        _integrate(src, left=(4000.0, 0.0, 0.0), right=(0.0, 3000.0, 0.0))
+        snap = src.get_flow_accumulator_state()
+
+        # Destination FC: restore from the snapshot.
+        dst = FlowCalculator()
+        dst.restore_flow_accumulator_state(snap)
+        # Next cycle adds nothing — the restored accumulator IS the state.
+        result = dst.integrate_energy_flows(PowerFlows(), interval_seconds=0)
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(4.0)
+        assert result.per_charger["right"].grid_to_ev == pytest.approx(3.0)
+
+    def test_restore_legacy_snapshot_without_per_charger(self):
+        """Pre-v1.6.15 snapshot (no ``per_charger`` key) — restore
+        cleanly, no per-charger state, no exceptions."""
+        fc = FlowCalculator()
+        legacy_snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {"solar_to_ev": 4.0, "grid_to_ev": 1.0},
+        }
+        fc.restore_flow_accumulator_state(legacy_snap)
+        assert fc._flow_accumulators["solar_to_ev"] == pytest.approx(4.0)
+        assert fc._per_charger_accumulators == {}
+
+
+class TestDataDict:
+    """v1.6.15: ``SEMData.to_dict`` emits per-charger
+    keys when ``PowerFlows.per_charger`` / ``EnergyFlows.per_charger``
+    are populated. Sensor descriptions in ``sensor.py`` (gated on
+    ``len(ev_chargers) > 1``) look up these keys."""
+
+    def test_dict_includes_per_charger_keys(self):
+        from custom_components.solar_energy_management.coordinator.types import (
+            ChargerEnergyFlows, SEMData,
+        )
+        d = SEMData()
+        d.power_flows.per_charger["left"] = ChargerFlows(
+            solar_to_ev=2500.0, grid_to_ev=0.0, battery_to_ev=0.0,
+        )
+        d.energy_flows.per_charger["left"] = ChargerEnergyFlows(
+            solar_to_ev=1.25, grid_to_ev=0.0, battery_to_ev=0.0,
+        )
+        out = d.to_dict()
+        assert out["charger_left_flow_solar_to_ev_power"] == 2500.0
+        assert out["charger_left_flow_grid_to_ev_power"] == 0.0
+        assert out["charger_left_flow_solar_to_ev_energy"] == 1.25
+        # Sanity: fleet keys untouched.
+        assert "flow_solar_to_ev_power" in out
+
+    def test_dict_omits_per_charger_keys_when_empty(self):
+        from custom_components.solar_energy_management.coordinator.types import (
+            SEMData,
+        )
+        d = SEMData()
+        out = d.to_dict()
+        # No per_charger keys leak in the single-charger case.
+        leaked = [k for k in out if k.startswith("charger_") and "flow" in k]
+        assert leaked == []
+
+    def test_dict_multi_charger_emits_all_six_keys_per_charger(self):
+        """For each charger present in either power_flows.per_charger
+        or energy_flows.per_charger, ``to_dict`` emits 6 keys: 3 power
+        + 3 energy. These are the keys ``sensor.py`` looks up."""
+        from custom_components.solar_energy_management.coordinator.types import (
+            ChargerEnergyFlows, SEMData,
+        )
+        d = SEMData()
+        for cid in ("left", "right"):
+            d.power_flows.per_charger[cid] = ChargerFlows(
+                solar_to_ev=2500.0, grid_to_ev=500.0, battery_to_ev=1000.0,
+            )
+            d.energy_flows.per_charger[cid] = ChargerEnergyFlows(
+                solar_to_ev=2.5, grid_to_ev=0.5, battery_to_ev=1.0,
+            )
+        out = d.to_dict()
+        for cid in ("left", "right"):
+            for suffix in (
+                "flow_solar_to_ev_power", "flow_grid_to_ev_power",
+                "flow_battery_to_ev_power", "flow_solar_to_ev_energy",
+                "flow_grid_to_ev_energy", "flow_battery_to_ev_energy",
+            ):
+                assert f"charger_{cid}_{suffix}" in out, (
+                    f"Missing key for {cid}/{suffix}"
+                )
+
+
+class TestEdgeCases:
+    """Real-world transients: chargers appearing mid-day, disappearing,
+    or the accumulator persistently surfacing kWh after the EV unplugs."""
+
+    def test_charger_appears_mid_day_starts_at_zero(self):
+        """Cycle 1: only ``left``. Cycle 2: ``right`` joins. The accumulator
+        for ``right`` starts at 0 and integrates the cycle's draw — it
+        doesn't backfill any imaginary earlier draw."""
+        fc = FlowCalculator()
+        # Cycle 1: only left, 1 h at 4000 W → 4 kWh.
+        _integrate(fc, left=(4000.0, 0.0, 0.0))
+        assert fc._per_charger_accumulators["left"]["solar_to_ev"] == pytest.approx(4.0)
+        assert "right" not in fc._per_charger_accumulators
+        # Cycle 2: right appears (1 h at 1000 W solar). Left also draws.
+        result = _integrate(fc, left=(4000.0, 0.0, 0.0), right=(1000.0, 0.0, 0.0))
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(8.0, rel=1e-2)
+        assert result.per_charger["right"].solar_to_ev == pytest.approx(1.0, rel=1e-2)
+
+    def test_charger_idle_in_cycle_still_surfaces_accumulator(self):
+        """After accumulating kWh for ``left``, a cycle where the
+        ``power_flows.per_charger`` map omits ``left`` (car unplugged)
+        must NOT drop ``left`` from the result — the kWh stays
+        visible until the day rollover."""
+        fc = FlowCalculator()
+        _integrate(fc, left=(4000.0, 0.0, 0.0))
+        # Cycle 2: only right, no left in power_flows.
+        result = _integrate(fc, right=(1000.0, 0.0, 0.0))
+        assert "left" in result.per_charger
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(4.0, rel=1e-2)
+
+    def test_zero_interval_no_accumulation(self):
+        """``interval_seconds=0`` (e.g. immediately after restore) →
+        no accumulation, but the existing accumulator state IS
+        emitted."""
+        fc = FlowCalculator()
+        _integrate(fc, left=(4000.0, 0.0, 0.0))
+        before = fc._per_charger_accumulators["left"]["solar_to_ev"]
+        flows = PowerFlows()
+        flows.per_charger["left"] = ChargerFlows(solar_to_ev=4000.0)
+        result = fc.integrate_energy_flows(flows, interval_seconds=0)
+        after = fc._per_charger_accumulators["left"]["solar_to_ev"]
+        assert after == pytest.approx(before)
+        # Result still mirrors the accumulator.
+        assert result.per_charger["left"].solar_to_ev == pytest.approx(before, rel=1e-2)
+
+
+class TestBadSnapshotDefence:
+    """The restore path should accept legacy + valid snapshots and
+    ignore malformed ones rather than crashing. Pin the per-charger
+    counterpart to the existing legacy_snap test."""
+
+    def test_restore_non_dict_per_charger_silently_skipped(self):
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {"solar_to_ev": 4.0},
+            "per_charger": "not-a-dict",  # type-bad
+        }
+        # Must not raise.
+        fc.restore_flow_accumulator_state(snap)
+        assert fc._flow_accumulators["solar_to_ev"] == pytest.approx(4.0)
+        assert fc._per_charger_accumulators == {}
+
+    def test_restore_per_charger_with_non_dict_entry(self):
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {"solar_to_ev": 4.0},
+            "per_charger": {"left": "not-a-dict-either"},
+        }
+        fc.restore_flow_accumulator_state(snap)
+        # ``left`` silently skipped — no entry in accumulators.
+        assert "left" not in fc._per_charger_accumulators
+
+    def test_restore_per_charger_with_non_numeric_values(self):
+        """Same defence as the fleet path: non-numeric values are
+        silently skipped per-key rather than failing the whole
+        restore."""
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {},
+            "per_charger": {
+                "left": {"solar_to_ev": 2.5, "grid_to_ev": "bad", "battery_to_ev": None},
+            },
+        }
+        fc.restore_flow_accumulator_state(snap)
+        assert fc._per_charger_accumulators["left"]["solar_to_ev"] == pytest.approx(2.5)
+        assert "grid_to_ev" not in fc._per_charger_accumulators["left"]
+        assert "battery_to_ev" not in fc._per_charger_accumulators["left"]
+
+
+class TestSensorDescriptions:
+    """v1.6.15 wires per-charger flow descriptions in ``sensor.py``
+    gated on ``len(ev_chargers) > 1``. Reproducing the gate in a
+    unit test pins the user-visible entity surface."""
+
+    def test_single_charger_no_per_charger_flow_descriptions(self):
+        """One charger configured → no per-charger flow sensors
+        (the fleet ``sensor.sem_flow_*_to_ev_*`` entities are
+        authoritative)."""
+        ev_chargers = [{"id": "left", "name": "Wallbox Left"}]
+        descriptions = self._build_per_charger_descriptions(ev_chargers)
+        flow_keys = [d.key for d in descriptions if "flow_" in d.key]
+        assert flow_keys == []
+
+    def test_multi_charger_emits_six_flow_descriptions_per_charger(self):
+        """Two chargers → 12 flow descriptions: 3 power + 3 energy × 2."""
+        ev_chargers = [
+            {"id": "left", "name": "Wallbox Left"},
+            {"id": "right", "name": "Wallbox Right"},
+        ]
+        descriptions = self._build_per_charger_descriptions(ev_chargers)
+        flow_keys = sorted(d.key for d in descriptions if "flow_" in d.key)
+        assert flow_keys == [
+            "charger_left_flow_battery_to_ev_energy",
+            "charger_left_flow_battery_to_ev_power",
+            "charger_left_flow_grid_to_ev_energy",
+            "charger_left_flow_grid_to_ev_power",
+            "charger_left_flow_solar_to_ev_energy",
+            "charger_left_flow_solar_to_ev_power",
+            "charger_right_flow_battery_to_ev_energy",
+            "charger_right_flow_battery_to_ev_power",
+            "charger_right_flow_grid_to_ev_energy",
+            "charger_right_flow_grid_to_ev_power",
+            "charger_right_flow_solar_to_ev_energy",
+            "charger_right_flow_solar_to_ev_power",
+        ]
+
+    @staticmethod
+    def _build_per_charger_descriptions(ev_chargers):
+        """Mirror the gating logic in ``sensor.py:async_setup_entry``
+        for the v1.6.15 flow descriptions. Kept in-test so the unit
+        check is independent of the broader setup pipeline (importing
+        the real ``async_setup_entry`` would pull in HA's full entity
+        registry, well outside this test's scope)."""
+        from homeassistant.components.sensor import (
+            SensorDeviceClass, SensorEntityDescription, SensorStateClass,
+        )
+        from homeassistant.const import UnitOfEnergy, UnitOfPower
+        out = []
+        if len(ev_chargers) > 1:
+            for c in ev_chargers:
+                cid = c.get("id", "ev_charger")
+                cname = c.get("name", "EV Charger")
+                for src in ("solar", "grid", "battery"):
+                    out.append(SensorEntityDescription(
+                        key=f"charger_{cid}_flow_{src}_to_ev_power",
+                        name=f"{cname} {src.title()} → EV Power",
+                        device_class=SensorDeviceClass.POWER,
+                        state_class=SensorStateClass.MEASUREMENT,
+                        native_unit_of_measurement=UnitOfPower.WATT,
+                        suggested_display_precision=0,
+                    ))
+                    out.append(SensorEntityDescription(
+                        key=f"charger_{cid}_flow_{src}_to_ev_energy",
+                        name=f"{cname} {src.title()} → EV Energy",
+                        device_class=SensorDeviceClass.ENERGY,
+                        state_class=SensorStateClass.TOTAL,
+                        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                        suggested_display_precision=2,
+                    ))
+        return out


### PR DESCRIPTION
Third of the four-release multi-charger closeout (bundled into v1.6.14). Closes the v1.6.9 follow-up that left ``PowerFlows.per_charger`` as data with no entity surface.

## Summary

- ``ChargerEnergyFlows`` dataclass + ``EnergyFlows.per_charger`` field.
- ``FlowCalculator._per_charger_accumulators`` (kWh) integrated alongside the fleet accumulator; sum invariant pinned.
- ``sensor.py`` adds 6 descriptions per charger gated on ``len(ev_chargers) > 1``: 3 power + 3 energy.
- ``SEMData.to_dict`` emits ``charger_{cid}_flow_*_to_ev_*`` keys; sensors look them up.
- Snapshot persistence: new ``per_charger`` key under the existing dict, omitted when empty (pre-v1.6.15 snapshots restore bit-identical).
- Accumulator semantic: once a charger appears, its kWh stays surfaced until day rollover even on idle cycles.
- Day rollover (local midnight) clears both fleet AND per-charger accumulators.

## Why

@RienduPre's #316 observation: \"Sankey shows charger 2 sourcing from grid even in solar_only mode.\" v1.6.9 fixed the data; v1.6.15 ships the entity surface so the dashboard / Energy dashboard actually render the per-charger split.

## Tests (20 new, 2244 total)

``tests/test_per_charger_energy_flows.py``:
- Sum invariant under varied splits (2 tests)
- Multi-cycle accumulation
- Day rollover clears per-charger too
- Persistence round-trip (4 tests, incl. legacy snapshot back-compat)
- SEMData.to_dict emits / omits keys correctly (3 tests)
- Edge cases: charger appears mid-day, charger idle in cycle, zero-interval (3 tests)
- Bad-snapshot defence: non-dict per_charger, non-dict entry, non-numeric values (3 tests)
- Sensor description generation gate (2 tests)

Full suite 2244 green on Python 3.12.

## Release strategy

Per ``[Unreleased] — v1.6.14 candidate`` convention. No manifest bump in this PR. Final consolidation PR (after v1.6.16 FleetEvPower newtype) bumps to 1.6.14 and renames the CHANGELOG section.

## Test plan

- [x] 20 new + 2224 baseline green on Python 3.12
- [x] CHANGELOG + ``docs/MULTI_CHARGER.md`` roadmap updated
- [ ] CI green (5 checks)
- [ ] HA-TEST multi-charger soak (verify per-charger flow sensors populate in HA Energy dashboard)