### PR TITLE
fix(#346): solar_only must not charge at night (strategy mode-gate)

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2547,6 +2547,30 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         if not power.ev_connected:
             return ("idle", f"ev disconnected")
 
+        # Mode gate (#346): consult the per-charger named ``charge_mode``
+        # BEFORE the is_night_mode() branch. Pre-fix the night branch
+        # returned ``"night_grid"`` unconditionally, so a charger in
+        # ``solar_only`` or ``off`` mode silently inherited the MIN_PV
+        # floor (≈1380 W) at night — the state machine returned
+        # NIGHT_DISABLED in parallel, producing the v1.7.0 PROD bug
+        # (KEBA drew ~1.5 kW from battery/grid 22:07–00:48 while
+        # sensor.sem_charging_state showed "Night charging disabled").
+        # ``MODE_NIGHT_ALLOWED`` is the same set used by
+        # _read_night_enabled_raw — solar_only and off are not in it.
+        from ..consts.ev_charge_modes import MODE_NIGHT_ALLOWED
+        _mode_for_night = self._effective_charge_mode_for(charger_cfg or {})
+        if (
+            self.time_manager.is_night_mode()
+            and _mode_for_night not in MODE_NIGHT_ALLOWED
+        ):
+            if _mode_for_night == "off":
+                return ("disabled", "Charging disabled (mode=off)")
+            return (
+                "idle",
+                f"night mode but charge_mode={_mode_for_night} forbids "
+                f"grid charging",
+            )
+
         # Night mode → grid charging tops up to the floor (Min) (#245).
         # remaining_need above is already the Min-bound value (default bound="min").
         if self.time_manager.is_night_mode():

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -564,21 +564,29 @@ class EVControlMixin:
         if ev._session_active:
             await ev.stop_session()
         elif (
-            context.charging_strategy == "disabled"
+            context.charging_strategy in ("disabled", "idle")
             and self._this_charger_drawing_power(ev, power)
         ):
-            # User intent is mode=off but the charger is physically drawing
-            # real power that SEM doesn't own (#315). KEBA P30 is the
-            # canonical example: its firmware self-resumes on plug-in or
-            # after certain internal events using a stored setpoint,
-            # completely independent of SEM. Since SEM never started a
-            # session here, `_session_active` is False and the branch
-            # above is skipped, but the charger keeps drawing. Force-call
-            # stop_session to invoke the per-brand disable (e.g.
-            # ``keba.disable``) every cycle until ev_power drops below
-            # the 500 W threshold (handshake idle is 100–200 W; real
-            # charging starts at 4140 W). Idempotent — safe to call on
+            # User intent is mode=off (#315) or solar_only at night with no
+            # surplus (#346) — but the charger is physically drawing real
+            # power that SEM doesn't own. KEBA P30 is the canonical example:
+            # its firmware self-resumes on plug-in or after certain internal
+            # events using a stored setpoint, completely independent of SEM.
+            # Since SEM never started a session here, ``_session_active`` is
+            # False and the branch above is skipped, but the charger keeps
+            # drawing. Force-call stop_session to invoke the per-brand
+            # disable (e.g. ``keba.disable``) every cycle until ev_power
+            # drops below the 500 W threshold (handshake idle is 100–200 W;
+            # real charging starts at 4140 W). Idempotent — safe to call on
             # an already-disabled charger.
+            #
+            # #346 extended the trigger from {"disabled"} to {"disabled",
+            # "idle"} after a PROD incident where a solar_only KEBA
+            # self-resumed at 22:07 and drew 1.5 kW from the home battery
+            # till 00:48. With the strategy fix in coordinator.py honoring
+            # MODE_NIGHT_ALLOWED, solar_only at night now returns "idle";
+            # without this guard the actuator's terminal branch would still
+            # let the self-resumed session run.
             await ev.stop_session()
             # Suppress the per-cycle INFO log from stop_session() once
             # we've logged it for this self-resume episode. The
@@ -589,14 +597,15 @@ class EVControlMixin:
             # drops below threshold so the next episode is loud again.
             if getattr(self, "_off_mode_stop_logged_for", None) != ev.device_id:
                 _LOGGER.warning(
-                    "Charger %s self-resumed while mode=off (drawing %.0fW). "
+                    "Charger %s self-resumed while strategy=%s (drawing %.0fW). "
                     "Calling stop_session() — will re-assert every cycle "
-                    "until ev_power drops below 500W. (#315)",
-                    ev.name, self._this_charger_power(ev, power),
+                    "until ev_power drops below 500W. (#315/#346)",
+                    ev.name, context.charging_strategy,
+                    self._this_charger_power(ev, power),
                 )
                 self._off_mode_stop_logged_for = ev.device_id
         elif (
-            context.charging_strategy == "disabled"
+            context.charging_strategy in ("disabled", "idle")
             and getattr(self, "_off_mode_stop_logged_for", None) == ev.device_id
         ):
             # Charger settled below threshold — clear the log-suppression

--- a/tests/test_346_solar_only_night.py
+++ b/tests/test_346_solar_only_night.py
@@ -1,0 +1,147 @@
+"""Regression tests for #346 — solar_only mode must not charge at night.
+
+PROD incident 2026-05-31 22:07 → 00:48: a KEBA charger configured with
+``charge_mode = solar_only`` drew ~1.5 kW from the home battery + grid
+overnight despite solar being 0 W. ``sensor.sem_charging_state``
+correctly reported "Night charging disabled" the whole time, but the
+EV charged anyway.
+
+Root cause: ``_determine_charging_strategy`` returned ``"night_grid"``
+unconditionally when ``is_night_mode()`` was True, regardless of the
+per-charger ``charge_mode``. The named-mode dispatch (``mode ==
+"solar_only"`` etc.) only ran in the day branch. The legacy mapper
+then converted ``"night_grid"`` → ``EVBudgetStrategy.MIN_PV`` (≈1380 W
+floor). With the state machine in NIGHT_DISABLED in parallel, the
+actuator's terminal branch couldn't kill the self-resumed KEBA
+session — same disagreement-class bug #282 was supposed to retire.
+
+Fix: gate the night branch on ``MODE_NIGHT_ALLOWED`` first. Also
+extend the #315 self-resume guard from {"disabled"} to
+{"disabled", "idle"} so future strategy bugs land safely.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.consts.states import (
+    ChargingState,
+)
+from custom_components.solar_energy_management.coordinator.coordinator import (
+    SEMCoordinator,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    PowerReadings,
+)
+
+
+def _coord(charge_mode="solar_only", is_night=True):
+    with patch.object(SEMCoordinator, "__init__", return_value=None):
+        c = SEMCoordinator.__new__(SEMCoordinator)
+    charger = {
+        "id": "keba", "ev_min_current": 6,
+        "ev_night_initial_current": 10, "charge_mode": charge_mode,
+    }
+    c.config = {
+        "ev_chargers": [charger],
+        "ev_max_current": 32,
+        "target_peak_limit": 6.0,
+        "ev_ramp_rate_amps": 2,
+        "ev_stall_cooldown": 120,
+        "battery_capacity_kwh": 15,
+    }
+    c._load_manager = None
+    c.time_manager = MagicMock()
+    c.time_manager.is_night_mode = MagicMock(return_value=is_night)
+    c.time_manager.get_night_end_time = MagicMock(return_value="07:00")
+    c.hass = MagicMock()
+    c.hass.states.is_state = MagicMock(return_value=False)
+    c._tariff_provider = MagicMock()
+    c._cycle_vehicle_soc = None
+    c._cycle_forecast = MagicMock(available=False)
+    c._forecast_reader = MagicMock()
+    c._forecast_reader.read_forecast = MagicMock(return_value=MagicMock(available=False))
+    c._forecast_tracker = MagicMock(dampening_factor=1.0)
+    c._state_machine = MagicMock()
+    c._state_machine.current_state = ChargingState.SOLAR_IDLE
+    c._ev_device = None
+    return c, charger
+
+
+def _power_night():
+    """PROD snapshot 2026-05-31 22:07: solar zero, battery discharging,
+    home consuming, EV connected and SEM thinks it should be idle."""
+    return PowerReadings(
+        solar_power=0.0,
+        grid_power=-353.0,
+        battery_power=-4474.0,
+        home_consumption_power=1045.0,
+        ev_power=0.0,
+        ev_connected=True,
+        ev_charging=False,
+    )
+
+
+class TestStrategyHonorsModeAtNight:
+    """``_determine_charging_strategy`` must consult the per-charger
+    ``charge_mode`` before defaulting to ``night_grid``."""
+
+    def test_solar_only_at_night_returns_idle_not_night_grid(self):
+        coord, cfg = _coord(charge_mode="solar_only")
+        strategy, reason = coord._determine_charging_strategy(
+            _power_night(), MagicMock(daily_ev=0.0), cfg,
+        )
+        assert strategy == "idle", (
+            f"solar_only at night must NOT return night_grid (got "
+            f"{strategy!r} / {reason!r}). This is the #346 PROD bug "
+            f"that caused 4 kWh of overnight grid charging."
+        )
+        assert "solar_only" in reason
+
+    def test_off_mode_at_night_returns_disabled(self):
+        coord, cfg = _coord(charge_mode="off")
+        strategy, _ = coord._determine_charging_strategy(
+            _power_night(), MagicMock(daily_ev=0.0), cfg,
+        )
+        # off mode keeps the explicit ``disabled`` strategy so the
+        # actuator's #315 terminal branch can self-resume-guard.
+        assert strategy == "disabled"
+
+    @pytest.mark.parametrize(
+        "mode", ["min_plus_solar", "always_max", "solar_plus_cheap"],
+    )
+    def test_night_allowed_modes_still_return_night_grid(self, mode):
+        """Modes in ``MODE_NIGHT_ALLOWED`` must keep the legacy
+        ``night_grid`` behaviour — the fix only narrows, doesn't
+        change min_plus_solar / always_max / solar_plus_cheap."""
+        coord, cfg = _coord(charge_mode=mode)
+        # solar_plus_cheap also needs a tariff stub
+        coord._tariff_provider.get_price_level = MagicMock(return_value=None)
+        coord._tariff_provider.find_cheapest_hours = MagicMock(return_value=[])
+        coord._night_plan_per_charger = {}
+        strategy, _ = coord._determine_charging_strategy(
+            _power_night(), MagicMock(daily_ev=0.0), cfg,
+        )
+        # In all three the legacy path produces "night_grid"
+        # when remaining_need > 0.1 kWh. Mock daily_ev=0 so
+        # remaining_need is positive.
+        assert strategy == "night_grid", (
+            f"mode={mode} (in MODE_NIGHT_ALLOWED) must still produce "
+            f"night_grid at night (got {strategy!r})"
+        )
+
+
+class TestStrategyDayBehaviourUnchanged:
+    """The fix only gates the NIGHT branch — day behaviour must be
+    pixel-identical to today for all modes."""
+
+    def test_solar_only_during_day_unchanged(self):
+        coord, cfg = _coord(charge_mode="solar_only", is_night=False)
+        strategy, _ = coord._determine_charging_strategy(
+            PowerReadings(
+                solar_power=3000.0, battery_soc=50.0,
+                ev_connected=True,
+            ),
+            MagicMock(daily_ev=0.0), cfg,
+        )
+        # solar_only day → self_consumption strategy (returns "solar_only")
+        assert strategy == "solar_only"

--- a/tests/test_ev_deadline_tariff.py
+++ b/tests/test_ev_deadline_tariff.py
@@ -602,16 +602,42 @@ class TestOffModeTerminatesActiveCharge:
         dev.stop_session.assert_awaited()
 
     @pytest.mark.asyncio
-    async def test_idle_strategy_does_not_trigger_override(self):
-        """Generic ``"idle"`` (Zone 1, solar<200W, target met) must NOT
-        trigger the override — only the explicit-off ``"disabled"`` does.
-        Pre-refinement check: prevents the #305 conflation from creeping
-        back in via the actuator path."""
+    async def test_idle_strategy_triggers_override_on_self_resume(self):
+        """#346: ``"idle"`` strategy + charger drawing >500 W without an
+        active session = self-resume anomaly. Same pattern as #315 for
+        ``"disabled"``. The original test asserted the opposite (that
+        only ``"disabled"`` triggered the override), which is exactly
+        what made the PROD #346 incident possible: a solar_only KEBA
+        in NIGHT_DISABLED state with strategy=idle and a self-resumed
+        session kept drawing 1.5 kW because the actuator wouldn't kill
+        a session it didn't own.
+
+        Legitimate ``"idle"`` states (Zone 1, solar<200W, target met)
+        either have an active SEM session (caught by the first branch
+        above) or have ev_power ≈ 0 (handshake idle, caught by the
+        500 W threshold). The combination "idle + no session +
+        >500 W draw" only happens when the charger is acting
+        independently of SEM, which is always wrong.
+        """
         coord = _build_coordinator()
         dev = _make_device(session_active=False, current_setpoint=0)
         coord._ev_device = dev
         ctx = ChargingContext(ev_connected=True, charging_strategy="idle")
         power = PowerReadings(ev_connected=True, ev_power=4140.0)
+        await coord._execute_ev_control(
+            ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
+        dev.stop_session.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_idle_strategy_handshake_only_no_override(self):
+        """#346 + #315: ``"idle"`` with ev_power below the 500 W
+        handshake threshold doesn't trigger the override. Mirrors
+        the equivalent ``"disabled"`` test above."""
+        coord = _build_coordinator()
+        dev = _make_device(session_active=False, current_setpoint=0)
+        coord._ev_device = dev
+        ctx = ChargingContext(ev_connected=True, charging_strategy="idle")
+        power = PowerReadings(ev_connected=True, ev_power=110.0)
         await coord._execute_ev_control(
             ChargingState.SOLAR_IDLE, power, MagicMock(), ctx)
         dev.stop_session.assert_not_awaited()


### PR DESCRIPTION
## Summary

PROD incident 2026-05-31 22:07 → 00:48: a KEBA in `charge_mode = solar_only` drew ~4 kWh from battery + grid overnight despite solar = 0 W. `sensor.sem_charging_state` correctly read "Night charging disabled" the entire time.

## Root cause

Strategy/state-machine disagreement (the bug class #282 was supposed to retire):

- `coordinator._determine_charging_strategy` returned `("night_grid", …)` unconditionally on `is_night_mode()`, ignoring the per-charger `charge_mode`. The named-mode dispatch (`mode == "solar_only"`) only ran in the day branch. The legacy mapper then converts `night_grid` → `EVBudgetStrategy.MIN_PV` (≈1380 W floor).
- `charging_control._night_state_machine` correctly returned `NIGHT_DISABLED` (solar_only ∉ `MODE_NIGHT_ALLOWED`).
- The actuator's terminal branch (`ev_control.py:563`) only killed sessions when `_session_active=True` **or** `charging_strategy == "disabled"`. KEBA self-resumed without an SEM-owned session, and the strategy was `"night_grid"` — so SEM did nothing while the charger drew 1.5 kW from the battery for 2h41m.

## Fix — two layers

1. **Root cause** (`coordinator/coordinator.py:2546`): consult `MODE_NIGHT_ALLOWED` **before** the `is_night_mode()` branch. solar_only at night → `"idle"`; off → `"disabled"`. Other modes (min_plus_solar, always_max, solar_plus_cheap) unchanged.

2. **Defence in depth** (`coordinator/ev_control.py:606`): extend the #315 self-resume guard from `{"disabled"}` to `{"disabled", "idle"}` so future strategy bugs land safely. The legitimate "idle" cases (Zone 1, target met, etc.) either have an active SEM session (caught by the first branch) or have ev_power below the 500 W handshake threshold.

## Test plan

- [x] New file `tests/test_346_solar_only_night.py` — 6 tests pin the new contract (solar_only at night → idle; off → disabled; min_plus_solar/always_max/solar_plus_cheap still night_grid; day behaviour unchanged)
- [x] `test_idle_strategy_does_not_trigger_override` was inverted — it pinned the OLD restrictive actuator behaviour that made this bug possible. Renamed to `test_idle_strategy_triggers_override_on_self_resume` and asserts the new contract. Added a companion handshake-only no-override test.
- [x] Full suite: **2320 passed**, 7 skipped
- [ ] Deploy to HA-PROD; verify solar_only KEBA stays at 0 A overnight
- [ ] Confirm no false-positive stop_sessions on legitimate day cycles

## Affected versions

Bug predates v1.7.0 — the night-branch return has been in place since April 2026 (`^530db4c`). Latent until a user actually picked `solar_only` post-#277 Phase C consolidation.

Fixes #346