### PR TITLE
fix(v1.7.0): autarky + cost-savings use flow attribution

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -951,15 +951,38 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     _LOGGER.warning("Tariff rate update failed; using previous rates: %s", e)
                     self._tariff_rate_warned = True
 
-            # Step 2: Calculate energy from power integration
-            energy = self._energy_calculator.calculate_energy(power)
-
-            # Step 3: Calculate costs and performance
-            costs = self._energy_calculator.calculate_costs(energy)
-            performance = self._energy_calculator.calculate_performance(power, energy)
-
-            # Step 4: Calculate power flows (instantaneous)
+            # Step 2a: Compute instantaneous power flows FIRST. v1.7.0
+            # reorder — the autarky + cost-savings calculators need the
+            # flow-attributed values (``solar_to_home``, ``grid_to_home``
+            # etc.) so we can distinguish "grid → home" from "grid →
+            # battery". Without this, autarky on HA-PROD was reading 0 %
+            # any time the battery had been overnight-grid-charged
+            # (raw ``daily_grid_import`` includes the battery-bound
+            # slice; the flow attribution doesn't).
             power_flows = self._flow_calculator.calculate_power_flows(power)
+
+            # Step 2b: Calculate energy from power integration. The
+            # solar-self-consumed cost-savings accumulator inside
+            # ``calculate_energy`` now uses ``power_flows.solar_to_home
+            # + solar_to_ev`` directly instead of the legacy
+            # subtraction heuristic. See the note inside the function.
+            energy = self._energy_calculator.calculate_energy(power, power_flows)
+
+            # Step 2c: Time-integrate the per-cycle flows into daily
+            # kWh totals. ``energy_flows.grid_to_home + grid_to_ev``
+            # feeds the autarky calculator below.
+            energy_flows = self._flow_calculator.integrate_energy_flows(
+                power_flows, self.update_interval.total_seconds(),
+            )
+
+            # Step 3: Calculate costs and performance. ``performance``
+            # gets ``energy_flows`` so autarky uses the
+            # flow-attributed grid-to-consumption rather than raw
+            # grid_import.
+            costs = self._energy_calculator.calculate_costs(energy)
+            performance = self._energy_calculator.calculate_performance(
+                power, energy, energy_flows,
+            )
 
             # Step 4.5: Update session tracking (before charging decisions)
             # Multi-charger (#112): track sessions for each charger
@@ -1067,15 +1090,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             ev_intelligence = self._update_ev_intelligence(power, energy)
             self._last_ev_intelligence = ev_intelligence  # For notifications (#106)
 
-            # Step 5: Integrate energy flows from this cycle's instantaneous
-            # power_flows (#282). Replaces the legacy daily proportional
-            # allocation (calculate_energy_flows) which credited solar to the
-            # EV even when the EV wasn't drawing. The integrated version
-            # matches the session attribution: small honest numbers that
-            # reflect what physically happened, not a daily average.
-            energy_flows = self._flow_calculator.integrate_energy_flows(
-                power_flows, self.update_interval.total_seconds(),
-            )
+            # (``energy_flows`` was already computed up at step 2c so
+            # ``calculate_performance`` could feed the autarky calculator
+            # with flow-attributed grid_to_home + grid_to_ev. The
+            # legacy step-5 ``integrate_energy_flows`` call here was
+            # removed in v1.7.0 to avoid double-integration.)
 
             # Step 6: Build the charging context. The canonical EV budget
             # is computed inside (#282 unification, Phase B+D) and cached

--- a/coordinator/energy_calculator.py
+++ b/coordinator/energy_calculator.py
@@ -9,7 +9,10 @@ from typing import Dict, Any, Optional
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .types import PowerReadings, EnergyTotals, CostData, PerformanceMetrics
+from .types import (
+    PowerReadings, EnergyTotals, CostData, PerformanceMetrics,
+    PowerFlows, EnergyFlows,
+)
 from ..utils.time_manager import TimeManager
 
 _LOGGER = logging.getLogger(__name__)
@@ -112,7 +115,10 @@ class EnergyCalculator:
         latest = max(deadlines)
         return self._time_manager.get_current_meter_day_offset_based(latest)
 
