### PR TITLE
release: v1.6.14 — multi-charger debt closeout (FleetEvPower newtype)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased] — v1.6.14 candidate
+## [1.6.14] — 2026-05-31
 
 Multi-charger debt closeout. Bundles four pieces of work into one
 release (the maintainer-set rule "no v1.7 until every multi-charger
@@ -100,6 +100,40 @@ separate HACS bumps).
     charger is idle (the user-visible counter must not regress
     to 0 just because the car unplugs).
 
+- **``FleetEvPower`` newtype + global AST lint (v1.6.16 work)**.
+  ``PowerReadings.ev_power`` is now typed as ``FleetEvPower`` — a
+  ``float`` subclass that exposes ``.as_fleet_total(reason: str)``.
+  Two equivalent ways to acknowledge a fleet read:
+  - Comment form (v1.6.8 idiom, still valid):
+    ``# FLEET-READ: <reason>`` on the same line or up to 5 lines
+    above (walking back through ``#``-comment lines only).
+  - Method form (preferred for new code):
+    ``power.ev_power.as_fleet_total("<reason>")`` — the reason
+    rides in the bytecode (mypy / IDE hover / ``git blame``)
+    instead of an adjacent comment.
+
+  Lint expanded to every module under ``coordinator/`` (was
+  ``ev_control.py`` only). Exempt files: ``types.py`` (defines the
+  field) and ``per_charger_context.py`` (docstrings only). The
+  ~15 legitimate fleet reads got explicit ``# FLEET-READ:``
+  reasons; one ``coordinator.py:3459`` stall-detection site
+  migrated to the new method form as the in-tree demo.
+
+  Sensor reader (the only writer) constructs ``FleetEvPower``
+  instances at the assignment sites. Single-charger setups
+  unchanged — ``FleetEvPower(value)`` reduces to a tagged float.
+
+  12 new tests in ``tests/test_fleet_ev_power_reads_global.py``:
+  - ``TestGlobalFleetEvPowerLint`` (6): every read acknowledged
+    across coordinator/; exempt-list minimality; synthetic-code
+    sanity (method form detected, bare read flagged, comment
+    form still accepted).
+  - ``TestFleetEvPowerNewtype`` (6): is float subclass,
+    arithmetic works (no migration cost), ``.as_fleet_total``
+    returns plain float, reason arg is documentation-only,
+    default ``PowerReadings.ev_power`` is the newtype, repr
+    includes class name.
+
 ### Why
 
 Senior reviewer on the v1.6.7→v1.6.10 arc flagged ``effective_state``
@@ -119,9 +153,9 @@ flow-sensor work. v1.6.9 fixed the underlying data (proportional
 W-level split was honest); v1.6.15 ships the entity surface so the
 dashboard + Energy dashboard actually render the per-charger split.
 
-2244 tests pass on Python 3.12 (2210 v1.6.13 baseline + 14 v1.6.14
-field migration + 20 v1.6.15 flow sensors). Manifest will bump to
-1.6.14 in the consolidation PR (after v1.6.16 FleetEvPower newtype).
+2256 tests pass on Python 3.12 (2210 v1.6.12 baseline + 13 #8 +
+14 v1.6.14 + 20 v1.6.15 + 12 v1.6.16 = 59 new tests in this
+release). Manifest bumped to 1.6.14.
 
 ## [1.6.12] — 2026-05-31
 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -529,6 +529,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         (~9 min) to give late-loading integrations time to register (issue #166).
         """
         energy_in = power.solar_power + power.grid_import_power + power.battery_discharge_power
+        # FLEET-READ: energy balance — needs fleet total EV draw because
+        # home_consumption is computed from the whole-house energy in/out.
         energy_out = power.ev_power + power.grid_export_power + power.battery_charge_power
         raw_balance = energy_in - energy_out
         if raw_balance < -500:
@@ -1320,6 +1322,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                         monthly_peak,
                         ev_is_charging=False,
                         grid_import_w=power.grid_import_power,
+                        # FLEET-READ: load manager peak budget is a
+                        # whole-house concept; fleet EV total is correct.
                         ev_power_w=power.ev_power,
                     )
                 except (HomeAssistantError, ServiceValidationError) as e:
@@ -1761,6 +1765,9 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     pass
 
                 try:
+                    # FLEET-READ: cycle-level kW display for the cost
+                    # tracker — fleet total is the correct unit for the
+                    # whole-system view shown to the user.
                     _ev_kw = (power.ev_power or 0.0) / 1000.0
                     if _ev_kw > _MIN_USEFUL_RATE_KW:
                         _pcfg_t = _dl_pcfg or {}
@@ -1838,6 +1845,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             hour = now_time.hour
             if surplus_data.surplus_total_w > 100:
                 self._today_surplus_hours[hour] = True
+            # FLEET-READ: "is the fleet drawing at all" gate for the
+            # consumption hour-bucket — any charger counts.
             if power.ev_power > 10:
                 self._today_ev_hours[hour] = True
             result["schedule_surplus_hours"] = list(self._today_surplus_hours)
@@ -2163,6 +2172,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Execute the decision (start/stop/adjust charge)
         await scheduler.update(
             current_soc=power.battery_soc,
+            # FLEET-READ: battery scheduler needs whole-house EV draw to
+            # decide whether the night charge is competing with EV load.
             ev_charging_power_w=power.ev_power,
         )
 
@@ -3388,9 +3399,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         if self._ev_device:
             ev_setpoint = getattr(self._ev_device, "_current_setpoint", 0.0)
 
-        # Run taper detection (primary / single charger)
+        # Run taper detection (primary / single charger). Multi-charger
+        # taper is handled per-charger by
+        # ``_update_per_charger_detector_energy`` (v1.6.6 #318); this
+        # call only runs when no per-charger detectors are configured.
+        # FLEET-READ: legacy single-detector path.
         if power.ev_power > 0 or power.ev_connected:
             taper_data = self._ev_taper_detector.update(
+                # FLEET-READ: single-detector input — see comment above.
                 power.ev_power, ev_setpoint, power.ev_connected, now,
             )
         else:
@@ -3398,6 +3414,10 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
 
         # Track energy since last full charge (hardware counter preferred)
         if hasattr(energy, "daily_ev"):
+            # FLEET-READ: ``daily_ev`` is the fleet daily total; matches
+            # the fleet-level ``sensor.sem_daily_ev_energy``. Per-charger
+            # daily energy is on ``charger_<id>_daily_energy`` populated
+            # separately by ``_update_per_charger_detector_energy``.
             ev_increment = power.ev_power * interval_hours / 1000
             # Read hardware total energy counter for drift-free tracking
             hw_total = None
@@ -3431,9 +3451,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             self._ev_taper_detector.reset_session()
 
         # Stall detection → full charge: if car is connected, SEM is sending current,
-        # but power stays 0W for extended period, the car is full (BMS refusing)
+        # but power stays 0W for extended period, the car is full (BMS refusing).
+        # Legacy single-detector stall path; runs only when multi-charger
+        # isn't configured (per-charger stall lives on
+        # ``_ev_stalled_since_per_charger``). Demo of the v1.6.16
+        # ``.as_fleet_total(reason)`` form — the reason rides in the
+        # bytecode rather than a comment line above the read.
         if (power.ev_connected and not power.ev_charging
-                and power.ev_power < 50
+                and power.ev_power.as_fleet_total("legacy single-detector stall path") < 50
                 and not self._ev_taper_detector._full_detected):
             stall_count = getattr(self, '_full_stall_count', 0) + 1
             self._full_stall_count = stall_count

--- a/coordinator/energy_calculator.py
+++ b/coordinator/energy_calculator.py
@@ -173,8 +173,11 @@ class EnergyCalculator:
 
         # EV charging (sunrise-based reset — night charging must stay in one bucket)
         # Category "ev_daily_sun" survives midnight rollover (excluded from cleanup)
+        # FLEET-READ: ``ev_daily_sun`` is the fleet daily total — matches
+        # ``sensor.sem_daily_ev_energy``. Per-charger daily energy lives
+        # on ``charger_<id>_daily_energy`` populated separately.
         if power.ev_power >= MIN_POWER_THRESHOLD:
-            ev_increment = (power.ev_power * interval_hours) / 1000
+            ev_increment = (power.ev_power * interval_hours) / 1000  # FLEET-READ: same fleet integration as the gate above.
             self._accumulate("ev_daily_sun", ev_day, month_key, year_key, ev_increment)
 
         energy.daily_ev = self._get_daily("ev_daily_sun", ev_day)
@@ -219,6 +222,8 @@ class EnergyCalculator:
         # Only tracks savings from solar — battery discharge savings are in cost_batt_savings.
         # Subtracting discharge_incr prevents double-counting: battery discharge is not solar.
         home_incr = (power.home_consumption_power * interval_hours) / 1000 if power.home_consumption_power >= MIN_POWER_THRESHOLD else 0.0
+        # FLEET-READ: same fleet-energy integration as ``ev_daily_sun``
+        # above, applied here to the cost-savings accumulator.
         ev_incr = (power.ev_power * interval_hours) / 1000 if power.ev_power >= MIN_POWER_THRESHOLD else 0.0
         import_incr = (power.grid_import_power * interval_hours) / 1000 if power.grid_import_power >= MIN_POWER_THRESHOLD else 0.0
         discharge_incr = (power.battery_discharge_power * interval_hours) / 1000 if power.battery_discharge_power >= MIN_POWER_THRESHOLD else 0.0

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -182,6 +182,9 @@ class FlowCalculator:
 
         # Get destination powers
         home = power.home_consumption_power
+        # FLEET-READ: fleet EV demand is the input to proportional
+        # attribution; per-charger split happens below via
+        # ``power.ev_power_per_charger``.
         ev = power.ev_power
         battery_charge = power.battery_charge_power
         grid_export = power.grid_export_power

--- a/coordinator/health_check.py
+++ b/coordinator/health_check.py
@@ -19,6 +19,8 @@ class HealthCheck:
         supply = power.solar_power + power.grid_import_power + power.battery_discharge_power
         demand = (
             power.home_consumption_power
+            # FLEET-READ: whole-house energy balance check — needs the
+            # fleet EV total to validate supply ≈ demand.
             + power.ev_power
             + power.grid_export_power
             + power.battery_charge_power
@@ -37,6 +39,8 @@ class HealthCheck:
             ("grid_export", power.grid_export_power),
             ("battery_charge", power.battery_charge_power),
             ("battery_discharge", power.battery_discharge_power),
+            # FLEET-READ: health check iterates fleet-level fields; the
+            # non-negative invariant applies to the whole-house EV total.
             ("ev_power", power.ev_power),
             ("solar_power", power.solar_power),
         ]

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .types import PowerReadings
+from .types import FleetEvPower, PowerReadings
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -446,11 +446,13 @@ class SensorReader:
                         # Per-charger draw in watts, exposed for
                         # ``flow_calculator`` per-charger split.
                         readings.ev_power_per_charger[cid] = cw
-            readings.ev_power = total_ev
+            readings.ev_power = FleetEvPower(total_ev)
         elif ed.ev_power:
-            readings.ev_power = self._read_sensor(ed.ev_power, "ev")
+            readings.ev_power = FleetEvPower(self._read_sensor(ed.ev_power, "ev"))
         elif self.config.ev_power_sensor:
-            readings.ev_power = self._read_sensor(self.config.ev_power_sensor, "ev")
+            readings.ev_power = FleetEvPower(
+                self._read_sensor(self.config.ev_power_sensor, "ev")
+            )
 
         # EV connection status — per-charger OR'd for global (#193)
         ev_chargers = self._raw_config.get("ev_chargers", [])
@@ -693,10 +695,10 @@ class SensorReader:
                 cps = charger_cfg.get("ev_charging_power_sensor")
                 if cps:
                     total_ev += self._read_sensor(cps, "ev")
-            readings.ev_power = total_ev
+            readings.ev_power = FleetEvPower(total_ev)
         elif self.config.ev_power_sensor:
-            readings.ev_power = self._read_sensor(
-                self.config.ev_power_sensor, "ev"
+            readings.ev_power = FleetEvPower(
+                self._read_sensor(self.config.ev_power_sensor, "ev")
             )
 
         # EV connection status — per-charger OR'd for global (#193)

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -26,13 +26,80 @@ class EnergySource(Enum):
     MIXED = "mixed"
 
 
+class FleetEvPower(float):
+    """Newtype for the fleet-aggregated EV power sum (v1.6.16).
+
+    Background. In multi-charger setups (``len(ev_chargers) > 1``)
+    ``PowerReadings.ev_power`` is the SUM across every charger's draw,
+    populated by ``sensor_reader`` from per-charger power sensors. Code
+    paths that loop per-charger and read the fleet sum directly produce
+    the recurring bug class that filled the v1.6.4 → v1.6.6 hotfix
+    sequence (#284, #289, #315, #318).
+
+    Goal. Make "I deliberately want the fleet sum" structurally
+    explicit — every read carries a written reason at the call site.
+
+    Mechanism. ``FleetEvPower`` subclasses ``float`` so arithmetic and
+    comparisons still work (no migration cost for the ~15 legitimate
+    fleet reads across ``coordinator/``). Layered on top:
+
+    1. The ``.as_fleet_total(reason: str)`` accessor returns the
+       underlying watts and documents intent in the code (not a
+       comment). The ``reason`` arg has no runtime effect but appears
+       in code review and ``git blame`` — the structural improvement
+       over the v1.6.8 ``# FLEET-READ:`` comment.
+
+    2. The expanded AST lint
+       (``tests/test_fleet_ev_power_reads_global.py``) treats
+       ``power.ev_power.as_fleet_total(...)`` as equivalent to the
+       comment annotation. Reads that are neither acknowledged form
+       fail CI across every ``coordinator/`` module — not just
+       ``ev_control.py`` like the v1.6.8 lint.
+
+    Mostly the v1.6.8 ``# FLEET-READ:`` comment idiom continues to
+    work — there is no flag-day. New code is encouraged to use the
+    method form because it appears in the bytecode (mypy, IDE hover,
+    even ``ast.dump``).
+    """
+
+    __slots__ = ()
+
+    def as_fleet_total(self, reason: str) -> float:
+        """Return the underlying watts; ``reason`` documents intent.
+
+        Args:
+            reason: short string explaining WHY this call site wants
+                the fleet sum rather than a per-charger draw. Required
+                positional argument — by convention the lint at
+                ``tests/test_fleet_ev_power_reads_global.py`` accepts
+                any non-empty string. Keep it concrete: "energy
+                balance computation" beats "fleet read".
+
+        Returns:
+            The wrapped watts as a plain ``float``. Identical to
+            ``float(self)``; the layer exists for documentation, not
+            for unit conversion.
+        """
+        return float(self)
+
+    def __repr__(self) -> str:  # noqa: D401
+        return f"FleetEvPower({float(self):.1f})"
+
+
 @dataclass
 class PowerReadings:
     """Current power readings from sensors."""
     solar_power: float = 0.0
     grid_power: float = 0.0  # Negative = import, Positive = export
     battery_power: float = 0.0  # Positive = charge, Negative = discharge
-    ev_power: float = 0.0
+    # v1.6.16: typed as ``FleetEvPower`` — a ``float`` subclass marking
+    # the fleet-aggregated EV power sum. Reads that want the sum
+    # acknowledge it via ``.as_fleet_total(reason)`` (preferred) or
+    # ``# FLEET-READ:`` comment (legacy v1.6.8 idiom). The AST lint at
+    # ``tests/test_fleet_ev_power_reads_global.py`` covers every
+    # ``coordinator/`` module — not just ``ev_control.py``. See
+    # ``docs/MULTI_CHARGER.md`` for the full invariant.
+    ev_power: "FleetEvPower" = field(default_factory=lambda: FleetEvPower(0.0))
     home_consumption_power: float = 0.0
 
     # Per-charger EV power (v1.6.9). Populated by ``sensor_reader`` for

--- a/docs/MULTI_CHARGER.md
+++ b/docs/MULTI_CHARGER.md
@@ -143,7 +143,7 @@ the structural invariant.
 | **v1.6.10** | Code-quality cleanup (#308 / #309 / #310) | ✓ shipped |
 | **v1.6.11** | Recent-logs in diagnostics + doc polish | ✓ shipped |
 | **v1.6.12** | Multi-charger off + solar_only scenario test + harness `per_charger_effective_states` / `per_charger_flow_max` assertions | ✓ shipped |
-| **v1.6.14 (in progress, bundled)** | (a) ✓ Surplus tracker jump-from-0 fix (#8); (b) ✓ `effective_state` + `this_power_w` migrated onto `PerChargerContext` fields; (c) ✓ per-charger flow sensors (`sensor.sem_charger_<id>_flow_*_to_ev_*` gated on `len(ev_chargers) > 1`); (d) ◻ `FleetEvPower` newtype. Shipping as one release rather than four per-PR HACS bumps. | ◐ in develop |
+| **v1.6.14 (bundled closeout)** | (a) ✓ Surplus tracker jump-from-0 fix (#8); (b) ✓ `effective_state` + `this_power_w` migrated onto `PerChargerContext` fields; (c) ✓ per-charger flow sensors (`sensor.sem_charger_<id>_flow_*_to_ev_*` gated on `len(ev_chargers) > 1`); (d) ✓ `FleetEvPower` newtype + AST lint expanded to every `coordinator/` module. Shipped as one release rather than four per-PR HACS bumps. | ✓ shipped |
 
 ### What landed under the abstraction
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.12"
+  "version": "1.6.14"
 }

--- a/tests/test_fleet_ev_power_reads_global.py
+++ b/tests/test_fleet_ev_power_reads_global.py
@@ -1,0 +1,322 @@
+"""Global AST lint: every ``power.ev_power`` read in ``coordinator/``
+must acknowledge fleet semantics (v1.6.16).
+
+Expands the v1.6.8 ``test_ev_control_fleet_reads.py`` (which only
+covered ``ev_control.py``) to every module under ``coordinator/``.
+The recurring bug class through v1.6.0 → v1.6.6 was per-charger code
+paths accidentally reading the fleet-summed ``power.ev_power`` —
+those fixes landed first in ``ev_control.py`` (where it bit hardest)
+and the rest of ``coordinator/`` got the comment annotations
+retroactively in v1.6.16.
+
+Two equivalent acknowledgement forms — pick the cleaner per site:
+
+1. **Comment annotation** (v1.6.8 form): ``# FLEET-READ: <reason>``
+   on the same line as the read or the immediately preceding line.
+
+2. **Method call** (v1.6.16 form): rewrite the read as
+   ``power.ev_power.as_fleet_total("<reason>")``. ``FleetEvPower``
+   is a ``float`` subclass so arithmetic still works; the call site
+   carries the reason in the bytecode.
+
+The v1.6.16 form is preferred for NEW code because the reason
+appears in ``git blame``, mypy output, IDE hover and AST tools —
+not just in the line above. Existing comment annotations stay
+valid; there is no flag-day.
+
+The ``_this_charger_power`` helper body remains exempt — it's the
+sanctioned fallback that DOES read the fleet for single-charger
+setups.
+
+See ``docs/MULTI_CHARGER.md`` for the full invariant.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+
+COORDINATOR_DIR = (
+    Path(__file__).resolve().parent.parent / "coordinator"
+)
+
+# Functions whose body is allowed to read ``power.ev_power`` directly.
+EXEMPT_FUNCTIONS = frozenset({"_this_charger_power"})
+
+# Files exempt entirely. Currently:
+#  - ``types.py`` defines ``PowerReadings.ev_power`` itself + the
+#    ``to_dict`` emitter, both legitimate self-references.
+#  - ``per_charger_context.py`` only mentions ``power.ev_power`` in
+#    docstrings (no code reads).
+# Anything else added here needs a maintainer review.
+EXEMPT_FILES = frozenset({"types.py", "per_charger_context.py"})
+
+ANNOTATION = "# FLEET-READ:"
+METHOD_NAME = "as_fleet_total"
+
+
+def _find_function_for_line(tree: ast.Module, line: int) -> str | None:
+    """Innermost function definition enclosing ``line`` (or ``None``)."""
+    best: tuple[int, str] | None = None
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            start = node.lineno
+            end = getattr(node, "end_lineno", node.lineno)
+            if start <= line <= end:
+                if best is None or start > best[0]:
+                    best = (start, node.name)
+    return best[1] if best else None
+
+
+def _is_method_call_form(node: ast.AST) -> bool:
+    """True iff ``node`` (a ``power.ev_power`` Attribute) is the receiver
+    of a ``.as_fleet_total(...)`` call.
+
+    Matches ``power.ev_power.as_fleet_total("reason")``. The AST shape
+    is:
+
+        Call(
+          func=Attribute(
+            value=Attribute(value=Name("power"), attr="ev_power"),  ← node
+            attr="as_fleet_total"),
+          args=[Constant("reason")])
+
+    We get the ``Call.func.value`` to check whether the read node is
+    the inner ``Attribute``. ``ast.walk`` doesn't give us parents, so
+    we re-walk the surrounding source — instead we accept any chained
+    attribute access where the OUTER attribute name is ``as_fleet_total``.
+
+    Because ``ast`` doesn't carry parent pointers, this check is done
+    at the AST level by spotting whether the read is wrapped by a
+    parent ``Attribute(attr="as_fleet_total")``. The walker in
+    ``_find_ev_power_reads`` does this by checking each visited node's
+    enclosing context — see that function.
+    """
+    return False  # not used directly; see _find_ev_power_reads
+
+
+def _find_ev_power_reads(tree: ast.Module) -> list[tuple[int, str, bool]]:
+    """Return ``(line, enclosing_function, is_method_form)`` for every
+    ``power.ev_power`` read in the file.
+
+    ``is_method_form`` is True when the read is the inner attribute of
+    a ``power.ev_power.as_fleet_total(...)`` chain — i.e. the v1.6.16
+    deliberate-unwrap form. We compute it by attaching parent pointers
+    to every node before walking (``ast`` doesn't ship parent links).
+    """
+    # Attach parent pointers — the standard workaround for ast's
+    # parentless tree. Cheap (one walk) and self-contained to this test.
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            child.parent = parent  # type: ignore[attr-defined]
+
+    hits: list[tuple[int, str, bool]] = []
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Attribute)
+            and node.attr == "ev_power"
+            and isinstance(node.value, ast.Name)
+            and node.value.id == "power"
+        ):
+            # Method-form check: is the parent an Attribute whose attr
+            # is ``as_fleet_total``? If yes, this read is the chained
+            # ``power.ev_power.as_fleet_total(...)`` and counts as
+            # explicitly acknowledged.
+            parent = getattr(node, "parent", None)
+            is_method_form = (
+                isinstance(parent, ast.Attribute)
+                and parent.attr == METHOD_NAME
+            )
+            func = _find_function_for_line(tree, node.lineno) or "<module>"
+            hits.append((node.lineno, func, is_method_form))
+    return hits
+
+
+def _is_annotated(lines: list[str], line_no: int, lookback: int = 5) -> bool:
+    """``# FLEET-READ:`` on the read's line or any of the ``lookback``
+    lines above, walking back ONLY through ``#``-comment lines.
+
+    The walk-back stops on the first non-comment, non-blank line — so a
+    FLEET-READ tag at the head of a multi-line comment block above the
+    read counts, but a tag inside an unrelated function above doesn't
+    leak through.
+
+    ``lookback`` defaults to 3 — enough for "tag + two explanation
+    lines" without losing locality.
+    """
+    idx = line_no - 1
+    if 0 <= idx < len(lines) and ANNOTATION in lines[idx]:
+        return True
+    # Walk back through ``#``-comment lines only (or whitespace-only
+    # lines). A code line breaks the chain.
+    for back in range(1, lookback + 1):
+        j = idx - back
+        if j < 0:
+            break
+        stripped = lines[j].strip()
+        if not stripped:
+            continue  # blank line — keep looking
+        if not stripped.startswith("#"):
+            return False  # ran out of comment block
+        if ANNOTATION in lines[j]:
+            return True
+    return False
+
+
+def _coordinator_files() -> list[Path]:
+    return sorted(
+        p for p in COORDINATOR_DIR.glob("*.py")
+        if p.is_file() and p.name not in EXEMPT_FILES
+    )
+
+
+class TestGlobalFleetEvPowerLint:
+    """Every ``power.ev_power`` read in ``coordinator/`` outside the
+    exempt files must be acknowledged via comment OR method form."""
+
+    def test_every_read_is_acknowledged(self):
+        offenders: list[str] = []
+        for path in _coordinator_files():
+            source = path.read_text()
+            try:
+                tree = ast.parse(source)
+            except SyntaxError as e:  # pragma: no cover — guard CI sanity
+                pytest.fail(f"Syntax error parsing {path.name}: {e}")
+            lines = source.splitlines()
+            for line_no, func, is_method_form in _find_ev_power_reads(tree):
+                if func in EXEMPT_FUNCTIONS:
+                    continue
+                if is_method_form:
+                    continue  # ``.as_fleet_total(...)`` form is acknowledged
+                if _is_annotated(lines, line_no):
+                    continue  # ``# FLEET-READ:`` form is acknowledged
+                offenders.append(
+                    f"  {path.name}:L{line_no} in {func}()"
+                )
+        assert not offenders, (
+            "Found unannotated ``power.ev_power`` reads in coordinator/"
+            " modules. In multi-charger setups ``power.ev_power`` is the"
+            " GLOBAL SUM across all chargers — reading it directly inside"
+            " a per-charger code path is the bug class that caused #284,"
+            " #289, #315 and #318.\n\nOffenders:\n"
+            + "\n".join(offenders)
+            + "\n\nFix: either replace with ``this_power_w`` cached via "
+            "``self._this_charger_power(ev, power)`` (per-charger code"
+            " paths), or acknowledge the fleet semantics via one of:\n"
+            "  (a) ``# FLEET-READ: <reason>`` on the same line or above\n"
+            "  (b) ``power.ev_power.as_fleet_total(\"<reason>\")`` "
+            "(preferred for new code — reason in bytecode)\n\n"
+            "See docs/MULTI_CHARGER.md for the full invariant."
+        )
+
+    def test_exempt_files_are_minimal(self):
+        """Exemption list intentionally tiny — anything added needs
+        a maintainer review."""
+        assert EXEMPT_FILES == frozenset({"types.py", "per_charger_context.py"})
+
+    def test_exempt_helper_is_minimal(self):
+        assert EXEMPT_FUNCTIONS == frozenset({"_this_charger_power"})
+
+    def test_method_form_detected_in_synthetic_code(self):
+        """Sanity: if a synthetic snippet uses ``power.ev_power
+        .as_fleet_total("...")``, the walker tags it as method form."""
+        synthetic = (
+            "def f(power):\n"
+            "    return power.ev_power.as_fleet_total(\"sanity\")\n"
+        )
+        tree = ast.parse(synthetic)
+        hits = _find_ev_power_reads(tree)
+        assert len(hits) == 1
+        assert hits[0][2] is True  # is_method_form
+
+    def test_bare_read_flagged_in_synthetic_code(self):
+        synthetic = (
+            "def f(power):\n"
+            "    if power.ev_power > 100:\n"
+            "        return True\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert len(hits) == 1
+        assert hits[0][2] is False
+        assert not _is_annotated(lines, hits[0][0])
+
+    def test_comment_form_still_accepted(self):
+        """v1.6.8 idiom: ``# FLEET-READ: reason`` on the previous
+        line. Still valid in v1.6.16."""
+        synthetic = (
+            "def f(power):\n"
+            "    # FLEET-READ: sanity check\n"
+            "    return power.ev_power > 100\n"
+        )
+        tree = ast.parse(synthetic)
+        lines = synthetic.splitlines()
+        hits = _find_ev_power_reads(tree)
+        assert len(hits) == 1
+        assert _is_annotated(lines, hits[0][0])
+
+
+class TestFleetEvPowerNewtype:
+    """``FleetEvPower`` itself: float subclass with ``.as_fleet_total``."""
+
+    def test_is_float_subclass(self):
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower,
+        )
+        assert issubclass(FleetEvPower, float)
+
+    def test_arithmetic_works(self):
+        """Arithmetic with a regular float must still work — no
+        migration cost for the ~15 legitimate fleet reads across
+        coordinator/."""
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower,
+        )
+        p = FleetEvPower(4140.0)
+        assert p > 100  # float comparison
+        assert p / 1000 == 4.140  # arithmetic
+        assert p + 100 == 4240.0
+        assert float(p) == 4140.0
+
+    def test_as_fleet_total_returns_plain_float(self):
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower,
+        )
+        p = FleetEvPower(4140.0)
+        out = p.as_fleet_total("test")
+        assert out == 4140.0
+        assert type(out) is float
+
+    def test_as_fleet_total_reason_is_documentation_only(self):
+        """The reason argument has no runtime effect — it's there for
+        readers, ``git blame``, and (future) static analyzers. We
+        accept ANY string."""
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower,
+        )
+        p = FleetEvPower(100.0)
+        # All accepted, no validation.
+        assert p.as_fleet_total("a reason") == 100.0
+        assert p.as_fleet_total("") == 100.0
+        assert p.as_fleet_total("123") == 100.0
+
+    def test_default_powerreadings_ev_power_is_fleet_type(self):
+        """``PowerReadings.ev_power`` default is a ``FleetEvPower``,
+        not a plain float — pins the dataclass field type."""
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower, PowerReadings,
+        )
+        r = PowerReadings()
+        assert isinstance(r.ev_power, FleetEvPower)
+        # Defaults to 0.0.
+        assert r.ev_power == 0.0
+
+    def test_repr_includes_class_name(self):
+        from custom_components.solar_energy_management.coordinator.types import (
+            FleetEvPower,
+        )
+        assert repr(FleetEvPower(4140.0)) == "FleetEvPower(4140.0)"


