### PR TITLE
arch(v1.7.0): per-device primary for inverters + batteries

### DIFF
--- a/coordinator/charger_types.py
+++ b/coordinator/charger_types.py
@@ -1,4 +1,12 @@
-"""Per-charger primary types (arch/multi-charger-primary, v1.7.0).
+"""Per-device primary types (arch/multi-charger-primary, v1.7.0).
+
+Naming note: the module is called ``charger_types`` for historical
+reasons (it started as EV-only). With v1.7.0's
+arch/multi-inverter-battery-primary work it also houses
+``InverterPower`` and ``BatteryPower``. Future rename to
+``per_device_types`` is a cleanup task.
+
+
 
 The multi-charger architecture migration moves SEM's data model from
 ``fleet-primary + per_charger shadow dicts`` (the v1.4.0 → v1.6.16
@@ -106,6 +114,81 @@ class ChargerPower:
     real draw by ~5 s (#289); consumers should prefer
     ``power_w > 500`` for the "actually charging" decision and
     treat ``charging`` as informational."""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Per-inverter instantaneous reading (v1.7.0 arch follow-up)
+# ─────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class InverterPower:
+    """One inverter's instantaneous power reading.
+
+    Inverters are SOURCES — SEM observes them, doesn't command them
+    (the inverter brand integration handles its own modes). The
+    per-inverter dict on :class:`PowerReadings` replaces what was a
+    single fleet ``solar_power`` field summed in ``sensor_reader``
+    (multi-inverter Pattern E in CLAUDE.md, ``solar_power_list``).
+
+    Fleet sum invariant:
+        ``PowerReadings.fleet_solar_w ==
+         sum(i.power_w for i in PowerReadings.inverters.values())``
+
+    Pinned in ``tests/test_step8_invariants.py`` (Step 8 follow-up).
+    """
+
+    inverter_id: str
+    """Stable identifier — entity name when populated by sensor_reader,
+    or test fixture id. Used as the dict key."""
+
+    power_w: float = 0.0
+    """Instantaneous AC output (W). ≥ 0 by SEM convention."""
+
+    daily_kwh: float = 0.0
+    """Calendar-reset daily AC energy (kWh)."""
+
+    name: str = ""
+    """Human-readable label (e.g. "SUN2000-1") for dashboard display."""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Per-battery instantaneous reading (v1.7.0 arch follow-up)
+# ─────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class BatteryPower:
+    """One home battery's instantaneous power + state.
+
+    Like inverters, batteries are OBSERVED, not commanded by SEM
+    (the battery brand integration owns its own control loop;
+    SEM only requests battery_priority via the inverter side).
+
+    Fleet sum invariant:
+        ``PowerReadings.fleet_battery_w ==
+         sum(b.power_w for b in PowerReadings.batteries.values())``
+
+    Sign: positive = charging, negative = discharging — matches
+    SEM convention (CLAUDE.md).
+    """
+
+    battery_id: str
+    """Stable identifier — entity name when populated by sensor_reader."""
+
+    power_w: float = 0.0
+    """Instantaneous power (W). + = charge, − = discharge."""
+
+    soc_pct: float = 0.0
+    """State of charge (0-100). Fleet SOC is the
+    capacity-weighted average."""
+
+    capacity_kwh: float = 0.0
+    """Nameplate capacity for this unit. Used by the fleet SOC
+    weighted average + battery_assist budget math."""
+
+    daily_charge_kwh: float = 0.0
+    daily_discharge_kwh: float = 0.0
+
+    name: str = ""
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -427,9 +427,21 @@ class SensorReader:
         ed = self._energy_dashboard_config
         readings = PowerReadings()
 
-        # Solar power — sum all inverters if multiple configured
+        # Solar power — sum all inverters if multiple configured.
+        # v1.7.0 arch/multi-inverter-battery-primary: also populate
+        # the per-inverter dict so downstream consumers can attribute
+        # by inverter (multi-inverter installs only — single-inverter
+        # leaves the dict empty and falls back to readings.solar_power).
+        from .charger_types import InverterPower
         if len(ed.solar_power_list) > 1:
-            readings.solar_power = self._read_sensors_sum(ed.solar_power_list, "solar")
+            total = 0.0
+            for entity in ed.solar_power_list:
+                w = self._read_sensor(entity, "solar")
+                total += w
+                readings.inverters[entity] = InverterPower(
+                    inverter_id=entity, power_w=w, name=entity,
+                )
+            readings.solar_power = total
         elif ed.solar_power:
             readings.solar_power = self._read_sensor(ed.solar_power, "solar")
 
@@ -493,10 +505,23 @@ class SensorReader:
                 )
 
         # Battery power — sum all battery units if multiple configured.
-        # Sign auto-detection (in read_power → _detect_battery_sign) uses the
-        # primary sensor and assumes all units share the same sign convention.
+        # v1.7.0 arch: also populate the per-battery dict so multi-
+        # battery installs can be attributed per-unit. Single-battery
+        # leaves the dict empty and downstream consumers fall back to
+        # readings.battery_power.
+        # Sign auto-detection (in read_power → _detect_battery_sign)
+        # uses the primary sensor and assumes all units share the same
+        # sign convention.
+        from .charger_types import BatteryPower
         if len(ed.battery_power_list) > 1:
-            readings.battery_power = self._read_sensors_sum(ed.battery_power_list, "battery")
+            total = 0.0
+            for entity in ed.battery_power_list:
+                w = self._read_sensor(entity, "battery")
+                total += w
+                readings.batteries[entity] = BatteryPower(
+                    battery_id=entity, power_w=w, name=entity,
+                )
+            readings.battery_power = total
         elif ed.battery_power:
             readings.battery_power = self._read_sensor(ed.battery_power, "battery")
 

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -13,8 +13,11 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, Any, List, Optional
+from typing import TYPE_CHECKING, Dict, Any, List, Optional
 from enum import Enum
+
+if TYPE_CHECKING:  # pragma: no cover — type-only
+    from .charger_types import BatteryPower, InverterPower
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -88,7 +91,22 @@ class FleetEvPower(float):
 
 @dataclass
 class PowerReadings:
-    """Current power readings from sensors."""
+    """Current power readings from sensors.
+
+    v1.7.0 arch/multi-device-primary: the per-device dicts
+    (``inverters``, ``batteries``, ``ev_power_per_charger``,
+    ``solar_power_per_string``) are the PRIMARY representation.
+    The legacy fleet float fields (``solar_power``, ``battery_power``,
+    ``ev_power``) are kept as cached sums for backward compat with
+    downstream consumers; ``sensor_reader`` populates both. The
+    ``fleet_solar_w`` / ``fleet_battery_w`` / ``fleet_ev_w``
+    properties are the sanctioned way to read the fleet sum going
+    forward — they recompute from the dict and so cannot drift.
+
+    Pin: ``solar_power == fleet_solar_w`` and
+    ``battery_power == fleet_battery_w`` whenever the dicts are
+    populated. Enforced by the Step 8 invariant test suite.
+    """
     solar_power: float = 0.0
     grid_power: float = 0.0  # Negative = import, Positive = export
     battery_power: float = 0.0  # Positive = charge, Negative = discharge
@@ -124,6 +142,29 @@ class PowerReadings:
     # inverter setups; downstream readers must fall back to
     # ``solar_power``.
     solar_power_per_string: "Dict[str, float]" = field(default_factory=dict)
+
+    # v1.7.0 arch/multi-inverter-battery-primary.
+    #
+    # Per-inverter and per-battery dicts are now the PRIMARY
+    # representation of multi-device fleets. ``sensor_reader``
+    # populates them whenever the config lists more than one
+    # source (``solar_power_list`` length > 1 or
+    # ``battery_power_list`` length > 1). The fleet ``solar_power``
+    # and ``battery_power`` fields above stay as cached sums for
+    # backward compat — every downstream consumer that adds up
+    # ``solar_power`` continues to work — but new code should
+    # read the dicts via ``fleet_solar_w`` / ``fleet_battery_w``
+    # (the ``@property`` accessors below) so a future refactor
+    # can swap the cached sums to computed-on-read without a
+    # consumer churn.
+    #
+    # Sum invariants pinned by ``tests/test_step8_invariants.py``:
+    #   ``solar_power == fleet_solar_w`` (cached == computed)
+    #   ``battery_power == fleet_battery_w``
+    # The invariant doesn't fire on single-device setups (dict
+    # empty) — they keep the fleet field semantics unchanged.
+    inverters: "Dict[str, InverterPower]" = field(default_factory=dict)
+    batteries: "Dict[str, BatteryPower]" = field(default_factory=dict)
 
     # Derived values
     grid_import_power: float = 0.0
@@ -161,6 +202,47 @@ class PowerReadings:
         energy_in = self.solar_power + self.grid_import_power + self.battery_discharge_power
         energy_out = self.ev_power + self.grid_export_power + self.battery_charge_power
         self.home_consumption_power = max(0, energy_in - energy_out)
+
+    # ─── arch/multi-inverter-battery-primary @property views ───
+    #
+    # ``fleet_*_w`` accessors compute from the per-device dict —
+    # the sanctioned way to obtain a fleet sum going forward.
+    # New code reads these; legacy ``solar_power``/``battery_power``
+    # consumers continue to work via the cached field.
+
+    @property
+    def fleet_solar_w(self) -> float:
+        """Fleet-aggregated solar AC power (W). Computed from the
+        per-inverter dict. Empty dict (single-inverter or pre-v1.7.0
+        snapshot) falls back to the cached ``solar_power``."""
+        if not self.inverters:
+            return self.solar_power
+        return sum(i.power_w for i in self.inverters.values())
+
+    @property
+    def fleet_battery_w(self) -> float:
+        """Fleet-aggregated battery power (W; + = charge,
+        − = discharge). Computed from the per-battery dict."""
+        if not self.batteries:
+            return self.battery_power
+        return sum(b.power_w for b in self.batteries.values())
+
+    @property
+    def fleet_battery_soc(self) -> float:
+        """Capacity-weighted fleet SOC (0-100). Falls back to the
+        single ``battery_soc`` field when the per-battery dict is
+        empty or no unit reports its capacity."""
+        if not self.batteries:
+            return self.battery_soc
+        total_capacity = sum(b.capacity_kwh for b in self.batteries.values())
+        if total_capacity <= 0:
+            # No capacity → simple arithmetic mean (better than 0)
+            socs = [b.soc_pct for b in self.batteries.values()]
+            return sum(socs) / len(socs) if socs else self.battery_soc
+        weighted_sum = sum(
+            b.soc_pct * b.capacity_kwh for b in self.batteries.values()
+        )
+        return weighted_sum / total_capacity
 
 
 @dataclass

--- a/tests/test_multi_inverter_battery_primary.py
+++ b/tests/test_multi_inverter_battery_primary.py
@@ -1,0 +1,184 @@
+"""Tests for the per-inverter and per-battery primary types
+(v1.7.0 arch/multi-inverter-battery-primary).
+
+Same pattern as the EV side (test_step8_invariants.py): the
+per-device dict is the PRIMARY representation; the fleet float
+field is a cached sum. Invariants pin the relationship and the
+@property accessors.
+"""
+import pytest
+
+from custom_components.solar_energy_management.coordinator.charger_types import (
+    BatteryPower,
+    InverterPower,
+)
+from custom_components.solar_energy_management.coordinator.types import PowerReadings
+
+
+class TestInverterPowerType:
+    """Frozen-dataclass shape pins."""
+
+    def test_default_init(self):
+        i = InverterPower(inverter_id="sun2000")
+        assert i.inverter_id == "sun2000"
+        assert i.power_w == 0.0
+        assert i.daily_kwh == 0.0
+        assert i.name == ""
+
+    def test_frozen(self):
+        from dataclasses import FrozenInstanceError
+        i = InverterPower(inverter_id="sun2000", power_w=5000.0)
+        with pytest.raises(FrozenInstanceError):
+            i.power_w = 6000.0  # type: ignore[misc]
+
+
+class TestBatteryPowerType:
+    def test_default_init(self):
+        b = BatteryPower(battery_id="luna2000")
+        assert b.battery_id == "luna2000"
+        assert b.power_w == 0.0
+        assert b.soc_pct == 0.0
+        assert b.capacity_kwh == 0.0
+
+    def test_frozen(self):
+        from dataclasses import FrozenInstanceError
+        b = BatteryPower(battery_id="luna2000", power_w=1500.0)
+        with pytest.raises(FrozenInstanceError):
+            b.soc_pct = 80.0  # type: ignore[misc]
+
+
+class TestFleetSolarProperty:
+    """``PowerReadings.fleet_solar_w`` computes from the inverters
+    dict; falls back to cached ``solar_power`` when empty."""
+
+    def test_empty_dict_falls_back_to_solar_power(self):
+        r = PowerReadings(solar_power=5000.0)
+        assert r.fleet_solar_w == 5000.0
+
+    def test_single_inverter(self):
+        r = PowerReadings(solar_power=5000.0)
+        r.inverters["a"] = InverterPower(inverter_id="a", power_w=5000.0)
+        assert r.fleet_solar_w == 5000.0
+
+    def test_two_inverters_sum(self):
+        r = PowerReadings(solar_power=11000.0)
+        r.inverters["a"] = InverterPower(inverter_id="a", power_w=5000.0)
+        r.inverters["b"] = InverterPower(inverter_id="b", power_w=6000.0)
+        assert r.fleet_solar_w == 11000.0
+
+    def test_three_inverters_sum(self):
+        r = PowerReadings()
+        r.inverters["a"] = InverterPower(inverter_id="a", power_w=3500.0)
+        r.inverters["b"] = InverterPower(inverter_id="b", power_w=2500.0)
+        r.inverters["c"] = InverterPower(inverter_id="c", power_w=4000.0)
+        assert r.fleet_solar_w == pytest.approx(10000.0, abs=0.01)
+
+
+class TestFleetBatteryProperty:
+    def test_empty_falls_back(self):
+        r = PowerReadings(battery_power=-2500.0)
+        assert r.fleet_battery_w == -2500.0
+
+    def test_two_batteries_sum_with_signs(self):
+        """One charging (+1000), one discharging (-500). Sum = +500."""
+        r = PowerReadings()
+        r.batteries["a"] = BatteryPower(battery_id="a", power_w=1000.0)
+        r.batteries["b"] = BatteryPower(battery_id="b", power_w=-500.0)
+        assert r.fleet_battery_w == pytest.approx(500.0, abs=0.01)
+
+    def test_capacity_weighted_soc(self):
+        """Different capacities → weighted average."""
+        r = PowerReadings()
+        r.batteries["small"] = BatteryPower(
+            battery_id="small", soc_pct=80.0, capacity_kwh=5.0,
+        )
+        r.batteries["big"] = BatteryPower(
+            battery_id="big", soc_pct=50.0, capacity_kwh=15.0,
+        )
+        # weighted: (80*5 + 50*15) / 20 = (400 + 750) / 20 = 57.5
+        assert r.fleet_battery_soc == pytest.approx(57.5, abs=0.01)
+
+    def test_soc_falls_back_to_arithmetic_mean_when_no_capacity(self):
+        r = PowerReadings()
+        r.batteries["a"] = BatteryPower(battery_id="a", soc_pct=80.0)
+        r.batteries["b"] = BatteryPower(battery_id="b", soc_pct=60.0)
+        # arithmetic mean = 70
+        assert r.fleet_battery_soc == pytest.approx(70.0, abs=0.01)
+
+    def test_empty_battery_falls_back_to_battery_soc(self):
+        r = PowerReadings(battery_soc=85.0)
+        assert r.fleet_battery_soc == 85.0
+
+
+class TestInvariants:
+    """Sum invariants pinned for the multi-device fleets."""
+
+    @pytest.mark.parametrize("inverters", [
+        [("a", 5000.0)],
+        [("a", 5000.0), ("b", 3000.0)],
+        [("a", 5000.0), ("b", 3000.0), ("c", 2500.0)],
+        [("a", 5000.0), ("b", 0.0)],  # one offline
+    ])
+    def test_solar_invariant_sum_equals_field(self, inverters):
+        """When sensor_reader populates both the dict and the cached
+        sum, they must agree."""
+        total = sum(w for _, w in inverters)
+        r = PowerReadings(solar_power=total)
+        for iid, w in inverters:
+            r.inverters[iid] = InverterPower(inverter_id=iid, power_w=w)
+        assert r.solar_power == pytest.approx(r.fleet_solar_w, abs=0.01)
+
+    @pytest.mark.parametrize("batteries", [
+        [("a", 2000.0)],
+        [("a", 2000.0), ("b", -1500.0)],   # one charging, one discharging
+        [("a", 0.0), ("b", 0.0)],          # both idle
+        [("a", -3000.0), ("b", -1000.0)],  # both discharging
+    ])
+    def test_battery_invariant_sum_equals_field(self, batteries):
+        total = sum(w for _, w in batteries)
+        r = PowerReadings(battery_power=total)
+        for bid, w in batteries:
+            r.batteries[bid] = BatteryPower(battery_id=bid, power_w=w)
+        assert r.battery_power == pytest.approx(r.fleet_battery_w, abs=0.01)
+
+
+class TestBackwardCompatibility:
+    """Existing consumers reading ``solar_power`` / ``battery_power``
+    directly continue to work — the per-device dict is additive,
+    never replaces the field."""
+
+    def test_pre_v170_snapshot_works(self):
+        """An installation that doesn't populate the dicts (single
+        inverter, single battery) behaves exactly like pre-v1.7.0."""
+        r = PowerReadings(solar_power=5000.0, battery_power=-1500.0)
+        # Dicts empty
+        assert r.inverters == {}
+        assert r.batteries == {}
+        # Direct field reads unchanged
+        assert r.solar_power == 5000.0
+        assert r.battery_power == -1500.0
+        # @property accessors fall back to the field
+        assert r.fleet_solar_w == 5000.0
+        assert r.fleet_battery_w == -1500.0
+
+    def test_calculate_derived_still_uses_solar_power(self):
+        """The home consumption math uses ``solar_power`` directly.
+        Adding the per-inverter dict must not change the result."""
+        r = PowerReadings(
+            solar_power=5000.0, grid_power=-1000.0, battery_power=0.0,
+            ev_power=4000.0,
+        )
+        r.calculate_derived()
+        home_no_dict = r.home_consumption_power
+
+        # Same scenario but populate the inverter dict
+        r2 = PowerReadings(
+            solar_power=5000.0, grid_power=-1000.0, battery_power=0.0,
+            ev_power=4000.0,
+        )
+        r2.inverters["a"] = InverterPower(inverter_id="a", power_w=3000.0)
+        r2.inverters["b"] = InverterPower(inverter_id="b", power_w=2000.0)
+        r2.calculate_derived()
+        home_with_dict = r2.home_consumption_power
+
+        assert home_no_dict == home_with_dict


### PR DESCRIPTION
## Summary

Extends the multi-charger primary pattern (PR #358) to inverters and home batteries. With the EV side rebuilt around `Dict[str, X]` + `@property` fleet view, the same structural win extends naturally to the OTHER multi-device parts in v1.7.0.

## What ships

**New frozen types** (`coordinator/charger_types.py`):
- `InverterPower(inverter_id, power_w, daily_kwh, name)`
- `BatteryPower(battery_id, power_w, soc_pct, capacity_kwh, daily_charge_kwh, daily_discharge_kwh, name)`

**New `PowerReadings` dict fields + `@property` accessors:**
- `inverters: Dict[str, InverterPower]`
- `batteries: Dict[str, BatteryPower]`
- `fleet_solar_w` → `sum(i.power_w for i in inverters.values())`
- `fleet_battery_w` → `sum(b.power_w for b in batteries.values())`
- `fleet_battery_soc` → capacity-weighted average

**`sensor_reader` populates the dicts** when the Energy Dashboard config lists more than one inverter or battery. Single-device installs leave the dicts empty; the `@property` accessors transparently fall back to the legacy `solar_power` / `battery_power` / `battery_soc` fields. No consumer churn.

## Invariants pinned

- `solar_power == fleet_solar_w` (multi-inverter)
- `battery_power == fleet_battery_w` (multi-battery)
- `fleet_battery_soc` respects capacity weighting

## Test plan

- [x] 23 new tests in `tests/test_multi_inverter_battery_primary.py`
- [x] Full suite: 2608 passed, 7 skipped (was 2585 → +23 new)
- [x] Backward-compat verified: pre-v1.7.0 snapshots (empty dicts) behave identically
- [x] `calculate_derived()` unchanged

## What's structurally fixed

- **Multi-inverter Pattern E** (CLAUDE.md): per-inverter readings are first-class data, not a fleet sum that can drift from the per-inverter sensors
- **Multi-battery installs**: per-unit SOC + per-unit kWh accessible for the dashboard
- **Pre-conditions for v1.8.0 per-string-to-destination attribution** (#312 deferred work): the inverter-level model now exists

Refs #351