-    def calculate_energy(self, power: PowerReadings) -> EnergyTotals:
+    def calculate_energy(
+        self, power: PowerReadings,
+        power_flows: "Optional[PowerFlows]" = None,
+    ) -> EnergyTotals:
         """Calculate energy totals by integrating power over time."""
         now = dt_util.now()
         today = now.date()  # Midnight-based reset — matches HA Energy Dashboard
@@ -220,15 +226,33 @@ class EnergyCalculator:
 
         # Solar self-consumption savings (incremental, rate-weighted for dynamic tariff accuracy)
         # Only tracks savings from solar — battery discharge savings are in cost_batt_savings.
-        # Subtracting discharge_incr prevents double-counting: battery discharge is not solar.
-        home_incr = (power.home_consumption_power * interval_hours) / 1000 if power.home_consumption_power >= MIN_POWER_THRESHOLD else 0.0
-        # FLEET-READ: same fleet-energy integration as ``ev_daily_sun``
-        # above, applied here to the cost-savings accumulator.
-        ev_incr = (power.ev_power * interval_hours) / 1000 if power.ev_power >= MIN_POWER_THRESHOLD else 0.0
-        import_incr = (power.grid_import_power * interval_hours) / 1000 if power.grid_import_power >= MIN_POWER_THRESHOLD else 0.0
-        discharge_incr = (power.battery_discharge_power * interval_hours) / 1000 if power.battery_discharge_power >= MIN_POWER_THRESHOLD else 0.0
-        # Solar self-consumed = total consumption minus what came from grid or battery discharge
-        solar_self_consumed = max(0.0, (home_incr + ev_incr) - import_incr - discharge_incr)
+        #
+        # v1.7.0: use flow-attributed solar_to_home + solar_to_ev when
+        # ``power_flows`` is passed (computed by ``calculate_power_flows``).
+        # The legacy subtraction heuristic
+        # ``(home + ev) - import - discharge`` undercounts savings whenever
+        # the grid is simultaneously charging the battery (cheap-tariff
+        # daytime, mixed solar+grid moments) because ``import_incr`` is the
+        # raw grid pull — including the grid → battery slice that DIDN'T
+        # displace any home consumption. Same bug class as the autarky
+        # mis-attribution; see ``calculate_performance`` for the symmetric
+        # fix.
+        if power_flows is not None:
+            solar_self_consumed = (
+                ((power_flows.solar_to_home + power_flows.solar_to_ev)
+                 * interval_hours) / 1000
+            )
+        else:
+            home_incr = (power.home_consumption_power * interval_hours) / 1000 if power.home_consumption_power >= MIN_POWER_THRESHOLD else 0.0
+            # FLEET-READ: legacy fallback path. ``power_flows`` is the
+            # preferred input in the v1.7.0+ coordinator pipeline; this
+            # branch only fires for the two-arg test fixtures that
+            # pre-date the per-cycle ``calculate_power_flows`` call.
+            ev_incr = (power.ev_power * interval_hours) / 1000 if power.ev_power >= MIN_POWER_THRESHOLD else 0.0
+            import_incr = (power.grid_import_power * interval_hours) / 1000 if power.grid_import_power >= MIN_POWER_THRESHOLD else 0.0
+            discharge_incr = (power.battery_discharge_power * interval_hours) / 1000 if power.battery_discharge_power >= MIN_POWER_THRESHOLD else 0.0
+            # Solar self-consumed = total consumption minus what came from grid or battery discharge
+            solar_self_consumed = max(0.0, (home_incr + ev_incr) - import_incr - discharge_incr)
         if solar_self_consumed > 0.0:
             self._accumulate_cost("cost_savings", today, month_key, year_key, solar_self_consumed * self._import_rate)
 
@@ -730,12 +754,30 @@ class EnergyCalculator:
         return costs
 
     def calculate_performance(
-        self, power: PowerReadings, energy: EnergyTotals
+        self, power: PowerReadings, energy: EnergyTotals,
+        energy_flows: "Optional[EnergyFlows]" = None,
     ) -> PerformanceMetrics:
