### PR TITLE
feat(v1.7.0): V+I → P synthesis for inverters without per-string power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,25 @@ but published as one user-visible release.
   `hardware_detection.discover_pv_strings_from_registry`
   (Huawei / GoodWe / Growatt / Kostal / Sungrow / Fronius /
   SolarEdge / Victron) now also feeds SEM's own sensors.
+- **V+I synthesis fallback**
+  `hardware_detection.discover_pv_string_vi_pairs` — when an
+  inverter exposes per-string voltage + current but no
+  per-string power sensor (Huawei Solar Modbus, generic
+  Modbus drivers, Solarman bridges), SEM detects sibling
+  `pv_N_voltage` + `pv_N_current` pairs and multiplies V × I
+  at read time to synthesise the per-string watts. Surfaces
+  the same `sensor.sem_pv_string_<slot>_power` entities as
+  the direct-power path; downstream consumers (cards, energy
+  accumulator, sum invariant) don't know which way the value
+  was sourced. Voltage / current patterns accept English
+  (`voltage` / `current` / `volt` / `amp`) and German
+  (`spannung` / `strom`) suffixes. When the same slot has
+  BOTH a direct power sensor AND a V+I pair, the direct
+  sensor wins (slightly more accurate — accounts for the
+  inverter's MPPT efficiency math). Confirmed on HA-PROD
+  2026-06-01: Huawei `inverter_pv_1_spannung` +
+  `..._strom` pair now feeds `sensor.sem_pv_string_pv1_power`
+  via this path.
 - **Per-PV-string chip strip** on three cards, auto-shown when
   ≥ 2 strings are present. Each chip shows `PVn N.NN kW` and
   links to the underlying sensor entity on tap.

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -658,15 +658,28 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 try:
                     from ..hardware_detection import (
                         discover_pv_strings_from_registry,
+                        discover_pv_string_vi_pairs,
                     )
                     pv_strings = discover_pv_strings_from_registry(
                         self.hass, dashboard_config,
-                    )
-                    self._sensor_reader.set_pv_strings(pv_strings or {})
-                    if pv_strings:
+                    ) or {}
+                    # V+I synthesis (v1.7.0): for integrations that
+                    # publish per-string voltage + current but no
+                    # per-string power (Huawei Solar Modbus, generic
+                    # Modbus drivers). SEM multiplies V × I at read
+                    # time so these users get the per-string sensors
+                    # without writing a template themselves. Direct
+                    # power match wins over V+I synthesis when both
+                    # exist for the same slot (real sensor preferred).
+                    vi_pairs = discover_pv_string_vi_pairs(
+                        self.hass, dashboard_config,
+                    ) or {}
+                    self._sensor_reader.set_pv_strings(pv_strings, vi_pairs)
+                    if pv_strings or vi_pairs:
                         _info(
-                            "Per-PV-string discovery found %d strings: %s",
-                            len(pv_strings), list(pv_strings.keys()),
+                            "Per-PV-string discovery: %d direct power, "
+                            "%d V+I pairs",
+                            len(pv_strings), len(vi_pairs),
                         )
                 except Exception as err:  # noqa: BLE001 — discovery never fatal
                     _LOGGER.debug(

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -115,31 +115,87 @@ class SensorReader:
             ev_charging_sensor=config.get("ev_charging_sensor", ""),
         )
 
