### PR TITLE
feat(v1.6.14 polish): one-shot upgrade notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -153,9 +153,45 @@ flow-sensor work. v1.6.9 fixed the underlying data (proportional
 W-level split was honest); v1.6.15 ships the entity surface so the
 dashboard + Energy dashboard actually render the per-charger split.
 
-2256 tests pass on Python 3.12 (2210 v1.6.12 baseline + 13 #8 +
-14 v1.6.14 + 20 v1.6.15 + 12 v1.6.16 = 59 new tests in this
-release). Manifest bumped to 1.6.14.
+### Polish (HA-TEST soak findings folded into v1.6.14)
+
+- **PR #333** — initialise ``SEMCoordinator._current_charger_budget``.
+  Missed in the v1.6.7 PerChargerContext refactor; ``__enter__``
+  snapshotted the attribute but ``__init__`` never set it, so every
+  multi-charger setup blew up its first cycle with
+  ``AttributeError``. Single-charger setups (HA-PROD) never tripped
+  it; HA-TEST today was the first multi-charger clean install since
+  v1.6.7. New regression test ``test_coordinator_swap_attrs_initialized.py``
+  AST-walks ``SEMCoordinator.__init__`` to assert every attribute
+  ``PerChargerContext.__enter__`` snapshots is initialised.
+
+- **PR #334** — per-charger notification ``NoneType`` coerce + flow
+  sensor zero-fill. ``intel.get(k, default)`` returns the default
+  only when the KEY is missing — mock chargers without upstream
+  data have the key set to ``None``, so ``est_soc > 0`` raised
+  ``TypeError`` every cycle (DEBUG noise). Fix: ``intel.get(k) or 0``.
+  Plus: ``flow_calculator`` now zero-fills per-charger flows when
+  the fleet is idle so the v1.6.15 flow sensors stay AVAILABLE at
+  0 W instead of going ``unavailable`` whenever no charger draws.
+
+- **PR #335** — upgrade-notification helper. After a HACS update +
+  HA restart, the browser's loaded frontend bootstrap still
+  references the OLD ``sem-localize.js`` URL until hard-refreshed
+  — soft reload serves the cached bootstrap → loads stale
+  translations → raw keys like ``today_plan_title`` /
+  ``plan_strip_idle`` appear in cards. HA-TEST 2026-05-31 confirmed.
+  New ``_maybe_emit_upgrade_notification`` helper detects a SEM
+  version change at setup (via a per-entry
+  ``hass.helpers.storage.Store``) and fires a one-shot
+  ``persistent_notification`` instructing users to hard-refresh
+  (Ctrl+Shift+R / Cmd+Shift+R). First install is silent. Failure
+  is non-fatal. 5 new tests pin the contract (first-install,
+  same-version, upgrade, per-version notification-id, per-entry
+  storage key).
+
+2263 tests pass on Python 3.12 (2210 v1.6.12 baseline + 13 #8 +
+14 v1.6.14 + 20 v1.6.15 + 12 v1.6.16 + 2 v1.6.14-hotfix +
+5 v1.6.14-polish = 66 new tests in this release). Manifest at 1.6.14.
 
 ## [1.6.12] — 2026-05-31
 

--- a/__init__.py
+++ b/__init__.py
@@ -64,6 +64,90 @@ def _content_hash_cache_bust(card_root: str, base_url: str, version: str) -> str
         return version
 
 