-        """Calculate performance metrics."""
+        """Calculate performance metrics.
+
+        ``energy_flows`` (v1.7.0+ — optional for back-compat with the
+        legacy two-arg call shape) provides flow-attributed daily
+        kWh totals. When supplied, the autarky calculation uses
+        ``grid_to_home + grid_to_ev`` instead of the raw
+        ``daily_grid_import``. The legacy formula treated every kWh
+        imported from the grid as a penalty against autarky — but a
+        kWh that flowed grid → battery (e.g. overnight cheap-tariff
+        charging) doesn't reduce the home's own-supply share. Live
+        evidence captured on HA-PROD 2026-06-01: 9.38 kWh grid_import
+        with 2.9 kWh going to the battery left autarky pinned at 0 %
+        while self_consumption was 98.1 % — clearly the formula was
+        mis-attributing the grid → battery slice.
+        """
         metrics = PerformanceMetrics()
 
-        # Self consumption rate = (solar - export) / solar
+        # Self consumption rate = (solar - export) / solar — direction-of-
+        # flow-agnostic; whatever solar didn't go to the grid was
+        # consumed locally (by home, battery, or EV). No flow attribution
+        # needed.
         if energy.daily_solar > 0:
             solar_used = energy.daily_solar - energy.daily_grid_export
             metrics.self_consumption_rate = round(
@@ -743,10 +785,21 @@ class EnergyCalculator:
             )
             metrics.self_consumption_rate = max(0, min(100, metrics.self_consumption_rate))
 
-        # Autarky rate = (consumption - import) / consumption
+        # Autarky rate = (consumption - grid-to-consumption) / consumption.
+        # Use the flow-attributed grid_to_home + grid_to_ev when
+        # available; fall back to the legacy raw daily_grid_import for
+        # callers that don't yet pass energy_flows (kept for the v1.6.x
+        # test fixtures + any external integration).
         total_consumption = energy.daily_home + energy.daily_ev
         if total_consumption > 0:
-            own_supply = total_consumption - energy.daily_grid_import
+            if energy_flows is not None:
+                grid_to_consumption = (
+                    getattr(energy_flows, "grid_to_home", 0.0)
+                    + getattr(energy_flows, "grid_to_ev", 0.0)
+                )
+            else:
+                grid_to_consumption = energy.daily_grid_import
+            own_supply = total_consumption - grid_to_consumption
             metrics.autarky_rate = round((own_supply / total_consumption) * 100, 1)
             metrics.autarky_rate = max(0, min(100, metrics.autarky_rate))
 