-    def set_pv_strings(self, pv_strings_map: Dict[str, str]) -> None:
-        """Register the discovered per-PV-string sensors (v1.7.0 / #312).
+    def _read_pv_string_source(self, slot: str, source) -> float:
+        """Read one per-PV-string source (v1.7.0 / #312).
 
-        ``pv_strings_map`` is the return value of
-        ``hardware_detection.discover_pv_strings_from_registry`` —
-        ``{"pv1_power": "sensor.inverter_pv1_power", ...}`` with up to
-        4 entries. We strip the trailing ``_power`` to get the stable
-        slot label (``"pv1"``, ``"pv2"``, …) used as the dict key on
-        ``PowerReadings.solar_power_per_string`` and the suffix on
-        the published sensors (``sensor.sem_pv_string_1_power`` etc.).
+        Handles both registered source shapes:
 
-        Single-string installs pass an empty dict; sensor reads stay
+        - ``str`` → direct power entity. Read the value, return W.
+        - ``tuple(V_entity, I_entity)`` → V+I synthesis. Read both,
+          return ``V × I`` (W). Used for inverter integrations that
+          publish voltage + current per string but no power sensor
+          (Huawei Solar Modbus is the motivating case — confirmed
+          on HA-PROD 2026-06-01: ``inverter_pv_1_spannung`` and
+          ``..._strom`` exist but no ``..._power``).
+
+        Returns 0.0 on any read failure (unavailable sensor, non-
+        numeric state, etc.) — same fail-soft contract as
+        ``_read_sensor``. The synthesised power is then surfaced
+        through the same ``solar_power_per_string`` dict as a
+        directly-read value; downstream consumers don't need to
+        know the source shape.
+        """
+        if isinstance(source, tuple):
+            v_entity, i_entity = source
+            v = self._read_sensor(v_entity, f"pv_{slot}_voltage")
+            i = self._read_sensor(i_entity, f"pv_{slot}_current")
+            return float(v) * float(i)
+        # Direct power entity — keep the legacy fast path.
+        return self._read_sensor(source, f"pv_{slot}")
+
+    def set_pv_strings(
+        self,
+        pv_strings_map: Dict[str, str],
+        pv_vi_pairs_map: Optional[Dict[str, "Tuple[str, str]"]] = None,
+    ) -> None:
+        """Register the discovered per-PV-string sources (v1.7.0 / #312).
+
+        Two sources supported, both feed the same ``_pv_strings`` dict:
+
+        - ``pv_strings_map``: result of
+          ``hardware_detection.discover_pv_strings_from_registry`` —
+          direct power sensors (``{"pv1_power": "sensor.inverter_pv1_power"}``).
+        - ``pv_vi_pairs_map`` (v1.7.0): result of
+          ``hardware_detection.discover_pv_string_vi_pairs`` —
+          V+I sibling pairs for inverters that publish only voltage
+          and current per string (Huawei Solar Modbus, generic
+          Modbus drivers). At read time SEM multiplies V × I to
+          synthesise the per-string watts. Keys are stripped slot
+          labels ``"pv1"`` / ``"pv2"`` / …; values are tuples
+          ``(voltage_entity, current_entity)``.
+
+        When the same slot appears in BOTH maps, the direct power
+        sensor wins — it's a real measurement rather than a
+        computed product, slightly more accurate (the inverter's
+        own internal computation accounts for MPPT efficiency etc.).
+
+        Single-string installs pass empty dicts; sensor reads stay
         identical to today.
 
         Called once from ``SEMCoordinator.async_initialize_energy_dashboard``
         after Energy Dashboard config is read — discovery is a config-
         flow operation, not something to repeat every cycle.
         """
-        self._pv_strings: Dict[str, str] = {}
+        # Internal shape: ``{slot: str | (V_entity, I_entity)}``. Stored
+        # as ``Any`` because the union type is awkward to express in
+        # a single dataclass field; the per-cycle read loop tags by
+        # ``isinstance(value, tuple)``.
+        self._pv_strings: Dict[str, "Any"] = {}
+
         for slot_key, entity_id in (pv_strings_map or {}).items():
             # Slot keys arrive as ``pv1_power``, ``mppt1_power`` etc.
             # Normalise to ``pv1`` for stable downstream labelling.
             label = slot_key.replace("_power", "").replace("mppt", "pv")
             if entity_id:
                 self._pv_strings[label] = entity_id
+
+        for slot_label, vi_pair in (pv_vi_pairs_map or {}).items():
+            # Don't override a direct power entry from a parallel
+            # V+I match — see contract above.
+            if slot_label in self._pv_strings:
+                continue
+            if vi_pair and len(vi_pair) == 2 and all(vi_pair):
+                self._pv_strings[slot_label] = tuple(vi_pair)
 
     def set_energy_dashboard_config(self, ed_config) -> None:
         """Set energy dashboard configuration for alternative sensor reading."""
@@ -380,11 +436,13 @@ class SensorReader:
         # v1.7.0 / #312: per-PV-string power. Gated on len ≥ 2 — single-
         # string setups get nothing here and downstream readers fall
         # back to ``readings.solar_power``. The discovery already
-        # capped the slot count at 4, so the loop is O(≤4).
+        # capped the slot count at 4, so the loop is O(≤4). Sources
+        # may be either a direct power entity (str) or a V+I sibling
+        # pair (tuple) — the per-cycle helper handles both.
         if len(self._pv_strings) >= 2:
-            for slot, entity_id in self._pv_strings.items():
-                readings.solar_power_per_string[slot] = self._read_sensor(
-                    entity_id, f"pv_{slot}",
+            for slot, source in self._pv_strings.items():
+                readings.solar_power_per_string[slot] = self._read_pv_string_source(
+                    slot, source,
                 )
 
         # Grid power from Energy Dashboard.

--- a/docs/PV_STRINGS.md
+++ b/docs/PV_STRINGS.md
@@ -55,6 +55,34 @@ a different pattern, file a [GitHub
 issue](https://github.com/traktore-org/sem-community/issues) with
 your entity IDs and we'll add the regex.
 
+## V+I synthesis fallback
+
+Some integrations expose per-string voltage and current but not
+power directly — typically Modbus-based drivers. The most common
+case in the SEM user base is **Huawei Solar Modbus** which
+publishes `sensor.inverter_pv_1_spannung` (V) and
+`sensor.inverter_pv_1_strom` (A) per string but no `pv_1_power`.
+
+SEM handles this automatically. After the direct-power discovery
+runs, a parallel `hardware_detection.discover_pv_string_vi_pairs`
+walks the same registry looking for sibling V+I pairs matching:
+
+| Quantity | Patterns matched |
+|---|---|
+| Voltage | `*_pvN_voltage`, `*_pvN_spannung`, `*_pvN_volt`, `*_mpptN_voltage`, `*_stringN_voltage` (and German equivalents) |
+| Current | `*_pvN_current`, `*_pvN_strom`, `*_pvN_amp`, `*_mpptN_current`, `*_stringN_current` (and German equivalents) |
+
+When a complete V+I pair is found for slot N, SEM multiplies
+V × I at read time to synthesise the per-string watts.
+Downstream consumers (cards, energy accumulator, sum invariant)
+don't know which way the value was sourced.
+
+**Conflict resolution**: when the same slot has BOTH a direct
+power sensor AND a V+I pair, the direct power sensor wins.
+It's a real measurement; the V+I synthesis is a computed
+fallback, slightly less accurate because it doesn't include
+the inverter's own MPPT-efficiency math.
+
 ## How discovery works
 
 1. Discovery runs once at integration setup

--- a/hardware_detection.py
+++ b/hardware_detection.py
@@ -1385,6 +1385,29 @@ _PV_STRING_PATTERNS: List[re.Pattern] = [
     re.compile(r"string[_\s]*(\d+)[_\s]*(?:power|watt)", re.IGNORECASE),
 ]
 
+# v1.7.0 V+I synthesis: some integrations (Huawei Solar Modbus, several
+# Modbus-only inverter brands) expose ``pv_N_voltage`` and
+# ``pv_N_current`` per string but no ``pv_N_power``. When these pairs
+# are discovered, SEM multiplies V × I at read time in
+# ``sensor_reader`` to synthesise the per-string power. Same slot
+# scheme (``pv1``, ``pv2``, …) and same len ≥ 2 gate as direct-power
+# discovery.
+#
+# Voltage / current names vary by integration locale:
+#   English: voltage / current
+#   German:  spannung / strom         (e.g. huawei_solar)
+#   Volt/Amp short forms also accepted
+_PV_VOLTAGE_PATTERNS: List[re.Pattern] = [
+    re.compile(r"pv[_\s]*(\d+)[_\s]*(?:voltage|spannung|volt)\b", re.IGNORECASE),
+    re.compile(r"mppt[_\s]*(\d+)[_\s]*(?:voltage|spannung|volt)\b", re.IGNORECASE),
+    re.compile(r"string[_\s]*(\d+)[_\s]*(?:voltage|spannung|volt)\b", re.IGNORECASE),
+]
+_PV_CURRENT_PATTERNS: List[re.Pattern] = [
+    re.compile(r"pv[_\s]*(\d+)[_\s]*(?:current|strom|amp)\b", re.IGNORECASE),
+    re.compile(r"mppt[_\s]*(\d+)[_\s]*(?:current|strom|amp)\b", re.IGNORECASE),
+    re.compile(r"string[_\s]*(\d+)[_\s]*(?:current|strom|amp)\b", re.IGNORECASE),
+]
+
 
 def discover_pv_strings_from_registry(
     hass: HomeAssistant,
@@ -1478,6 +1501,123 @@ def discover_pv_strings_from_registry(
         return result
 
     return {}
+
+
+def discover_pv_string_vi_pairs(
+    hass: "HomeAssistant",
+    energy_dashboard_config,
+) -> Dict[str, Tuple[str, str]]:
+    """Auto-discover per-string voltage+current sensor pairs (v1.7.0).
+
+    Companion to ``discover_pv_strings_from_registry``. Some integrations
+    (Huawei Solar Modbus, generic Modbus drivers, several other
+    Modbus-only inverter brands) expose ``pv_N_voltage`` and
+    ``pv_N_current`` per string but DO NOT publish a pre-multiplied
+    ``pv_N_power`` sensor. Detected on HA-PROD 2026-06-01:
+    ``sensor.inverter_pv_1_spannung`` + ``..._strom`` are there, but
+    no ``pv_1_power`` — direct-power discovery comes back empty.
+
+    This function fills the gap. The caller (coordinator) calls BOTH
+    functions; ``sensor_reader`` reads either form at runtime. When V
+    and I pair are stored, SEM multiplies them every cycle to
+    synthesise the per-string watts.
+
+    Args:
+        hass: Home Assistant instance.
+        energy_dashboard_config: ``EnergyDashboardConfig`` (same seed
+            as the direct-power discovery).
+
+    Returns:
+        Dict mapping slot label (``"pv1"``, ``"pv2"``, …) to a tuple
+        ``(voltage_entity_id, current_entity_id)``. Empty dict when
+        no pairs are found, fewer than 2 complete pairs are found, or
+        the seed is unavailable. Max 4 entries.
+
+    Why fewer-than-2 returns empty:
+        The downstream sensor surface is gated on ``len(strings) >= 2``
+        anyway (single-string users see no per-string entities — the
+        fleet ``sensor.sem_solar_power`` is authoritative there).
+        Returning ``{}`` early keeps the coordinator path consistent
+        with the direct-power discovery's gate semantics.
+    """
+    if energy_dashboard_config is None:
+        return {}
+
+    seed_candidates = [
+        getattr(energy_dashboard_config, "solar_power", None),
+        getattr(energy_dashboard_config, "solar_energy", None),
+    ]
+    seed_candidates = [s for s in seed_candidates if s]
+    if not seed_candidates:
+        return {}
+
+    entity_reg = entity_registry.async_get(hass)
+    seed_entry = None
+    for seed in seed_candidates:
+        entry = entity_reg.async_get(seed)
+        if entry is not None:
+            seed_entry = entry
+            break
+
+    if seed_entry is None or not seed_entry.platform:
+        return {}
+
+    platform = seed_entry.platform
+    config_entry_id = seed_entry.config_entry_id
+
+    # Collect candidate sibling sensors. Same scoping rule as
+    # ``discover_pv_strings_from_registry`` — same integration, same
+    # config entry — so cross-integration entities can't false-pair.
+    siblings: List[str] = []
+    for entry in entity_reg.entities.values():
+        if entry.platform != platform:
+            continue
+        if entry.disabled_by:
+            continue
+        if not entry.entity_id.startswith("sensor."):
+            continue
+        if config_entry_id and entry.config_entry_id != config_entry_id:
+            continue
+        siblings.append(entry.entity_id)
+
+    # Match voltage candidates per string number.
+    voltages: Dict[int, str] = {}
+    for eid in siblings:
+        for pat in _PV_VOLTAGE_PATTERNS:
+            m = pat.search(eid)
+            if m:
+                n = int(m.group(1))
+                if 1 <= n <= 4 and n not in voltages:
+                    voltages[n] = eid
+                break
+
+    # Match current candidates per string number.
+    currents: Dict[int, str] = {}
+    for eid in siblings:
+        for pat in _PV_CURRENT_PATTERNS:
+            m = pat.search(eid)
+            if m:
+                n = int(m.group(1))
+                if 1 <= n <= 4 and n not in currents:
+                    currents[n] = eid
+                break
+
+    # Intersect — only strings with BOTH V and I get returned.
+    paired = {n: (voltages[n], currents[n]) for n in voltages if n in currents}
+    if len(paired) < 2:
+        return {}
+
+    result = {
+        f"pv{n}": pair
+        for n, pair in sorted(paired.items())
+    }
+    for slot, (v_eid, c_eid) in result.items():
+        _LOGGER.info(
+            "PV string %s V+I pair detected: V=%s I=%s (platform=%s) "
+            "— SEM will synthesise power = V × I at read time",
+            slot, v_eid, c_eid, platform,
+        )
+    return result
 
 
 # ============================================================

--- a/tests/test_pv_string_vi_synthesis.py
+++ b/tests/test_pv_string_vi_synthesis.py
@@ -1,0 +1,322 @@
+"""Tests for v1.7.0 V+I → P synthesis (#312, HA-PROD 2026-06-01).
+
+Background. Several inverter integrations expose per-string voltage
+and current sensors but no per-string power. Huawei Solar Modbus
+(confirmed on HA-PROD: ``sensor.inverter_pv_1_spannung`` +
+``sensor.inverter_pv_1_strom`` exist, ``..._power`` does not) is the
+motivating case; generic Modbus drivers and Solarman-based bridges
+behave the same.
+
+Without these tests, v1.7.0 would silently leave Huawei users with
+zero per-string sensors. The discovery's direct-power regex finds
+nothing, the gate ``len >= 2`` holds zero, the sensor surface
+stays empty — correct behaviour but useless on the most common
+inverter brand in SEM's user base.
+
+These tests pin three layers:
+
+1. ``discover_pv_string_vi_pairs`` matches sibling V+I sensor pairs
+   in the entity registry, gated on the same seed-platform rule
+   as direct-power discovery.
+2. ``SensorReader.set_pv_strings`` accepts the V+I map alongside
+   the direct-power map; direct power wins on slot collisions.
+3. ``SensorReader._read_pv_string_source`` multiplies V × I at read
+   time for tuple-shaped sources; direct power entities use the
+   legacy fast path.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.hardware_detection import (
+    _PV_CURRENT_PATTERNS,
+    _PV_VOLTAGE_PATTERNS,
+)
+
+
+class TestPatterns:
+    """Regex matching for the V and I sibling patterns."""
+
+    @pytest.mark.parametrize("eid,expected_n", [
+        ("sensor.inverter_pv_1_spannung", 1),     # Huawei German
+        ("sensor.inverter_pv1_voltage", 1),       # English
+        ("sensor.inverter_pv_2_volt", 2),
+        ("sensor.solar_mppt_1_voltage", 1),
+        ("sensor.solar_string_3_spannung", 3),
+    ])
+    def test_voltage_pattern_extracts_string_number(self, eid, expected_n):
+        for pat in _PV_VOLTAGE_PATTERNS:
+            m = pat.search(eid)
+            if m:
+                assert int(m.group(1)) == expected_n
+                return
+        pytest.fail(f"No voltage pattern matched {eid!r}")
+
+    @pytest.mark.parametrize("eid,expected_n", [
+        ("sensor.inverter_pv_1_strom", 1),        # Huawei German
+        ("sensor.inverter_pv1_current", 1),       # English
+        ("sensor.inverter_pv_2_amp", 2),
+        ("sensor.solar_mppt_1_current", 1),
+        ("sensor.solar_string_3_strom", 3),
+    ])
+    def test_current_pattern_extracts_string_number(self, eid, expected_n):
+        for pat in _PV_CURRENT_PATTERNS:
+            m = pat.search(eid)
+            if m:
+                assert int(m.group(1)) == expected_n
+                return
+        pytest.fail(f"No current pattern matched {eid!r}")
+
+    def test_power_entities_do_NOT_match_voltage_pattern(self):
+        """The direct-power patterns and the V+I patterns must not
+        overlap — same entity matching both would double-count."""
+        for eid in ("sensor.inverter_pv_1_power", "sensor.inverter_mppt_1_power"):
+            for pat in _PV_VOLTAGE_PATTERNS:
+                assert pat.search(eid) is None, (
+                    f"{eid} should NOT match voltage pattern {pat.pattern!r}"
+                )
+
+
+class TestSensorReaderVISynthesis:
+    """``SensorReader._read_pv_string_source`` multiplies V × I for
+    tuple-shaped sources; direct power entities take the legacy path."""
+
+    def _make_reader(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        sr = SensorReader.__new__(SensorReader)
+        sr._sensor_unavailable = set()
+        sr.hass = MagicMock()
+        # _read_sensor reads from hass.states[entity].state. We mock it
+        # to return whatever the caller stashed in ``_mock_values``.
+        sr._mock_values = {}
+
+        def mock_read(entity_id, _purpose):
+            return float(sr._mock_values.get(entity_id, 0.0))
+
+        sr._read_sensor = mock_read
+        return sr
+
+    def test_direct_power_source_passes_through(self):
+        sr = self._make_reader()
+        sr._mock_values["sensor.inverter_pv_1_power"] = 3500.0
+        # str source → direct read path
+        watts = sr._read_pv_string_source("pv1", "sensor.inverter_pv_1_power")
+        assert watts == pytest.approx(3500.0)
+
+    def test_vi_pair_multiplies_at_read(self):
+        sr = self._make_reader()
+        # Huawei PROD layout: V on string 1 = 480 V, I = 7.5 A → 3600 W
+        sr._mock_values["sensor.inverter_pv_1_spannung"] = 480.0
+        sr._mock_values["sensor.inverter_pv_1_strom"] = 7.5
+        watts = sr._read_pv_string_source(
+            "pv1",
+            ("sensor.inverter_pv_1_spannung", "sensor.inverter_pv_1_strom"),
+        )
+        assert watts == pytest.approx(3600.0)
+
+    def test_vi_pair_zero_when_either_missing_or_zero(self):
+        """If V or I is 0/unavailable (night, fault), the product is 0
+        — no negative or NaN leaking through."""
+        sr = self._make_reader()
+        sr._mock_values["sensor.inverter_pv_1_spannung"] = 480.0
+        sr._mock_values["sensor.inverter_pv_1_strom"] = 0.0
+        watts = sr._read_pv_string_source(
+            "pv1",
+            ("sensor.inverter_pv_1_spannung", "sensor.inverter_pv_1_strom"),
+        )
+        assert watts == 0.0
+
+
+class TestSensorReaderSetPVStrings:
+    """``set_pv_strings`` accepts both direct-power and V+I maps and
+    stores them in the same ``_pv_strings`` dict, with the direct-
+    power form winning on slot collisions."""
+
+    def _make_reader(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        return SensorReader.__new__(SensorReader)
+
+    def test_direct_power_only(self):
+        sr = self._make_reader()
+        sr.set_pv_strings({
+            "pv1_power": "sensor.inverter_pv_1_power",
+            "pv2_power": "sensor.inverter_pv_2_power",
+        })
+        assert sr._pv_strings == {
+            "pv1": "sensor.inverter_pv_1_power",
+            "pv2": "sensor.inverter_pv_2_power",
+        }
+
+    def test_vi_pairs_only(self):
+        sr = self._make_reader()
+        sr.set_pv_strings({}, {
+            "pv1": ("sensor.inverter_pv_1_spannung",
+                    "sensor.inverter_pv_1_strom"),
+            "pv2": ("sensor.inverter_pv_2_spannung",
+                    "sensor.inverter_pv_2_strom"),
+        })
+        assert sr._pv_strings == {
+            "pv1": ("sensor.inverter_pv_1_spannung",
+                    "sensor.inverter_pv_1_strom"),
+            "pv2": ("sensor.inverter_pv_2_spannung",
+                    "sensor.inverter_pv_2_strom"),
+        }
+
+    def test_mixed_direct_power_wins_on_collision(self):
+        """When the same slot has BOTH a direct power AND a V+I pair,
+        the direct sensor wins — it's a real measurement, the V+I
+        synthesis is a computed fallback. Matches the contract in
+        ``set_pv_strings``'s docstring."""
+        sr = self._make_reader()
+        sr.set_pv_strings(
+            {"pv1_power": "sensor.real_pv1_power"},
+            {"pv1": ("sensor.fake_voltage", "sensor.fake_current")},
+        )
+        assert sr._pv_strings == {"pv1": "sensor.real_pv1_power"}
+
+    def test_mixed_non_collision_merges(self):
+        sr = self._make_reader()
+        sr.set_pv_strings(
+            {"pv1_power": "sensor.real_pv1_power"},
+            {"pv2": ("sensor.pv2_v", "sensor.pv2_i")},
+        )
+        assert sr._pv_strings == {
+            "pv1": "sensor.real_pv1_power",
+            "pv2": ("sensor.pv2_v", "sensor.pv2_i"),
+        }
+
+    def test_empty_vi_pair_skipped(self):
+        """Malformed V+I tuples (one entity missing) shouldn't pollute
+        the slot map."""
+        sr = self._make_reader()
+        sr.set_pv_strings({}, {
+            "pv1": ("sensor.pv1_v", ""),  # missing current
+            "pv2": ("", "sensor.pv2_i"),  # missing voltage
+            "pv3": (),                    # empty tuple
+        })
+        assert sr._pv_strings == {}
+
+
+class TestDiscoveryFunction:
+    """The discovery walks the entity registry; this exercises it
+    against a small fake registry stub."""
+
+    def _make_hass(self, entries):
+        """``entries`` is a list of dicts with ``entity_id``,
+        ``platform``, ``config_entry_id`` (default None),
+        ``disabled_by`` (default None)."""
+        hass = MagicMock()
+
+        class FakeEntry:
+            def __init__(self, eid, platform, config_entry_id=None, disabled_by=None):
+                self.entity_id = eid
+                self.platform = platform
+                self.config_entry_id = config_entry_id
+                self.disabled_by = disabled_by
+
+        entries_objs = [
+            FakeEntry(
+                e["entity_id"], e["platform"],
+                e.get("config_entry_id"), e.get("disabled_by"),
+            )
+            for e in entries
+        ]
+
+        registry = MagicMock()
+
+        def get(entity_id):
+            for e in entries_objs:
+                if e.entity_id == entity_id:
+                    return e
+            return None
+        registry.async_get = get
+        registry.entities = MagicMock()
+        registry.entities.values = lambda: entries_objs
+
+        # Patch the global registry getter.
+        from custom_components.solar_energy_management import hardware_detection
+        from unittest.mock import patch
+        return hass, patch.object(
+            hardware_detection.entity_registry,
+            "async_get",
+            return_value=registry,
+        )
+
+    def test_huawei_layout_finds_vi_pairs(self):
+        """The PROD-observed Huawei layout — German names, no power
+        sensors — should yield 2 V+I pairs."""
+        from custom_components.solar_energy_management.hardware_detection import (
+            discover_pv_string_vi_pairs,
+        )
+        hass, patcher = self._make_hass([
+            {"entity_id": "sensor.inverter_eingangsleistung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_1_spannung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_1_strom", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_2_spannung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_2_strom", "platform": "huawei_solar"},
+        ])
+        ed_config = MagicMock(
+            solar_power="sensor.inverter_eingangsleistung",
+            solar_energy=None,
+        )
+        with patcher:
+            result = discover_pv_string_vi_pairs(hass, ed_config)
+        assert result == {
+            "pv1": ("sensor.inverter_pv_1_spannung", "sensor.inverter_pv_1_strom"),
+            "pv2": ("sensor.inverter_pv_2_spannung", "sensor.inverter_pv_2_strom"),
+        }
+
+    def test_returns_empty_when_seed_missing(self):
+        from custom_components.solar_energy_management.hardware_detection import (
+            discover_pv_string_vi_pairs,
+        )
+        hass, patcher = self._make_hass([])
+        with patcher:
+            # No ed_config → empty
+            assert discover_pv_string_vi_pairs(hass, None) == {}
+            # ed_config with no solar source → empty
+            empty = MagicMock(solar_power=None, solar_energy=None)
+            assert discover_pv_string_vi_pairs(hass, empty) == {}
+
+    def test_returns_empty_when_fewer_than_2_pairs(self):
+        """Single-string installs aren't worth a per-string surface —
+        the v1.7.0 gate is ``len >= 2``. Return empty before SEM
+        creates a misleading single-entity row."""
+        from custom_components.solar_energy_management.hardware_detection import (
+            discover_pv_string_vi_pairs,
+        )
+        hass, patcher = self._make_hass([
+            {"entity_id": "sensor.inverter_eingangsleistung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_1_spannung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_1_strom", "platform": "huawei_solar"},
+        ])
+        ed_config = MagicMock(
+            solar_power="sensor.inverter_eingangsleistung",
+            solar_energy=None,
+        )
+        with patcher:
+            assert discover_pv_string_vi_pairs(hass, ed_config) == {}
+
+    def test_returns_empty_when_only_voltage_present(self):
+        """Voltage without matching current → no pair. Return empty."""
+        from custom_components.solar_energy_management.hardware_detection import (
+            discover_pv_string_vi_pairs,
+        )
+        hass, patcher = self._make_hass([
+            {"entity_id": "sensor.inverter_eingangsleistung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_1_spannung", "platform": "huawei_solar"},
+            {"entity_id": "sensor.inverter_pv_2_spannung", "platform": "huawei_solar"},
+            # No _strom entries
+        ])
+        ed_config = MagicMock(
+            solar_power="sensor.inverter_eingangsleistung",
+            solar_energy=None,
+        )
+        with patcher:
+            assert discover_pv_string_vi_pairs(hass, ed_config) == {}


### PR DESCRIPTION
HA-PROD 2026-06-01 deploy surfaced the gap: Huawei Solar Modbus publishes ``sensor.inverter_pv_1_spannung`` (V) + ``..._strom`` (A) per string but no ``..._power``. v1.7.0's direct-power discovery found 0 strings on PROD — silent gate hold, no per-string sensors. This patch closes the gap so Huawei users (probably the dominant inverter brand in SEM's user base) get the v1.7.0 feature working.

Stays as v1.7.0 — release hasn't published to HACS yet (still soaking on PROD).

## Summary

- New ``discover_pv_string_vi_pairs(hass, ed_config)`` companion to ``discover_pv_strings_from_registry``. Same seed-platform scoping; walks for ``pv_N_voltage`` + ``pv_N_current`` sibling pairs.
- Voltage / current patterns accept English (``voltage`` / ``current`` / ``volt`` / ``amp``) and German (``spannung`` / ``strom``) — handles huawei_solar's German entity naming directly.
- ``sensor_reader._read_pv_string_source`` multiplies V × I at read time for tuple sources; direct power wins on slot collisions (real measurement preferred over computed synthesis).
- Coordinator wires both discovery functions; INFO log distinguishes ``N direct power, N V+I pairs`` for debuggability.

## Tests (23 new, 2304 total)

``tests/test_pv_string_vi_synthesis.py``:
- 7 pattern tests (English + German + negative-case anti-overlap)
- 3 synthesis tests (direct passthrough, Huawei-shape V × I = 3600 W, zero-input safety)
- 5 set_pv_strings tests (direct-only, V+I-only, collision-winner, merge, malformed)
- 4 discovery function tests (PROD-shape match, no seed, gate, voltage-only)

Full Python suite: 2304 green on Python 3.12 (2281 baseline + 23 new).

## Docs

- ``CHANGELOG.md`` v1.7.0 entry: V+I synthesis bullet added.
- ``docs/PV_STRINGS.md``: new "V+I synthesis fallback" section with V/I pattern table + conflict resolution rule.

## Test plan

- [x] 23 new + 2281 baseline = 2304 green on Python 3.12
- [x] No manifest bump (stays v1.7.0)
- [ ] CI green
- [ ] Re-deploy v1.7.0 to HA-PROD; verify ``sensor.sem_pv_string_pv1_power`` and ``_pv2_power`` now populate from the V × I synthesis (Huawei publishes ~480 V × 0–10 A per string in daylight)