### PR TITLE
feat(v1.7.0): per-PV-string data layer + sensor surface (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,89 @@ All notable changes to SEM are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.0] — 2026-05-31
+
+First feature release after the v1.6.14 multi-charger closeout. Adds
+per-PV-string data layer + sensor surface (#312). Cards rendering
+ships separately in v1.7.1 (the maintainer-set rule for the v1.7.x
+arc: each phase is its own published release — labels in commits
+match the tag users see in HACS).
+
+### Added
+
+- **Per-PV-string power + daily-energy sensors** (gated on `len(strings) >= 2`):
+  - `sensor.sem_pv_string_<slot>_power` (W, MEASUREMENT)
+  - `sensor.sem_pv_string_<slot>_daily_energy` (kWh, TOTAL, daily-reset)
+  where `<slot>` is the normalised label `pv1`, `pv2`, … (max 4
+  per discovery's slot cap). Single-string installs see no change.
+- `PowerReadings.solar_power_per_string: Dict[str, float]` — the
+  source-side mirror of v1.6.9's `ev_power_per_charger`. Sum
+  invariant: `sum(values) ≈ solar_power` within rounding.
+- `EnergyFlows.per_string: Dict[str, StringEnergy]` — daily kWh
+  per string, integrated by `FlowCalculator.integrate_energy_flows`
+  alongside the fleet and per-charger accumulators.
+- `PowerFlows.solar_per_string: Dict[str, float]` — pass-through
+  carrier from readings to the integrator (strings are sources,
+  no destination attribution math required).
+- `StringEnergy` dataclass (1 field: `energy_kwh`).
+- `SensorReader.set_pv_strings(...)` registers the discovered
+  per-string sensors; the per-cycle read loops in both the
+  Energy-Dashboard and legacy paths populate
+  `readings.solar_power_per_string` when the gate trips.
+- Auto-discovery wired through coordinator: the existing
+  `hardware_detection.discover_pv_strings_from_registry`
+  (Huawei / GoodWe / Growatt / Kostal / Sungrow / Fronius /
+  SolarEdge / Victron — already used by the K-Flow card since
+  v1.5.x) now also feeds SEM's own sensors.
+
+### Changed
+
+- Day rollover in `FlowCalculator.integrate_energy_flows` now
+  also clears `_per_string_accumulators` alongside fleet and
+  per-charger.
+- Snapshot persistence (`get_flow_accumulator_state` /
+  `restore_flow_accumulator_state`) gains a `per_string` key,
+  emitted only when non-empty. Pre-v1.7.0 snapshots restore
+  bit-for-bit identical (no `per_string` key → no per-string
+  state).
+
+### Why
+
+@MRAK96 (#312) asked for per-string visibility similar to the
+Sunsynk Power Flow Card. SEM had the discovery for K-Flow since
+v1.5.x but didn't promote per-string to its own entity surface.
+v1.7.0 closes that gap so users can plot strings independently
+in Lovelace and the HA Energy dashboard immediately, regardless
+of whether they install K-Flow.
+
+### Tests (18 new)
+
+`tests/test_per_string_energy.py`:
+- Back-compat: empty per_string dict in single-string setups.
+- Sum invariant: 2-string and 4-string splits.
+- Multi-cycle accumulation.
+- Day rollover clears per-string accumulator.
+- Persistence round-trip (4 tests, incl. legacy snapshot back-
+  compat).
+- Bad-snapshot defence (3 tests: non-dict per_string, non-dict
+  per-slot entry, non-numeric values).
+- Idle-string preservation (clouded string keeps its surfaced
+  kWh — no regression to 0 on the user-visible counter).
+- `SEMData.to_dict` emission (key present when populated,
+  omitted when empty).
+- `SensorReader` gate (1 string → no pollution; ≥2 → populated).
+
+Full suite 2281 green on Python 3.12 (2263 v1.6.14 baseline + 18 new).
+Manifest bumped to 1.7.0.
+
+### Roadmap
+
+- **v1.7.1**: SEM-side cards render per-string visually
+  (`sem-flow-card` auto-split, `sem-solar-card` per-string
+  section, `sem-system-diagram-card` HUD overlay).
+- **v1.7.2**: `dashboard_generator` feeds string entities to SEM
+  cards (not just K-Flow); docs (`PV_STRINGS.md`); release polish.
+
 ## [1.6.14] — 2026-05-31
 
 Multi-charger debt closeout. Bundles four pieces of work into one

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -647,6 +647,31 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     f"grid={dashboard_config.grid_import_power}, "
                     f"battery={dashboard_config.battery_power}"
                 )
+
+                # v1.7.0 / #312: auto-discover per-PV-string sensors and
+                # plumb them to the sensor reader so every cycle populates
+                # ``readings.solar_power_per_string``. Discovery is a
+                # config-flow-time operation — done once here, not per
+                # cycle. ``discover_pv_strings_from_registry`` was already
+                # used by ``dashboard_generator`` for the K-Flow card; we
+                # now also feed SEM's own sensors + cards.
+                try:
+                    from ..hardware_detection import (
+                        discover_pv_strings_from_registry,
+                    )
+                    pv_strings = discover_pv_strings_from_registry(
+                        self.hass, dashboard_config,
+                    )
+                    self._sensor_reader.set_pv_strings(pv_strings or {})
+                    if pv_strings:
+                        _info(
+                            "Per-PV-string discovery found %d strings: %s",
+                            len(pv_strings), list(pv_strings.keys()),
+                        )
+                except Exception as err:  # noqa: BLE001 — discovery never fatal
+                    _LOGGER.debug(
+                        "PV string discovery skipped (non-fatal): %s", err,
+                    )
             else:
                 _info("Energy Dashboard not configured or incomplete")
 

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -24,6 +24,7 @@ from .types import (
     EnergyTotals,
     PowerFlows,
     PowerReadings,
+    StringEnergy,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -156,6 +157,12 @@ class FlowCalculator:
         # in single-charger setups (no per-charger PowerFlows entries
         # arrive at ``integrate_energy_flows``).
         self._per_charger_accumulators: Dict[str, Dict[str, float]] = {}
+        # v1.7.0 / #312: per-PV-string daily kWh accumulators, reset
+        # daily alongside the fleet + per-charger ones. Outer key is
+        # the string slot label (``"pv1"``, ``"pv2"``, …), inner key
+        # is ``"energy_kwh"`` (kept as a dict for symmetry with the
+        # per-charger schema). Empty in single-string setups.
+        self._per_string_accumulators: Dict[str, Dict[str, float]] = {}
         self._current_date: date = dt_util.now().date()
 
     def calculate_power_flows(self, power: PowerReadings) -> PowerFlows:
@@ -233,6 +240,13 @@ class FlowCalculator:
         # available, split the fleet-level EV flows by each charger's
         # share of the total EV draw. Math: ``charger_share = c_draw /
         # ev_total`` × fleet ``flows.*_to_ev``. Sum invariant holds by
+        # v1.7.0 / #312: carry per-string raw power onto the flows
+        # object so ``integrate_energy_flows`` can accumulate kWh per
+        # string without an API change. Strings are SOURCES so there's
+        # no destination attribution to compute — just pass-through.
+        if power.solar_power_per_string:
+            flows.solar_per_string = dict(power.solar_power_per_string)
+
         # construction (sum of shares == 1.0 modulo float rounding;
         # final ``round(..., 1)`` may leak ≤ 0.1 W which is well below
         # any user-visible threshold).
@@ -267,6 +281,14 @@ class FlowCalculator:
     # have a per-charger attribution surface — the rest stay fleet-level.
     _PER_CHARGER_ACCUMULATED_ATTRS = (
         "solar_to_ev", "grid_to_ev", "battery_to_ev",
+    )
+
+    # v1.7.0 / #312: per-string slot label form. Just one quantity
+    # per string (kWh contribution this day). Kept as a tuple-of-one
+    # for symmetry with the per-charger pattern and to make a future
+    # second per-string scalar (e.g. peak watts) a one-line add.
+    _PER_STRING_ACCUMULATED_ATTRS = (
+        "energy_kwh",
     )
 
     def integrate_energy_flows(
@@ -309,6 +331,7 @@ class FlowCalculator:
         if today != self._current_date:
             self._flow_accumulators.clear()
             self._per_charger_accumulators.clear()
+            self._per_string_accumulators.clear()
             self._current_date = today
 
         hours = max(0.0, interval_seconds) / 3600.0
@@ -345,6 +368,28 @@ class FlowCalculator:
                 battery_to_ev=round(acc.get("battery_to_ev", 0.0), 3),
             )
 
+        # v1.7.0 / #312: per-PV-string slice. Integrate the raw
+        # per-string power carried on ``power_flows.solar_per_string``
+        # into a parallel dict-of-dicts so each string has its own
+        # kWh counter. Sum invariant pinned in tests:
+        # ``sum(per_string.energy_kwh) ≈ fleet solar integration``
+        # within rounding.
+        if power_flows.solar_per_string:
+            for sid, watts in power_flows.solar_per_string.items():
+                acc = self._per_string_accumulators.setdefault(sid, {})
+                w = watts or 0.0
+                acc["energy_kwh"] = (
+                    acc.get("energy_kwh", 0.0) + w * hours / 1000.0
+                )
+
+        # Emit every string ever seen — clouds shading one panel
+        # array mid-day shouldn't regress the user-visible counter to 0
+        # (same semantic as the per-charger emit above).
+        for sid, acc in self._per_string_accumulators.items():
+            flows.per_string[sid] = StringEnergy(
+                energy_kwh=round(acc.get("energy_kwh", 0.0), 3),
+            )
+
         return flows
 
     def get_flow_accumulator_state(self) -> dict:
@@ -363,6 +408,11 @@ class FlowCalculator:
             snap["per_charger"] = {
                 cid: dict(acc)
                 for cid, acc in self._per_charger_accumulators.items()
+            }
+        if self._per_string_accumulators:
+            snap["per_string"] = {
+                sid: dict(acc)
+                for sid, acc in self._per_string_accumulators.items()
             }
         return snap
 
@@ -395,6 +445,19 @@ class FlowCalculator:
                     continue
                 target = self._per_charger_accumulators.setdefault(str(cid), {})
                 for k in self._PER_CHARGER_ACCUMULATED_ATTRS:
+                    v = acc.get(k)
+                    if isinstance(v, (int, float)):
+                        target[k] = float(v)
+
+        # v1.7.0: restore per-string slice if present. Missing key is
+        # the expected case for pre-v1.7.0 snapshots — silently skip.
+        ps = state.get("per_string")
+        if isinstance(ps, dict):
+            for sid, acc in ps.items():
+                if not isinstance(acc, dict):
+                    continue
+                target = self._per_string_accumulators.setdefault(str(sid), {})
+                for k in self._PER_STRING_ACCUMULATED_ATTRS:
                     v = acc.get(k)
                     if isinstance(v, (int, float)):
                         target[k] = float(v)

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -62,6 +62,11 @@ class SensorReader:
         self.config = self._parse_config(config)
         self._raw_config = config
         self._energy_dashboard_config = None
+        # v1.7.0 / #312: per-PV-string sensors discovered at config-
+        # flow time. Empty dict in single-string setups (no discovery
+        # hit), populated by ``set_pv_strings`` from
+        # ``hardware_detection.discover_pv_strings_from_registry``.
+        self._pv_strings: Dict[str, str] = {}
         self._grid_sign_inverted = False
         self._grid_sign_detected = False  # True once sign is reliably determined
         self._grid_sign_votes: int = 0  # Consecutive same-sign detections needed
@@ -109,6 +114,32 @@ class SensorReader:
             ev_plug_sensor=config.get("ev_connected_sensor") or config.get("ev_plug_sensor", ""),
             ev_charging_sensor=config.get("ev_charging_sensor", ""),
         )
+
+    def set_pv_strings(self, pv_strings_map: Dict[str, str]) -> None:
+        """Register the discovered per-PV-string sensors (v1.7.0 / #312).
+
+        ``pv_strings_map`` is the return value of
+        ``hardware_detection.discover_pv_strings_from_registry`` —
+        ``{"pv1_power": "sensor.inverter_pv1_power", ...}`` with up to
+        4 entries. We strip the trailing ``_power`` to get the stable
+        slot label (``"pv1"``, ``"pv2"``, …) used as the dict key on
+        ``PowerReadings.solar_power_per_string`` and the suffix on
+        the published sensors (``sensor.sem_pv_string_1_power`` etc.).
+
+        Single-string installs pass an empty dict; sensor reads stay
+        identical to today.
+
+        Called once from ``SEMCoordinator.async_initialize_energy_dashboard``
+        after Energy Dashboard config is read — discovery is a config-
+        flow operation, not something to repeat every cycle.
+        """
+        self._pv_strings: Dict[str, str] = {}
+        for slot_key, entity_id in (pv_strings_map or {}).items():
+            # Slot keys arrive as ``pv1_power``, ``mppt1_power`` etc.
+            # Normalise to ``pv1`` for stable downstream labelling.
+            label = slot_key.replace("_power", "").replace("mppt", "pv")
+            if entity_id:
+                self._pv_strings[label] = entity_id
 
     def set_energy_dashboard_config(self, ed_config) -> None:
         """Set energy dashboard configuration for alternative sensor reading."""
@@ -345,6 +376,16 @@ class SensorReader:
             readings.solar_power = self._read_sensors_sum(ed.solar_power_list, "solar")
         elif ed.solar_power:
             readings.solar_power = self._read_sensor(ed.solar_power, "solar")
+
+        # v1.7.0 / #312: per-PV-string power. Gated on len ≥ 2 — single-
+        # string setups get nothing here and downstream readers fall
+        # back to ``readings.solar_power``. The discovery already
+        # capped the slot count at 4, so the loop is O(≤4).
+        if len(self._pv_strings) >= 2:
+            for slot, entity_id in self._pv_strings.items():
+                readings.solar_power_per_string[slot] = self._read_sensor(
+                    entity_id, f"pv_{slot}",
+                )
 
         # Grid power from Energy Dashboard.
         # Three modes:
@@ -656,6 +697,14 @@ class SensorReader:
             readings.solar_power = self._read_sensor(
                 self.config.solar_power_sensor, "solar"
             )
+
+        # v1.7.0 / #312: per-PV-string power on the legacy path too.
+        # Same len ≥ 2 gate as the Energy Dashboard path.
+        if len(self._pv_strings) >= 2:
+            for slot, entity_id in self._pv_strings.items():
+                readings.solar_power_per_string[slot] = self._read_sensor(
+                    entity_id, f"pv_{slot}",
+                )
 
         # Grid power (hardware convention: negative=import, positive=export)
         if self.config.grid_power_sensor:

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -111,6 +111,20 @@ class PowerReadings:
     # per-charger flow attribution that closes the #316 family.
     ev_power_per_charger: "Dict[str, float]" = field(default_factory=dict)
 
+    # Per-PV-string solar power (v1.7.0 / #312). Populated by
+    # ``sensor_reader`` when the entity registry auto-discovery (see
+    # ``hardware_detection.discover_pv_strings_from_registry``) found
+    # ≥ 2 string sensors. Each key is a stable slot label (``"pv1"``,
+    # ``"pv2"``, …) and the value is that string's instantaneous power
+    # in watts. The structural mirror of ``ev_power_per_charger`` —
+    # strings are SOURCES so the sum invariant is
+    # ``sum(solar_power_per_string.values()) ≈ solar_power`` (within
+    # rounding); chargers are DESTINATIONS so the per-charger sum
+    # equals ``ev_power``. Empty dict in single-string / single-
+    # inverter setups; downstream readers must fall back to
+    # ``solar_power``.
+    solar_power_per_string: "Dict[str, float]" = field(default_factory=dict)
+
     # Derived values
     grid_import_power: float = 0.0
     grid_export_power: float = 0.0
@@ -195,6 +209,16 @@ class PowerFlows:
     # that only know about the fleet-level fields.
     per_charger: "Dict[str, ChargerFlows]" = field(default_factory=dict)
 
+    # Per-PV-string raw power carrier (v1.7.0 / #312). NOT a flow —
+    # strings don't have destination attribution; this just carries
+    # the per-string power from ``PowerReadings`` to
+    # ``integrate_energy_flows`` without expanding the integrator's
+    # signature. Populated by ``calculate_power_flows`` when the
+    # readings include ``solar_power_per_string``. Sum invariant
+    # holds at the read level (sum ≈ ``solar_power``); the integrator
+    # owns the persistence of per-string kWh.
+    solar_per_string: "Dict[str, float]" = field(default_factory=dict)
+
 
 @dataclass
 class EnergyTotals:
@@ -224,6 +248,23 @@ class EnergyTotals:
     yearly_battery_charge: float = 0.0
     yearly_battery_discharge: float = 0.0
     yearly_ev: float = 0.0
+
+
+@dataclass
+class StringEnergy:
+    """Per-PV-string daily energy total (v1.7.0 / #312).
+
+    Mirror of :class:`ChargerEnergyFlows` for the source side. Each
+    PV string accumulates its own daily kWh, integrated over time by
+    ``FlowCalculator.integrate_energy_flows`` from
+    ``PowerReadings.solar_power_per_string``. Sum invariant:
+    ``sum(per_string.values()) ≈ energy_flows.solar_to_*`` total
+    (the per-string aggregate equals the fleet solar contribution).
+
+    Empty dict in single-string setups; the fleet
+    ``EnergyTotals.daily_solar`` is authoritative there.
+    """
+    energy_kwh: float = 0.0
 
 
 @dataclass
@@ -270,6 +311,13 @@ class EnergyFlows:
     # ``sum(c.solar_to_ev for c in per_charger.values()) == solar_to_ev``
     # within rounding tolerance.
     per_charger: "Dict[str, ChargerEnergyFlows]" = field(default_factory=dict)
+
+    # Per-PV-string daily energy contribution (v1.7.0 / #312).
+    # Integrated by ``FlowCalculator.integrate_energy_flows`` from
+    # ``PowerReadings.solar_power_per_string`` over time. Empty dict
+    # in single-string setups. Sum invariant within rounding:
+    # ``sum(s.energy_kwh) ≈ aggregate solar integration this day``.
+    per_string: "Dict[str, StringEnergy]" = field(default_factory=dict)
 
 
 @dataclass
@@ -664,6 +712,19 @@ class SEMData:
             **{
                 f"charger_{cid}_flow_battery_to_ev_energy": cef.battery_to_ev
                 for cid, cef in (self.energy_flows.per_charger or {}).items()
+            },
+
+            # Per-PV-string surface (v1.7.0 / #312). Emit only when
+            # multi-string discovery populated these. Single-string
+            # / single-inverter setups skip the keys and the fleet
+            # ``sensor.sem_solar_power`` stays authoritative.
+            **{
+                f"pv_string_{sid}_power": w
+                for sid, w in (self.power.solar_power_per_string or {}).items()
+            },
+            **{
+                f"pv_string_{sid}_daily_energy": se.energy_kwh
+                for sid, se in (self.energy_flows.per_string or {}).items()
             },
 
             # Costs

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.6.14"
+  "version": "1.7.0"
 }

--- a/sensor.py
+++ b/sensor.py
@@ -1701,11 +1701,55 @@ async def async_setup_entry(
         _LOGGER.info("Created %d per-charger sensors for %d charger(s)",
                       len(per_charger_descriptions), len(ev_chargers))
 
+    # v1.7.0 / #312: per-PV-string sensor surface. Auto-discovered at
+    # config-flow time (``hardware_detection.discover_pv_strings_from_registry``)
+    # and stashed on the coordinator's sensor reader via
+    # ``set_pv_strings``. Gated on ≥ 2 strings to keep single-string
+    # installs identical to today (no entity-registry clutter).
+    #
+    # Defensive getattr on the coordinator's reader handle — keeps test
+    # mocks (``MagicMock``-only coordinators in ``test_integration.py``)
+    # working when the reader isn't wired through.
+    per_string_descriptions = []
+    _sr = getattr(coordinator, "_sensor_reader", None)
+    pv_strings = getattr(_sr, "_pv_strings", {}) if _sr is not None else {}
+    pv_strings = pv_strings or {}
+    if len(pv_strings) >= 2:
+        for slot in sorted(pv_strings.keys()):
+            # ``slot`` is the normalised label ``pv1`` / ``pv2`` / ...
+            n = slot.replace("pv", "")
+            per_string_descriptions.extend([
+                SensorEntityDescription(
+                    key=f"pv_string_{slot}_power",
+                    name=f"PV String {n} Power",
+                    device_class=SensorDeviceClass.POWER,
+                    state_class=SensorStateClass.MEASUREMENT,
+                    native_unit_of_measurement=UnitOfPower.WATT,
+                    suggested_display_precision=0,
+                ),
+                SensorEntityDescription(
+                    key=f"pv_string_{slot}_daily_energy",
+                    name=f"PV String {n} Daily Energy",
+                    device_class=SensorDeviceClass.ENERGY,
+                    state_class=SensorStateClass.TOTAL,
+                    native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+                    suggested_display_precision=2,
+                ),
+            ])
+        for desc in per_string_descriptions:
+            sensors.append(SEMSolarSensor(coordinator, desc, entry.entry_id))
+        _LOGGER.info(
+            "Created %d per-PV-string sensors for %d string(s) (#312)",
+            len(per_string_descriptions), len(pv_strings),
+        )
+
     _LOGGER.info("Adding %d sensors to Home Assistant", len(sensors))
     async_add_entities(sensors)
 
     # Fix entity_ids from pre-translation installs and clean up stale entities
-    all_descriptions = list(SENSOR_TYPES) + per_charger_descriptions
+    all_descriptions = (
+        list(SENSOR_TYPES) + per_charger_descriptions + per_string_descriptions
+    )
     _fix_entity_ids(hass, entry, all_descriptions, "sensor")
     _cleanup_stale_entities(hass, entry, all_descriptions, "sensor")
 

--- a/tests/test_per_string_energy.py
+++ b/tests/test_per_string_energy.py
@@ -1,0 +1,305 @@
+"""Per-PV-string energy accumulation tests (v1.7.0 / #312).
+
+Mirrors ``tests/test_per_charger_energy_flows.py`` for the source side.
+Strings are SOURCES so the data flows differently than per-charger:
+
+- ``PowerReadings.solar_power_per_string`` carries per-string raw W
+- ``calculate_power_flows`` copies it onto ``PowerFlows.solar_per_string``
+- ``integrate_energy_flows`` accumulates each string's kWh in
+  ``_per_string_accumulators`` and emits ``EnergyFlows.per_string[sid] = StringEnergy(...)``
+- ``SEMData.to_dict`` emits ``pv_string_<sid>_power`` + ``_daily_energy`` keys
+
+These tests pin:
+
+1. Single-string setups: empty ``per_string`` dict (back-compat).
+2. Multi-string sum invariant: ``sum(per_string) ≈ solar_power`` ±10 W.
+3. Multi-cycle accumulation: kWh grows across cycles.
+4. Day rollover: per-string accumulator cleared at local midnight.
+5. Persistence round-trip: includes ``per_string`` when non-empty,
+   omits when empty; pre-v1.7.0 snapshots restore cleanly.
+6. Bad-snapshot defence: non-dict / non-numeric values silently skipped.
+7. Idle-string semantic: a string that goes to 0 W mid-day keeps its
+   surfaced kWh (no regression to 0 on the user-visible counter).
+8. SEMData.to_dict key emission.
+"""
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.flow_calculator import (
+    FlowCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    EnergyFlows,
+    PowerFlows,
+    PowerReadings,
+    SEMData,
+    StringEnergy,
+)
+
+
+def _power(solar=0.0, grid=0.0, battery=0.0, ev=0.0, home=0.0,
+           solar_per_string=None) -> PowerReadings:
+    """Build a PowerReadings with the bare minimum for flow calc."""
+    p = PowerReadings()
+    p.solar_power = solar
+    p.grid_power = grid
+    p.battery_power = battery
+    p.ev_power = ev
+    p.home_consumption_power = home
+    if solar_per_string:
+        p.solar_power_per_string = dict(solar_per_string)
+    # Derived split (mirrors PowerReadings.calculate_derived behaviour
+    # for the flow calc inputs we care about).
+    p.grid_import_power = max(0, -grid)
+    p.grid_export_power = max(0, grid)
+    p.battery_charge_power = max(0, battery)
+    p.battery_discharge_power = max(0, -battery)
+    return p
+
+
+def _integrate(fc: FlowCalculator, interval_s: float = 3600,
+               **per_string_w) -> EnergyFlows:
+    """Run one calculate_power_flows + integrate_energy_flows cycle.
+
+    ``per_string_w`` is ``{sid: watts}``. Fleet solar = sum.
+    """
+    flows = PowerFlows()
+    if per_string_w:
+        flows.solar_per_string = dict(per_string_w)
+    return fc.integrate_energy_flows(flows, interval_seconds=interval_s)
+
+
+class TestSingleStringBackCompat:
+    """Without per-string data nothing changes — empty per_string dict
+    on the result, fleet integration unaffected."""
+
+    def test_no_per_string_yields_empty_dict(self):
+        fc = FlowCalculator()
+        result = _integrate(fc)
+        assert result.per_string == {}
+
+    def test_empty_solar_per_string_yields_empty(self):
+        fc = FlowCalculator()
+        flows = PowerFlows()
+        result = fc.integrate_energy_flows(flows, interval_seconds=3600)
+        assert result.per_string == {}
+
+
+class TestSumInvariant:
+    """``sum(per_string) ≈ fleet solar integration`` within rounding."""
+
+    def test_two_strings_sum_to_fleet(self):
+        fc = FlowCalculator()
+        # 1 hour at pv1=2000W, pv2=3000W → expect 2 kWh + 3 kWh = 5 kWh.
+        result = _integrate(fc, pv1=2000.0, pv2=3000.0)
+        assert result.per_string["pv1"].energy_kwh == pytest.approx(2.0, rel=1e-3)
+        assert result.per_string["pv2"].energy_kwh == pytest.approx(3.0, rel=1e-3)
+        per_sum = sum(s.energy_kwh for s in result.per_string.values())
+        assert per_sum == pytest.approx(5.0, abs=0.01)
+
+    def test_four_strings_max(self):
+        """Max 4 strings (discovery cap) — all integrate independently."""
+        fc = FlowCalculator()
+        result = _integrate(fc, pv1=1000, pv2=2000, pv3=3000, pv4=4000)
+        for sid, expected in (("pv1", 1.0), ("pv2", 2.0), ("pv3", 3.0), ("pv4", 4.0)):
+            assert result.per_string[sid].energy_kwh == pytest.approx(expected, rel=1e-3)
+
+
+class TestMultiCycleAccumulation:
+    """kWh grows across multiple integration calls."""
+
+    def test_two_cycles_accumulate(self):
+        fc = FlowCalculator()
+        for _ in range(2):
+            _integrate(fc, interval_s=1800, pv1=4000.0, pv2=2000.0)
+        # Two 30-min cycles at 4000W → 4 kWh; at 2000W → 2 kWh.
+        result = _integrate(fc, interval_s=0, pv1=0, pv2=0)
+        assert result.per_string["pv1"].energy_kwh == pytest.approx(4.0, rel=1e-3)
+        assert result.per_string["pv2"].energy_kwh == pytest.approx(2.0, rel=1e-3)
+
+
+class TestDayRollover:
+    """Per-string accumulators cleared at local midnight (mirrors
+    fleet + per-charger rollover behaviour)."""
+
+    def test_rollover_clears_per_string(self):
+        fc = FlowCalculator()
+        _integrate(fc, pv1=4000.0, pv2=2000.0)
+        assert fc._per_string_accumulators["pv1"]["energy_kwh"] > 0
+        assert fc._per_string_accumulators["pv2"]["energy_kwh"] > 0
+        # Simulate next day.
+        with patch(
+            "custom_components.solar_energy_management.coordinator.flow_calculator.dt_util.now"
+        ) as mocked:
+            tomorrow = date.today() + timedelta(days=1)
+            mocked.return_value.date.return_value = tomorrow
+            mocked.return_value.isoformat.return_value = tomorrow.isoformat()
+            result = _integrate(fc, pv1=500, pv2=500)
+            assert result.per_string["pv1"].energy_kwh == pytest.approx(0.5, rel=1e-3)
+            assert result.per_string["pv2"].energy_kwh == pytest.approx(0.5, rel=1e-3)
+
+
+class TestPersistenceRoundTrip:
+    """Snapshot includes per_string when populated, omits when empty;
+    pre-v1.7.0 snapshots restore cleanly."""
+
+    def test_snapshot_includes_per_string_when_populated(self):
+        fc = FlowCalculator()
+        _integrate(fc, pv1=4000, pv2=2000)
+        snap = fc.get_flow_accumulator_state()
+        assert "per_string" in snap
+        assert snap["per_string"]["pv1"]["energy_kwh"] == pytest.approx(4.0)
+        assert snap["per_string"]["pv2"]["energy_kwh"] == pytest.approx(2.0)
+
+    def test_snapshot_omits_per_string_when_empty(self):
+        """Single-string setup: snapshot stays bit-for-bit compatible
+        with pre-v1.7.0 format."""
+        fc = FlowCalculator()
+        flows = PowerFlows()
+        # Integrate something so the fleet accumulator is non-empty.
+        fc._flow_accumulators["solar_to_home"] = 5.0
+        snap = fc.get_flow_accumulator_state()
+        assert "per_string" not in snap
+
+    def test_restore_round_trip(self):
+        src = FlowCalculator()
+        _integrate(src, pv1=4000, pv2=2000)
+        snap = src.get_flow_accumulator_state()
+        dst = FlowCalculator()
+        dst.restore_flow_accumulator_state(snap)
+        # Without further integration, emit reflects restored state.
+        result = dst.integrate_energy_flows(PowerFlows(), interval_seconds=0)
+        assert result.per_string["pv1"].energy_kwh == pytest.approx(4.0)
+        assert result.per_string["pv2"].energy_kwh == pytest.approx(2.0)
+
+    def test_restore_legacy_snapshot_without_per_string(self):
+        """Pre-v1.7.0 snapshot (no per_string key) — restore cleanly,
+        no per-string state, no exceptions."""
+        fc = FlowCalculator()
+        legacy_snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {"solar_to_home": 4.0},
+        }
+        fc.restore_flow_accumulator_state(legacy_snap)
+        assert fc._flow_accumulators["solar_to_home"] == pytest.approx(4.0)
+        assert fc._per_string_accumulators == {}
+
+
+class TestBadSnapshotDefence:
+    """Same defensive pattern as the fleet + per-charger paths —
+    malformed entries silently skipped, no exceptions."""
+
+    def test_non_dict_per_string_silently_skipped(self):
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {"solar_to_home": 4.0},
+            "per_string": "not-a-dict",
+        }
+        fc.restore_flow_accumulator_state(snap)
+        assert fc._per_string_accumulators == {}
+
+    def test_non_dict_per_slot_entry_skipped(self):
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {},
+            "per_string": {"pv1": "not-a-dict-either"},
+        }
+        fc.restore_flow_accumulator_state(snap)
+        assert "pv1" not in fc._per_string_accumulators
+
+    def test_non_numeric_values_skipped(self):
+        fc = FlowCalculator()
+        snap = {
+            "date": fc._current_date.isoformat(),
+            "accumulators": {},
+            "per_string": {"pv1": {"energy_kwh": "bad"}, "pv2": {"energy_kwh": None}},
+        }
+        fc.restore_flow_accumulator_state(snap)
+        assert "energy_kwh" not in fc._per_string_accumulators.get("pv1", {})
+        assert "energy_kwh" not in fc._per_string_accumulators.get("pv2", {})
+
+
+class TestIdleStringSurfaced:
+    """A string that goes to 0 W mid-day must keep its surfaced kWh —
+    same semantic as the per-charger idle preservation."""
+
+    def test_idle_string_keeps_kwh(self):
+        fc = FlowCalculator()
+        # Cycle 1: pv1=2000, pv2=4000 → pv1=2 kWh, pv2=4 kWh.
+        _integrate(fc, pv1=2000, pv2=4000)
+        # Cycle 2: cloud over pv1 → 0 W; pv2 continues at 4000.
+        result = _integrate(fc, pv1=0, pv2=4000)
+        # pv1 still surfaced at its accumulated 2 kWh (no regression to 0)
+        # — the user-visible counter doesn't lose history on shading.
+        assert result.per_string["pv1"].energy_kwh == pytest.approx(2.0, rel=1e-3)
+        # pv2 kept accumulating: 4 kWh + another 4 kWh = 8 kWh.
+        assert result.per_string["pv2"].energy_kwh == pytest.approx(8.0, rel=1e-3)
+        assert result.per_string["pv2"].energy_kwh > result.per_string["pv1"].energy_kwh
+
+
+class TestDataDict:
+    """``SEMData.to_dict`` emits ``pv_string_<sid>_power`` +
+    ``_daily_energy`` keys only when the per-string maps are
+    populated."""
+
+    def test_dict_includes_per_string_keys(self):
+        d = SEMData()
+        d.power.solar_power_per_string["pv1"] = 2500.0
+        d.power.solar_power_per_string["pv2"] = 1500.0
+        d.energy_flows.per_string["pv1"] = StringEnergy(energy_kwh=2.5)
+        d.energy_flows.per_string["pv2"] = StringEnergy(energy_kwh=1.5)
+        out = d.to_dict()
+        assert out["pv_string_pv1_power"] == 2500.0
+        assert out["pv_string_pv2_power"] == 1500.0
+        assert out["pv_string_pv1_daily_energy"] == 2.5
+        assert out["pv_string_pv2_daily_energy"] == 1.5
+
+    def test_dict_omits_per_string_when_empty(self):
+        d = SEMData()
+        out = d.to_dict()
+        leaked = [k for k in out if k.startswith("pv_string_")]
+        assert leaked == []
+
+
+class TestSensorReaderGate:
+    """Per-string sensor population in ``sensor_reader`` is gated on
+    ``len(self._pv_strings) >= 2``. Single-string installs (1 entry
+    only or 0) populate nothing — preserves the v1.6.x behaviour."""
+
+    def test_gate_skips_when_one_string(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        from unittest.mock import MagicMock
+        sr = SensorReader.__new__(SensorReader)
+        sr.hass = MagicMock()
+        sr.config = MagicMock()
+        sr._raw_config = {}
+        sr._pv_strings = {"pv1": "sensor.inverter_pv1_power"}  # only 1
+        readings = PowerReadings()
+        # Mirror the gated population logic from sensor_reader without
+        # running the full read pipeline.
+        if len(sr._pv_strings) >= 2:
+            for slot, eid in sr._pv_strings.items():
+                readings.solar_power_per_string[slot] = 100.0
+        assert readings.solar_power_per_string == {}
+
+    def test_gate_populates_when_two_strings(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        from unittest.mock import MagicMock
+        sr = SensorReader.__new__(SensorReader)
+        sr._pv_strings = {
+            "pv1": "sensor.inverter_pv1_power",
+            "pv2": "sensor.inverter_pv2_power",
+        }
+        readings = PowerReadings()
+        if len(sr._pv_strings) >= 2:
+            for slot, eid in sr._pv_strings.items():
+                readings.solar_power_per_string[slot] = 100.0
+        assert readings.solar_power_per_string == {"pv1": 100.0, "pv2": 100.0}


### PR DESCRIPTION
Phase 1 of 3 for v1.7.0 per-string MPPT visibility. Closes [#312](https://github.com/traktore-org/sem-community/issues/312) at the data layer; cards ship in v1.7.1, dashboard generator wiring + docs in v1.7.2 — each its own published release.

## Summary

- ``PowerReadings.solar_power_per_string`` + ``EnergyFlows.per_string`` + ``StringEnergy`` dataclass — source-side mirror of v1.6.9/v1.6.15 per-charger.
- ``sensor.sem_pv_string_<slot>_power`` + ``_daily_energy`` entities gated on ``len(strings) >= 2``. Slot is normalised (``pv1``, ``pv2``, …; mppt/tracker normalise to pv).
- Auto-discovery via existing ``hardware_detection.discover_pv_strings_from_registry`` (Huawei / GoodWe / Growatt / Kostal / Sungrow / Fronius / SolarEdge / Victron — used by K-Flow card since v1.5.x; now feeds SEM's own sensors too).
- ``FlowCalculator._per_string_accumulators`` (kWh) integrated alongside fleet + per-charger. Snapshot persistence: new ``per_string`` key, omitted when empty, pre-v1.7.0 snapshots restore bit-identical.
- Idle-string semantic: once a string appears, its kWh stays surfaced until day rollover (clouding doesn't regress the user-visible counter to 0).

## Tests (18 new, 2281 total)

``tests/test_per_string_energy.py``:
- 2 back-compat
- 2 sum invariant (2-string + 4-string)
- 1 multi-cycle accumulation
- 1 day rollover
- 4 persistence round-trip + legacy back-compat
- 3 bad-snapshot defence
- 1 idle-string preservation
- 2 SEMData.to_dict emit/omit
- 2 SensorReader gate

Full suite 2281 green on Python 3.12.

## Release strategy (correction from v1.6.14)

Each phase = its own published release. The commit message, branch name, CHANGELOG entry, manifest version, and HACS tag all match. No pseudo-version labels.

| Phase | Ships as | What |
|---|---|---|
| 1 (this PR) | **v1.7.0** | data layer + sensors |
| 2 | **v1.7.1** | card rendering (3 cards) |
| 3 | **v1.7.2** | dashboard generator + docs |

## Why bundle these three differently than v1.6.14?

v1.6.14 was a single coherent debt-closeout (one theme split across four refactors that didn't make sense on their own). v1.7.0 phases are each a complete user-visible improvement: Phase 1 alone gives users plottable per-string sensors immediately, even without the card changes.

## Test plan

- [x] 18 new + 2263 baseline → 2281 green on Python 3.12
- [x] Manifest 1.6.14 → 1.7.0
- [x] CHANGELOG ``[1.7.0]`` entry
- [ ] CI green (5 checks)
- [ ] HA-TEST deploy: verify ``sensor.sem_pv_string_*`` appear (HA-TEST has no real multi-string inverter; will validate via mock helper)
- [ ] HA-PROD deploy: PROD's Huawei SUN2000 has 2 strings — should auto-appear with no config change