--- a/tests/test_autarky_flow_attribution.py
+++ b/tests/test_autarky_flow_attribution.py
@@ -1,0 +1,180 @@
+"""Tests for v1.7.0 flow-attributed autarky + cost-savings (#PROD-2026-06-01).
+
+Background. SEM v1.6.x pinned ``autarky_rate`` at 0 % on HA-PROD
+whenever the battery had been overnight-grid-charged: the formula
+``(home - daily_grid_import) / home`` treats every imported kWh as a
+penalty against own-supply, but the grid-to-battery slice doesn't
+displace any home consumption. Symmetric bug in the cost-savings
+accumulator inside ``calculate_energy``.
+
+v1.7.0 fixes both by piping flow-attributed values from
+``FlowCalculator`` into the metric calculators.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.energy_calculator import (
+    EnergyCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    EnergyFlows,
+    EnergyTotals,
+    PowerFlows,
+    PowerReadings,
+)
+
+
+class TestAutarkyFlowAttribution:
+    """``calculate_performance`` autarky uses
+    ``energy_flows.grid_to_home + grid_to_ev`` when supplied."""
+
+    def _calc(self):
+        from unittest.mock import MagicMock
+        return EnergyCalculator(config={}, time_manager=MagicMock())
+
+    def test_prod_scenario_autarky_no_longer_zero(self):
+        """HA-PROD 2026-06-01: home 9.25 kWh, grid_import 9.38 kWh,
+        of which 2.9 went to battery. Pre-fix the formula gave
+        autarky=0 % because raw grid_import > home. With flow
+        attribution the battery-bound slice is excluded."""
+        calc = self._calc()
+        energy = EnergyTotals(
+            daily_home=9.25, daily_ev=0.0,
+            daily_grid_import=9.38, daily_grid_export=0.12,
+            daily_battery_charge=2.9, daily_battery_discharge=3.42,
+            daily_solar=6.18,
+        )
+        flows = EnergyFlows(
+            grid_to_home=6.48, grid_to_ev=0.0,
+            grid_to_battery=2.9,
+        )
+        metrics = calc.calculate_performance(PowerReadings(), energy, flows)
+        # autarky = (9.25 - 6.48) / 9.25 = 29.9 %
+        assert metrics.autarky_rate == pytest.approx(29.9, abs=0.1)
+
+    def test_legacy_call_still_works_no_flows(self):
+        """Two-arg call without ``energy_flows`` → legacy formula."""
+        calc = self._calc()
+        energy = EnergyTotals(
+            daily_home=10.0, daily_ev=0.0,
+            daily_grid_import=3.0, daily_solar=8.0,
+        )
+        metrics = calc.calculate_performance(PowerReadings(), energy)
+        # legacy: (10 - 3) / 10 = 70 %
+        assert metrics.autarky_rate == pytest.approx(70.0, abs=0.1)
+
+    def test_autarky_100_when_no_grid_to_consumption(self):
+        """All grid import went to battery — autarky pinned at 100 %."""
+        calc = self._calc()
+        energy = EnergyTotals(
+            daily_home=5.0, daily_ev=0.0,
+            daily_grid_import=2.0, daily_solar=8.0,
+        )
+        flows = EnergyFlows(grid_to_home=0.0, grid_to_ev=0.0, grid_to_battery=2.0)
+        metrics = calc.calculate_performance(PowerReadings(), energy, flows)
+        assert metrics.autarky_rate == pytest.approx(100.0)
+
+    def test_autarky_clamps_to_zero_on_negative(self):
+        """Edge: if grid_to_home > home (sensor lag, rounding), clamp to 0."""
+        calc = self._calc()
+        energy = EnergyTotals(daily_home=5.0, daily_ev=0.0)
+        flows = EnergyFlows(grid_to_home=7.0, grid_to_ev=0.0)
+        metrics = calc.calculate_performance(PowerReadings(), energy, flows)
+        assert metrics.autarky_rate == 0.0
+
+    def test_autarky_includes_ev_grid_consumption(self):
+        """EV charged from grid counts as grid_to_consumption too."""
+        calc = self._calc()
+        energy = EnergyTotals(
+            daily_home=5.0, daily_ev=10.0,
+            daily_grid_import=12.0,
+        )
+        flows = EnergyFlows(
+            grid_to_home=4.0, grid_to_ev=6.0, grid_to_battery=2.0,
+        )
+        # total_consumption=15, grid_to_consumption=10 → autarky=33.3 %
+        metrics = calc.calculate_performance(PowerReadings(), energy, flows)
+        assert metrics.autarky_rate == pytest.approx(33.3, abs=0.1)
+
+    def test_self_consumption_unaffected_by_flows(self):
+        """self_consumption_rate is (solar - export) / solar; flow
+        attribution should not change it."""
+        calc = self._calc()
+        energy = EnergyTotals(daily_solar=10.0, daily_grid_export=2.0)
+        m_with = calc.calculate_performance(
+            PowerReadings(), energy, EnergyFlows(grid_to_home=0.0),
+        )
+        m_without = calc.calculate_performance(PowerReadings(), energy)
+        assert m_with.self_consumption_rate == pytest.approx(80.0)
+        assert m_without.self_consumption_rate == pytest.approx(80.0)
+
+
+class TestCostSavingsFlowAttribution:
+    """``calculate_energy`` solar-self-consumption savings use
+    flow-attributed solar_to_home + solar_to_ev when supplied."""
+
+    def _calc(self):
+        from unittest.mock import MagicMock
+        calc = EnergyCalculator(config={}, time_manager=MagicMock())
+        calc._import_rate = 0.25
+        return calc
+
+    def _make_power(self, **kw):
+        p = PowerReadings()
+        for k, v in kw.items():
+            setattr(p, k, v)
+        return p
+
+    def test_flow_path_credits_solar_during_grid_to_battery(self):
+        """The motivating case: grid charges battery (4 kW) while
+        solar covers home (500 W). Legacy heuristic gives 0 savings
+        (500 − 4000 < 0); flow path credits the 500 W correctly."""
+        from datetime import date
+        calc_legacy = self._calc()
+        calc_flow = self._calc()
+        # Configure for a 10 s update interval so the first-cycle
+        # branch in ``calculate_energy`` derives a known kWh delta
+        # without us having to fake datetime.
+        calc_legacy.config["update_interval"] = 10
+        calc_flow.config["update_interval"] = 10
+        power = self._make_power(
+            solar_power=4500.0, home_consumption_power=500.0,
+            grid_import_power=4000.0, battery_charge_power=8000.0,
+            battery_discharge_power=0.0, ev_power=0.0,
+        )
+        flows = PowerFlows(
+            solar_to_home=500.0, solar_to_ev=0.0,
+            grid_to_home=0.0, grid_to_ev=0.0,
+            grid_to_battery=4000.0,
+        )
+        calc_legacy.calculate_energy(power)
+        calc_flow.calculate_energy(power, flows)
+        today_key = f"cost_savings_{date.today()}"
+        legacy = calc_legacy._daily_cost_accumulators.get(today_key, 0.0)
+        flowed = calc_flow._daily_cost_accumulators.get(today_key, 0.0)
+        # legacy = 0 (the bug — 500 − 4000 clamps to 0).
+        assert legacy == 0.0
+        # flow-attributed > 0 (500 W × 10s / 3600 / 1000 × 0.25 ≈ 0.000347).
+        assert flowed > 0.0
+        # Sanity: the flow value matches the expected math.
+        expected = 500.0 * (10.0 / 3600.0) / 1000.0 * 0.25
+        assert flowed == pytest.approx(expected, rel=1e-2)
+
+    def test_legacy_fallback_works_without_flows(self):
+        """No ``power_flows`` → subtraction heuristic still runs."""
+        from datetime import date
+        calc = self._calc()
+        calc.config["update_interval"] = 10
+        power = self._make_power(
+            solar_power=5000.0, home_consumption_power=2000.0,
+            grid_import_power=0.0, battery_charge_power=3000.0,
+            battery_discharge_power=0.0, ev_power=0.0,
+        )
+        calc.calculate_energy(power)
+        today_key = f"cost_savings_{date.today()}"
+        savings = calc._daily_cost_accumulators.get(today_key, 0.0)
+        # legacy: home + ev − import − discharge = 2000 − 0 − 0 = 2000 W
+        # → 2000 × 10/3600/1000 × 0.25 ≈ 0.00139
+        expected = 2000.0 * (10.0 / 3600.0) / 1000.0 * 0.25
+        assert savings == pytest.approx(expected, rel=1e-2)


### PR DESCRIPTION
HA-PROD 2026-06-01 surfaced: sensor.sem_autarky_rate pinned at 0 % while self_consumption showed 98.1 %. Two related bugs, same root cause.

## Bugs

**Bug 1 — autarky_rate.** Formula treated raw daily_grid_import as a penalty against own-supply. But the grid → battery slice (overnight cheap-tariff fill) didn't displace any home consumption. PROD: home 9.25, import 9.38, battery_charge 2.9 → own_supply = 9.25 − 9.38 = −0.13, clamped to 0 %.

**Bug 2 — solar self-consumed cost savings.** solar_self_consumed = (home + ev) − import − discharge undercounts whenever grid charges the battery (cheap-tariff daytime): the battery-bound grid import doesn't displace any home consumption either.

## Fix

Both metrics now use flow-attributed values from FlowCalculator:

- calculate_performance(..., energy_flows=None) uses grid_to_home + grid_to_ev instead of daily_grid_import.
- calculate_energy(..., power_flows=None) uses solar_to_home + solar_to_ev directly instead of subtraction.
- Coordinator pipeline reordered so flows are computed before the metric calculators.
- Legacy two-arg / one-arg call shapes preserved for back-compat.

## What stays the same

- self_consumption_rate formula — already correct (direction-of-flow-agnostic).
- lifetime_grid_cost — correct (paid for all imports).
- daily_co2_avoided — correct.

## Tests (8 new, 2312 total)

- 6 tests pinning autarky with various flow attributions (PROD reproduction, 100 % case, clamp, EV grid consumption, legacy back-compat, self-consumption unaffected).
- 2 tests on cost-savings (motivating case + legacy fallback).

## Test plan

- [x] 8 new + 2304 baseline = 2312 green on Python 3.12
- [x] No manifest bump (v1.7.0 still soaking)
- [ ] CI green
- [ ] Re-deploy to HA-PROD; observe sensor.sem_autarky_rate recover to a realistic value once overnight battery-charging has flowed through the integrator.