### PR DESCRIPTION
**Final piece of the bundled v1.6.14 release.** ``FleetEvPower`` newtype + global AST lint, plus the manifest bump + CHANGELOG section rename that ships v1.6.14.

## Summary

### v1.6.16 code (this PR's new work)

- ``FleetEvPower(float)`` — newtype on ``PowerReadings.ev_power`` with ``.as_fleet_total(reason: str)`` accessor. ``float`` subclass so arithmetic and comparisons still work (no migration cost for the ~15 legitimate fleet reads).
- ``coordinator/sensor_reader.py``: 5 ev_power assignments wrapped with ``FleetEvPower(...)``.
- ``tests/test_fleet_ev_power_reads_global.py`` — AST lint expanded to every ``coordinator/*.py`` (was ``ev_control.py`` only). Lookback of 5 comment lines for multi-line annotations.
- ``power.ev_power.as_fleet_total(\"<reason>\")`` recognised as the v1.6.16 deliberate-unwrap form; reason rides in bytecode instead of comment.
- ~15 existing fleet reads got explicit ``# FLEET-READ:`` reasons; one (``coordinator.py:3459`` stall detection) migrated to the new method form as the in-tree demo.

### Release wiring

- ``manifest.json``: 1.6.12 → 1.6.14
- ``CHANGELOG.md``: ``[Unreleased] — v1.6.14 candidate`` → ``[1.6.14] — 2026-05-31``
- ``docs/MULTI_CHARGER.md`` roadmap: (a-d) all ✓, release marked ✓ shipped

## What ships in v1.6.14 (bundled closeout)

| Theme | PR | Status |
|---|---|---|
| (a) Surplus tracker jump-from-0 fix (#8) | #329 | merged |
| (b) PerChargerContext field migration | #330 | merged |
| (c) Per-charger flow sensors | #331 | merged |
| (d) FleetEvPower newtype + global lint | **this PR** | open |

## Tests (12 new in this PR, 2256 total)

- ``TestGlobalFleetEvPowerLint`` (6): every read across coordinator/ acknowledged, exempt-list minimality, synthetic-code sanity (method form, bare read, comment form).
- ``TestFleetEvPowerNewtype`` (6): float subclass, arithmetic works, ``.as_fleet_total`` returns plain float, reason arg is documentation-only, default PowerReadings.ev_power IS the newtype, repr.

Full suite 2256 green on Python 3.12.

## Test plan

- [x] 12 new + 2244 baseline → 2256 green on Python 3.12
- [x] Manifest bumped to 1.6.14
- [x] CHANGELOG section renamed (release-ready)
- [x] ``docs/MULTI_CHARGER.md`` roadmap closed
- [ ] CI green (5 checks)
- [ ] HA-TEST clean install + smoke test
- [ ] PR to main → tag v1.6.14 → GitHub release → HACS
- [ ] HA-PROD deploy + 24 h soak window