### PR TITLE
fix(v1.6.14): polish — per-charger notif NoneType + flow sensor zero-fill

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2264,10 +2264,17 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             for cid, intel in per_charger_intel.items():
                 charger_name = self._ev_devices[cid].name if cid in self._ev_devices else cid
                 charger_connected = self._last_ev_connected_per_charger.get(cid, False)
-                mins_to_full = intel.get("minutes_to_full", 0)
-                est_soc = intel.get("estimated_soc", 0)
-                charge_needed = intel.get("charge_needed", False)
-                nights = intel.get("nights_until_charge", 0)
+                # ``or 0`` covers both missing key AND None value — the
+                # latter arises for chargers whose per-charger intel
+                # builder hasn't populated the field yet (e.g. mock
+                # chargers without a real upstream sensor). Without the
+                # coercion the subsequent ``> 0`` comparison raised
+                # ``TypeError`` every cycle (DEBUG log spam observed on
+                # HA-TEST 2026-05-31 after the v1.6.14 deploy).
+                mins_to_full = intel.get("minutes_to_full") or 0
+                est_soc = intel.get("estimated_soc") or 0
+                charge_needed = intel.get("charge_needed") or False
+                nights = intel.get("nights_until_charge") or 0
 
                 # 1. Nearly full: taper detector shows < 5 minutes remaining
                 if mins_to_full > 0 and mins_to_full < 5 and power.ev_charging:

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -236,12 +236,14 @@ class FlowCalculator:
         # construction (sum of shares == 1.0 modulo float rounding;
         # final ``round(..., 1)`` may leak ≤ 0.1 W which is well below
         # any user-visible threshold).
-        if power.ev_power_per_charger and ev > 0:
+        if power.ev_power_per_charger:
             for cid, charger_ev_w in power.ev_power_per_charger.items():
-                if charger_ev_w <= 0:
-                    # An idle charger gets a zero-filled ChargerFlows so
-                    # downstream readers can safely dict-lookup any
-                    # configured charger id without KeyError.
+                if charger_ev_w <= 0 or ev <= 0:
+                    # An idle charger (or the whole fleet idle) gets a
+                    # zero-filled ChargerFlows so the per-charger
+                    # sensors stay AVAILABLE at 0 W instead of going
+                    # ``unavailable`` whenever no charger is drawing
+                    # (HA-TEST 2026-05-31 noise after first deploy).
                     flows.per_charger[cid] = ChargerFlows()
                     continue
                 share = charger_ev_w / ev

--- a/tests/test_per_charger_flows_319.py
+++ b/tests/test_per_charger_flows_319.py
@@ -199,14 +199,25 @@ class TestRegressionForIssue316:
 
 class TestNoEvDraw:
     """Edge case: ``ev_power_per_charger`` populated but total EV draw is 0.
-    The guard ``and ev > 0`` skips the per-charger loop entirely (avoids
-    divide-by-zero); ``flows.per_charger`` stays empty."""
+    Pre-v1.6.14 behaviour skipped the loop entirely so ``per_charger`` stayed
+    ``{}`` — this caused the per-charger flow SENSORS (added in v1.6.15)
+    to go ``unavailable`` whenever no charger was drawing.
 
-    def test_zero_ev_total_skips_split(self):
+    Updated for v1.6.14: zero-fill each configured charger so the sensors
+    stay AVAILABLE at 0 W. Avoids divide-by-zero via the ``ev <= 0``
+    early-return in the inner loop."""
+
+    def test_zero_ev_total_zero_fills_each_charger(self):
         fc = FlowCalculator()
         flows = fc.calculate_power_flows(_power(
             solar=2000, grid=2000, battery=0, ev=0, home=2000,
             ev_per_charger={"left": 0.0, "right": 0.0},
         ))
         assert flows.solar_to_ev == 0.0
-        assert flows.per_charger == {}
+        # Both chargers present with zero-filled entries.
+        assert set(flows.per_charger.keys()) == {"left", "right"}
+        for cid in ("left", "right"):
+            cf = flows.per_charger[cid]
+            assert cf.solar_to_ev == 0.0
+            assert cf.grid_to_ev == 0.0
+            assert cf.battery_to_ev == 0.0


### PR DESCRIPTION
Two HA-TEST 2026-05-31 soak findings post-v1.6.14 deploy. Neither is user-facing critical — both are observable noise from the multi-charger setup with a mock partner.

## 1. NoneType comparison spam (DEBUG every cycle)

``coordinator.py:_send_notifications`` per-charger block unpacked:
```python
mins_to_full = intel.get(\"minutes_to_full\", 0)
est_soc      = intel.get(\"estimated_soc\", 0)
```
``.get(k, default)`` returns the default only when the KEY is missing — when the VALUE is ``None`` (mock charger without a real upstream sensor) ``.get()`` returns ``None``, and ``est_soc > 0`` raises ``TypeError`` every cycle.

Fix: ``intel.get(k) or 0`` covers both missing-key AND None-value cases.

## 2. Per-charger flow sensors stuck ``unavailable`` when fleet idle

``flow_calculator.calculate_power_flows`` had ``if power.ev_power_per_charger and ev > 0`` gating the per-charger split. Fleet idle → ``flows.per_charger == {}`` → v1.6.15 sensors had no key → went unavailable. Confusing UX.

Fix: zero-fill the per_charger map whenever ``ev_power_per_charger`` is configured (multi-charger). Divide-by-zero protected by the existing ``ev <= 0`` early-return on the inner loop. Per-charger sensors stay AVAILABLE at 0 W.

## Test update

``test_zero_ev_total_skips_split`` was pinning the pre-v1.6.14 \"per_charger stays empty\" behaviour — it would have caught my change as a regression. Updated + renamed to ``test_zero_ev_total_zero_fills_each_charger``; the new assertion matches the v1.6.14 intent (sensors stay available).

## Test plan

- [x] 2258 / 2257 (-1 broken test) + 1 (updated) → 2258 pass on Python 3.12
- [ ] CI green
- [ ] Redeploy to HA-TEST, verify (a) no more DEBUG NoneType spam, (b) per-charger flow sensors stay available at 0 W