+_VERSION_STORE_VERSION = 1
+_VERSION_STORE_KEY_PREFIX = "sem_seen_version_"
+
+
+async def _maybe_emit_upgrade_notification(hass, entry) -> None:
+    """Fire a one-shot persistent notification when SEM has upgraded.
+
+    Compares the integration's current ``manifest.json`` version to a
+    locally-stored "last seen" version from ``hass.helpers.storage.Store``
+    (per config entry). On version change — and only on change — emits
+    a persistent notification telling the user to hard-refresh the
+    browser. First install is silent (stored=None → record current,
+    skip notify) so the user doesn't see an upgrade banner on day one.
+
+    The notification message names the specific cache-bust failure
+    mode (raw translation keys like ``today_plan_title`` showing in
+    the dashboard) so the user can correlate what they see with the
+    advice to hard-refresh.
+
+    Failure of any sub-step (Store read/write, ``async_get_integration``,
+    notification service call) is non-fatal — the caller wraps this in
+    a ``try/except`` because a transient frontend issue should never
+    block coordinator setup. We log at DEBUG so a healthy install
+    stays quiet.
+    """
+    from homeassistant.helpers.storage import Store
+    from homeassistant.loader import async_get_integration
+
+    integration = await async_get_integration(hass, DOMAIN)
+    current_version = str(integration.version or "unknown")
+
+    store = Store(
+        hass,
+        _VERSION_STORE_VERSION,
+        f"{_VERSION_STORE_KEY_PREFIX}{entry.entry_id}",
+    )
+    stored = await store.async_load() or {}
+    previous_version = stored.get("version")
+
+    if previous_version == current_version:
+        return  # No change.
+
+    # Record the new version regardless of whether we notify, so the
+    # next setup compares against today's version.
+    await store.async_save({"version": current_version})
+
+    if not previous_version:
+        # First install — silent record.
+        return
+
+    # Upgrade path — fire the one-shot notification.
+    await hass.services.async_call(
+        "persistent_notification",
+        "create",
+        {
+            "title": f"SEM updated to v{current_version}",
+            "message": (
+                f"Solar Energy Management was upgraded from "
+                f"v{previous_version} to v{current_version}.\n\n"
+                "**Please hard-refresh your browser** "
+                "(Ctrl+Shift+R on Windows/Linux, Cmd+Shift+R on Mac, "
+                "or Shift+reload on the HA companion app) so the "
+                "updated dashboard cards and translations load.\n\n"
+                "Without a hard refresh you may see raw translation "
+                "keys (e.g. `today_plan_title`, `charge_mode_off`) "
+                "in some cards — that's HA's frontend bootstrap "
+                "loading from cache and not picking up the new "
+                "asset URLs.\n\n"
+                "[CHANGELOG]"
+                "(https://github.com/traktore-org/sem-community/"
+                "blob/main/CHANGELOG.md)"
+            ),
+            "notification_id": (
+                f"sem_upgrade_{current_version.replace('.', '_')}"
+            ),
+        },
+        blocking=False,
+    )
+    _LOGGER.info(
+        "SEM upgraded from v%s to v%s — emitted hard-refresh notification.",
+        previous_version, current_version,
+    )
+
+
 class _SEMYAMLModeSkip(Exception):
     """Sentinel: bail out of the Lovelace resource registration block
     when the user is running YAML-mode Lovelace (#283). YAML-mode
@@ -609,6 +693,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     entry.runtime_data = coordinator
     # Also store in hass.data for backward compatibility with platform setup
     hass.data[DOMAIN][entry.entry_id] = coordinator
+
+    # Version-change detection (v1.6.14): on first setup after an upgrade
+    # — HACS pulled new code, HA restarted with it — fire a one-shot
+    # persistent notification telling the user to hard-refresh.
+    # Background. ``add_extra_js_url`` URLs include a content-hash
+    # cache-bust (``?v={version}-{sha1}``) but the browser's loaded
+    # frontend bootstrap still references the OLD URL until the page
+    # is hard-reloaded. Soft reload (F5) hits cached bootstrap → loads
+    # old sem-localize.js → raw translation keys appear in cards.
+    # HA-TEST 2026-05-31 repro: after v1.6.14 deploy the user saw
+    # ``TODAY_PLAN_TITLE`` / ``plan_strip_idle`` etc. until Ctrl+Shift+R.
+    # Failure here is non-fatal — fire-and-forget the version check.
+    try:
+        await _maybe_emit_upgrade_notification(hass, entry)
+    except Exception as err:  # noqa: BLE001 — defensive: never fail setup over this
+        _LOGGER.debug("Version-change notification skipped: %s", err)
 
     # Create repair issue if EV charger is not configured (quality scale: repair-issues)
     if not full_config.get("ev_connected_sensor") and not full_config.get("ev_charging_power_sensor"):

--- a/tests/test_upgrade_notification.py
+++ b/tests/test_upgrade_notification.py
@@ -1,0 +1,177 @@
+"""Tests for the v1.6.14 upgrade-notification helper.
+
+Background. After a SEM HACS update + HA restart, ``add_extra_js_url``
+serves a new content-hashed ``sem-localize.js`` URL — but the user's
+browser still has the OLD frontend bootstrap cached, which references
+the OLD URL. Soft reload (F5) hits the cached bootstrap → loads stale
+``sem-localize.js`` → cards render raw translation keys.
+HA-TEST 2026-05-31 repro: ``TODAY_PLAN_TITLE``, ``plan_strip_idle``
+etc. visible until Ctrl+Shift+R.
+
+The helper at ``__init__._maybe_emit_upgrade_notification`` solves
+this by detecting a version change at setup and firing a one-shot
+``persistent_notification`` with hard-refresh instructions. These
+tests pin the contract:
+
+1. First install (stored=None) → record current, no notification.
+2. Same version → no notification, no Store write.
+3. Upgrade (different version) → notification fired AND Store updated.
+4. Notification ID is per-version (so an upgrade replaces the
+   previous version's notification rather than stacking).
+5. Failure of any sub-step is swallowed by the caller.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management import (
+    _maybe_emit_upgrade_notification,
+)
+
+
+def _make_entry(entry_id="abc123"):
+    e = MagicMock()
+    e.entry_id = entry_id
+    return e
+
+
+def _patches(stored_version, current_version):
+    """Build a (Store-mock, async_get_integration-mock) pair.
+
+    Returns three things the caller patches in: ``store_mock``
+    (the constructed Store instance), ``store_class`` (the factory —
+    asserted with), and ``integration_class``.
+    """
+    store_instance = MagicMock()
+    store_instance.async_load = AsyncMock(
+        return_value=({"version": stored_version} if stored_version else None)
+    )
+    store_instance.async_save = AsyncMock()
+    store_class = MagicMock(return_value=store_instance)
+
+    integration = MagicMock()
+    integration.version = current_version
+    integration_getter = AsyncMock(return_value=integration)
+
+    return store_instance, store_class, integration_getter
+
+
+@pytest.mark.asyncio
+async def test_first_install_silent_record():
+    """No stored version → record current, no notification fired."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    entry = _make_entry()
+
+    store, store_cls, integration_get = _patches(None, "1.6.14")
+    with patch(
+        "custom_components.solar_energy_management.Store"
+        if False else "homeassistant.helpers.storage.Store",
+        store_cls,
+    ), patch(
+        "homeassistant.loader.async_get_integration", integration_get,
+    ):
+        await _maybe_emit_upgrade_notification(hass, entry)
+
+    # Stored.
+    store.async_save.assert_called_once_with({"version": "1.6.14"})
+    # NOT notified.
+    hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_same_version_no_op():
+    """Stored == current → neither save nor notify."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    entry = _make_entry()
+
+    store, store_cls, integration_get = _patches("1.6.14", "1.6.14")
+    with patch(
+        "homeassistant.helpers.storage.Store", store_cls,
+    ), patch(
+        "homeassistant.loader.async_get_integration", integration_get,
+    ):
+        await _maybe_emit_upgrade_notification(hass, entry)
+
+    store.async_save.assert_not_called()
+    hass.services.async_call.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_emits_notification():
+    """Upgrade: stored=1.6.12, current=1.6.14 → save + notify."""
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    entry = _make_entry()
+
+    store, store_cls, integration_get = _patches("1.6.12", "1.6.14")
+    with patch(
+        "homeassistant.helpers.storage.Store", store_cls,
+    ), patch(
+        "homeassistant.loader.async_get_integration", integration_get,
+    ):
+        await _maybe_emit_upgrade_notification(hass, entry)
+
+    # Updated.
+    store.async_save.assert_called_once_with({"version": "1.6.14"})
+    # Notified.
+    hass.services.async_call.assert_called_once()
+    call = hass.services.async_call.call_args
+    assert call.args[0] == "persistent_notification"
+    assert call.args[1] == "create"
+    body = call.args[2]
+    assert "v1.6.14" in body["title"]
+    assert "Ctrl+Shift+R" in body["message"]
+    assert "hard-refresh" in body["message"].lower()
+    assert "today_plan_title" in body["message"]  # specific bug reference
+    # Per-version notification ID so a new upgrade replaces the prior banner.
+    assert body["notification_id"] == "sem_upgrade_1_6_14"
+
+
+@pytest.mark.asyncio
+async def test_notification_id_per_version():
+    """Different upgrades produce different notification_ids — so the
+    HA notifications drawer doesn't suppress the new banner as a
+    duplicate of an older one."""
+    ids: list[str] = []
+    for prev, cur in [("1.6.12", "1.6.13"), ("1.6.13", "1.6.14")]:
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock()
+        entry = _make_entry()
+        store, store_cls, integration_get = _patches(prev, cur)
+        with patch(
+            "homeassistant.helpers.storage.Store", store_cls,
+        ), patch(
+            "homeassistant.loader.async_get_integration", integration_get,
+        ):
+            await _maybe_emit_upgrade_notification(hass, entry)
+        ids.append(hass.services.async_call.call_args.args[2]["notification_id"])
+    assert ids == ["sem_upgrade_1_6_13", "sem_upgrade_1_6_14"]
+    assert len(set(ids)) == 2
+
+
+@pytest.mark.asyncio
+async def test_per_entry_store_key():
+    """Two SEM entries (rare but possible) → independent ``Store``
+    instances keyed by ``entry_id``."""
+    keys: list[str] = []
+    for eid in ("entry_alpha", "entry_beta"):
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock()
+        entry = _make_entry(eid)
+        _, store_cls, integration_get = _patches(None, "1.6.14")
+        with patch(
+            "homeassistant.helpers.storage.Store", store_cls,
+        ), patch(
+            "homeassistant.loader.async_get_integration", integration_get,
+        ):
+            await _maybe_emit_upgrade_notification(hass, entry)
+        # 3rd positional arg is the store key
+        keys.append(store_cls.call_args.args[2])
+    assert keys == [
+        "sem_seen_version_entry_alpha",
+        "sem_seen_version_entry_beta",
+    ]


### PR DESCRIPTION
HA-TEST 2026-05-31 surfaced the last v1.6.14 polish item — after upgrading SEM, the user sees raw translation keys in cards (``today_plan_title``, ``charge_mode_off`` etc) until they Ctrl+Shift+R the browser. The cache-bust ``?v=`` URLs are correct; what's stale is the browser's frontend bootstrap that still references the OLD URL until a hard refresh.

## Summary

- ``_maybe_emit_upgrade_notification(hass, entry)`` in ``__init__.py``: compares the integration's current ``manifest.json`` version to a per-entry ``hass.helpers.storage.Store`` (key ``sem_seen_version_{entry_id}``).
- First install → silent record, no notification.
- Same version → no-op.
- Upgrade → save + fire ``persistent_notification`` with explicit hard-refresh instructions (``Ctrl+Shift+R`` / ``Cmd+Shift+R``) and a specific reference to the raw-key symptom so the user can correlate what they see with what to do.
- Notification id is per-version (``sem_upgrade_1_6_14``) so future upgrades replace rather than stack with old banners.
- Called from ``async_setup_entry``; failure of any sub-step is non-fatal (frontend hiccup shouldn't block coordinator setup).

## Tests (5 new, 2263 total)

``tests/test_upgrade_notification.py``:
- first-install silent record
- same-version no-op
- upgrade fires notification w/ expected title + message + symptom reference
- notification ids differ per upgrade
- per-entry storage keys independent

Full suite 2263 green on Python 3.12.

## Docs

CHANGELOG v1.6.14 section: appended a \"Polish\" subsection covering the three soak-driven follow-ups (#333 + #334 + #335). Test count updated to 2263.

## Test plan

- [x] 5/5 new tests pass
- [x] 2263 total green on Python 3.12
- [ ] CI green
- [ ] HA-TEST: upgrade from a pretend v1.6.13 state to v1.6.14, verify notification appears