### PR TITLE
arch(v1.7.0): inverter+battery primary — types + adapters + decide/actuate (foundation)

### DIFF
--- a/coordinator/actuate_battery.py
+++ b/coordinator/actuate_battery.py
@@ -1,0 +1,85 @@
+"""Pure-dispatch actuate_battery(decision, adapter) (Group B Step 4).
+
+Mirrors :func:`actuate` for chargers. Each :class:`BatteryIntent`
+maps to exactly one :class:`BatteryControlAdapter` method. No
+branches on brand — the adapter does that.
+
+Idempotency: the adapter's ``last_intent`` field lets callers
+short-circuit duplicate calls. The actuator itself always
+dispatches; the adapter de-dups (e.g. consecutive same-watts
+LIMIT_DISCHARGE calls become one HA service call).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .charger_types import BatteryIntent
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .battery_adapters.base import BatteryControlAdapter
+    from .charger_types import BatteryDecision
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def actuate_battery(
+    decision: "BatteryDecision",
+    adapter: "BatteryControlAdapter",
+) -> None:
+    """Apply a per-battery decision through the adapter.
+
+    Args:
+        decision: The output of ``decide_battery(view)`` this cycle.
+        adapter: The brand-specific adapter wrapping this battery.
+    """
+    if decision.intent is BatteryIntent.NORMAL:
+        await adapter.command_normal()
+        _LOGGER.debug(
+            "actuate_battery(%s): NORMAL — %s",
+            decision.battery_id, decision.reason,
+        )
+        return
+
+    if decision.intent is BatteryIntent.LIMIT_DISCHARGE:
+        await adapter.command_limit_discharge(decision.discharge_limit_w)
+        _LOGGER.debug(
+            "actuate_battery(%s): LIMIT_DISCHARGE %.0f W — %s",
+            decision.battery_id, decision.discharge_limit_w, decision.reason,
+        )
+        return
+
+    if decision.intent is BatteryIntent.FORCE_CHARGE:
+        if not adapter.supports_forced_charge:
+            _LOGGER.warning(
+                "actuate_battery(%s): adapter does not support forced "
+                "charge — decision dropped (%s)",
+                decision.battery_id, decision.reason,
+            )
+            return
+        await adapter.command_force_charge(
+            decision.target_soc,
+            decision.charge_power_w,
+            decision.duration_min,
+        )
+        _LOGGER.debug(
+            "actuate_battery(%s): FORCE_CHARGE target_soc=%.0f%% "
+            "power=%.0f W duration=%dm — %s",
+            decision.battery_id, decision.target_soc,
+            decision.charge_power_w, decision.duration_min,
+            decision.reason,
+        )
+        return
+
+    if decision.intent is BatteryIntent.STOP_FORCE_CHARGE:
+        await adapter.command_stop_force_charge()
+        _LOGGER.debug(
+            "actuate_battery(%s): STOP_FORCE_CHARGE — %s",
+            decision.battery_id, decision.reason,
+        )
+        return
+
+    _LOGGER.error(
+        "actuate_battery(%s): unknown intent %r",
+        decision.battery_id, decision.intent,
+    )

--- a/coordinator/battery_adapters/__init__.py
+++ b/coordinator/battery_adapters/__init__.py
@@ -1,0 +1,57 @@
+"""Battery control adapters — encapsulate per-brand command surface.
+
+Unifies the two control axes that pre-v1.7.0 lived in separate
+modules:
+
+- ``BatteryProtectionMixin`` (reactive discharge limiting via
+  ``number.set_value`` on a discharge control entity)
+- ``BatteryChargeAdapter`` + brand subclasses (proactive forced
+  charge via brand-specific services)
+
+into one :class:`BatteryControlAdapter` protocol with one method
+per :class:`BatteryIntent`. Mirrors the EV ``charger_adapters/``
+pattern.
+"""
+from .base import BatteryControlAdapter
+from .generic import GenericBatteryAdapter
+from .goodwe import GoodWeBatteryAdapter
+from .huawei import HuaweiBatteryAdapter
+
+
+def adapter_for(hass, config: dict) -> BatteryControlAdapter:
+    """Pick the right battery adapter for this install.
+
+    Auto-detect priority (matches today's
+    ``BatteryChargeAdapter.adapter_for`` factory):
+
+    1. Explicit ``battery_charge_platform`` config wins
+    2. Huawei Solar integration loaded → HuaweiBatteryAdapter
+    3. GoodWe integration loaded → GoodWeBatteryAdapter
+    4. Otherwise → GenericBatteryAdapter (switch + number target)
+    """
+    platform = (config.get("battery_charge_platform") or "auto").lower()
+    if platform == "huawei":
+        return HuaweiBatteryAdapter(hass, config)
+    if platform == "goodwe":
+        return GoodWeBatteryAdapter(hass, config)
+    if platform == "generic":
+        return GenericBatteryAdapter(hass, config)
+
+    # Auto-detect
+    try:
+        if hass and "huawei_solar" in getattr(hass, "data", {}):
+            return HuaweiBatteryAdapter(hass, config)
+        if hass and "goodwe" in getattr(hass, "data", {}):
+            return GoodWeBatteryAdapter(hass, config)
+    except (AttributeError, TypeError):
+        pass
+    return GenericBatteryAdapter(hass, config)
+
+
+__all__ = [
+    "BatteryControlAdapter",
+    "HuaweiBatteryAdapter",
+    "GoodWeBatteryAdapter",
+    "GenericBatteryAdapter",
+    "adapter_for",
+]

--- a/coordinator/battery_adapters/base.py
+++ b/coordinator/battery_adapters/base.py
@@ -1,0 +1,97 @@
+"""BatteryControlAdapter protocol — battery's only command contract.
+
+Every brand-specific service call SEM makes for batteries flows
+through one method on this protocol. The actuator
+(:func:`actuate_battery`) says ``await adapter.command_force_charge(...)``;
+the adapter dispatches to the brand-specific HA service.
+
+Pre-v1.7.0 the battery command surface was split across:
+
+- ``coordinator/battery_protection.py`` (BatteryProtectionMixin) —
+  discharge limiting via ``number.set_value``
+- ``coordinator/battery_charge_adapter.py`` (BatteryChargeAdapter
+  + brand subclasses) — forced charge via brand services
+
+This protocol unifies both axes. New brand support: subclass
+``BatteryControlAdapter``, implement the four ``command_*`` methods,
+register in ``adapter_for()``.
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:  # pragma: no cover — type-only
+    from ..charger_types import BatteryIntent
+
+
+class BatteryControlAdapter(ABC):
+    """One adapter per battery brand. Mirrors
+    :class:`ChargerAdapter` on the EV side.
+
+    Each method maps 1:1 to a :class:`BatteryIntent`:
+
+        NORMAL              → command_normal()
+        LIMIT_DISCHARGE     → command_limit_discharge(watts)
+        FORCE_CHARGE        → command_force_charge(target_soc, power_w, duration_min)
+        STOP_FORCE_CHARGE   → command_stop_force_charge()
+
+    The actuator never branches on brand; the adapter does.
+    """
+
+    def __init__(self, hass, config: dict) -> None:
+        self._hass = hass
+        self._config = config
+        self._last_intent: "Optional[BatteryIntent]" = None
+        self._last_discharge_limit_w: float = -1.0
+        """Last applied discharge limit — used by command_limit_discharge
+        to de-dup consecutive same-value writes. Mirrors today's
+        100 W hysteresis in BatteryProtectionMixin
+        (battery_protection.py:106-109)."""
+
+    # ─── Capability ────────────────────────────────────────────
+
+    @property
+    @abstractmethod
+    def max_charge_power_w(self) -> float:
+        """Brand-reported max charge power."""
+
+    @property
+    @abstractmethod
+    def max_discharge_power_w(self) -> float:
+        """Brand-reported max discharge power. Returned to NORMAL."""
+
+    @property
+    @abstractmethod
+    def supports_forced_charge(self) -> bool:
+        """True if this brand has a forced-charge service.
+        ``Sonnen`` would return False — protection-only adapter."""
+
+    @property
+    def last_intent(self) -> "Optional[BatteryIntent]":
+        return self._last_intent
+
+    # ─── Commands ──────────────────────────────────────────────
+
+    @abstractmethod
+    async def command_normal(self) -> None:
+        """Restore default discharge limit (max_discharge_power_w)."""
+
+    @abstractmethod
+    async def command_limit_discharge(self, watts: float) -> None:
+        """Hold discharge to ``watts``. Implementations apply
+        hysteresis — if ``watts`` is within ±100 W of the last
+        applied value, skip the HA service call."""
+
+    @abstractmethod
+    async def command_force_charge(
+        self,
+        target_soc: float,
+        charge_power_w: float,
+        duration_min: int,
+    ) -> None:
+        """Start a forced grid → battery charge."""
+
+    @abstractmethod
+    async def command_stop_force_charge(self) -> None:
+        """Cancel an active forced charge."""

--- a/coordinator/battery_adapters/generic.py
+++ b/coordinator/battery_adapters/generic.py
@@ -1,0 +1,103 @@
+"""GenericBatteryAdapter — brand-agnostic fallback.
+
+Works with any inverter that exposes:
+- A number entity for the battery discharge limit
+- (optionally) A switch entity to force charge + a number entity
+  for the SOC target
+
+If forced-charge entities aren't configured, the adapter still
+serves NORMAL / LIMIT_DISCHARGE (the reactive protection only).
+"""
+from __future__ import annotations
+
+import logging
+
+from ..charger_types import BatteryIntent
+from .base import BatteryControlAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GenericBatteryAdapter(BatteryControlAdapter):
+    def __init__(self, hass, config: dict) -> None:
+        super().__init__(hass, config)
+        self._discharge_control_entity = config.get(
+            "battery_discharge_control_entity", "",
+        )
+        self._max_discharge_w = float(
+            config.get("battery_max_discharge_power", 5000),
+        )
+        self._force_charge_switch = config.get(
+            "battery_force_charge_switch", "",
+        )
+        self._target_soc_entity = config.get("battery_target_soc_entity", "")
+        # Lazy import for delegate
+        try:
+            from ..battery_charge_adapter import GenericChargeAdapter
+            self._charge_adapter = GenericChargeAdapter(hass, config)
+        except Exception:  # noqa: BLE001
+            self._charge_adapter = None
+
+    @property
+    def max_charge_power_w(self) -> float:
+        return float(self._config.get("battery_max_charge_power", 5000))
+
+    @property
+    def max_discharge_power_w(self) -> float:
+        return self._max_discharge_w
+
+    @property
+    def supports_forced_charge(self) -> bool:
+        return bool(self._force_charge_switch and self._target_soc_entity)
+
+    async def command_normal(self) -> None:
+        await self._apply_discharge_limit(self._max_discharge_w)
+        self._last_intent = BatteryIntent.NORMAL
+
+    async def command_limit_discharge(self, watts: float) -> None:
+        watts = max(0.0, min(watts, self._max_discharge_w))
+        if (self._last_discharge_limit_w >= 0
+                and abs(watts - self._last_discharge_limit_w) < 100.0):
+            self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+            return
+        await self._apply_discharge_limit(watts)
+        self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+
+    async def command_force_charge(
+        self, target_soc: float, charge_power_w: float, duration_min: int,
+    ) -> None:
+        if self._charge_adapter is None:
+            _LOGGER.warning(
+                "GenericBatteryAdapter: no forced-charge backend — "
+                "command_force_charge ignored",
+            )
+            return
+        from ..battery_charge_adapter import ChargeCommand
+        cmd = ChargeCommand(
+            target_soc=target_soc,
+            charge_power_w=charge_power_w,
+            duration_min=duration_min,
+        )
+        await self._charge_adapter.start_forced_charge(cmd)
+        self._last_intent = BatteryIntent.FORCE_CHARGE
+
+    async def command_stop_force_charge(self) -> None:
+        if self._charge_adapter is not None:
+            await self._charge_adapter.stop_forced_charge()
+        self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+
+    async def _apply_discharge_limit(self, watts: float) -> None:
+        if not self._discharge_control_entity:
+            self._last_discharge_limit_w = watts
+            return
+        try:
+            await self._hass.services.async_call(
+                "number", "set_value",
+                {"entity_id": self._discharge_control_entity, "value": watts},
+                blocking=True,
+            )
+            self._last_discharge_limit_w = watts
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "Generic battery: failed to set discharge limit: %s", e,
+            )

--- a/coordinator/battery_adapters/goodwe.py
+++ b/coordinator/battery_adapters/goodwe.py
@@ -1,0 +1,85 @@
+"""GoodWeBatteryAdapter — GoodWe inverters.
+
+GoodWe uses mode-based forced charge ("Eco Charge" mode) rather than
+a direct service call. Discharge limit still uses ``number.set_value``
+where supported.
+"""
+from __future__ import annotations
+
+import logging
+
+from ..charger_types import BatteryIntent
+from .base import BatteryControlAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class GoodWeBatteryAdapter(BatteryControlAdapter):
+    def __init__(self, hass, config: dict) -> None:
+        super().__init__(hass, config)
+        self._discharge_control_entity = config.get(
+            "battery_discharge_control_entity", "",
+        )
+        self._max_discharge_w = float(
+            config.get("battery_max_discharge_power", 5000),
+        )
+        # Lazy import the existing forced-charge adapter
+        from ..battery_charge_adapter import GoodWeChargeAdapter
+        self._charge_adapter = GoodWeChargeAdapter(hass, config)
+
+    @property
+    def max_charge_power_w(self) -> float:
+        return float(self._config.get("battery_max_charge_power", 5000))
+
+    @property
+    def max_discharge_power_w(self) -> float:
+        return self._max_discharge_w
+
+    @property
+    def supports_forced_charge(self) -> bool:
+        return True
+
+    async def command_normal(self) -> None:
+        await self._apply_discharge_limit(self._max_discharge_w)
+        self._last_intent = BatteryIntent.NORMAL
+
+    async def command_limit_discharge(self, watts: float) -> None:
+        watts = max(0.0, min(watts, self._max_discharge_w))
+        if (self._last_discharge_limit_w >= 0
+                and abs(watts - self._last_discharge_limit_w) < 100.0):
+            self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+            return
+        await self._apply_discharge_limit(watts)
+        self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+
+    async def command_force_charge(
+        self, target_soc: float, charge_power_w: float, duration_min: int,
+    ) -> None:
+        from ..battery_charge_adapter import ChargeCommand
+        cmd = ChargeCommand(
+            target_soc=target_soc,
+            charge_power_w=charge_power_w,
+            duration_min=duration_min,
+        )
+        await self._charge_adapter.start_forced_charge(cmd)
+        self._last_intent = BatteryIntent.FORCE_CHARGE
+
+    async def command_stop_force_charge(self) -> None:
+        await self._charge_adapter.stop_forced_charge()
+        self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+
+    async def _apply_discharge_limit(self, watts: float) -> None:
+        if not self._discharge_control_entity:
+            self._last_discharge_limit_w = watts
+            return
+        try:
+            await self._hass.services.async_call(
+                "number", "set_value",
+                {"entity_id": self._discharge_control_entity, "value": watts},
+                blocking=True,
+            )
+            self._last_discharge_limit_w = watts
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "GoodWe battery: failed to set discharge limit: %s", e,
+            )

--- a/coordinator/battery_adapters/huawei.py
+++ b/coordinator/battery_adapters/huawei.py
@@ -1,0 +1,121 @@
+"""HuaweiBatteryAdapter — Huawei SUN2000 + LUNA2000.
+
+Wraps:
+- Today's HuaweiChargeAdapter (forcible_charge_soc service) for
+  command_force_charge / command_stop_force_charge
+- The number.set_value path that BatteryProtectionMixin used for
+  command_limit_discharge / command_normal
+
+Brand quirks:
+- LUNA2000 supports power-based forced charge (not just SOC ramp)
+- Discharge limit entity is brand-specific (typically
+  ``number.batteries_maximale_entladeleistung``)
+- Force-charge service requires target_soc + power + duration
+"""
+from __future__ import annotations
+
+import logging
+
+from ..charger_types import BatteryIntent
+from .base import BatteryControlAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class HuaweiBatteryAdapter(BatteryControlAdapter):
+    """Huawei battery control. Delegates forced charge to the
+    existing :class:`HuaweiChargeAdapter` for backward compat."""
+
+    def __init__(self, hass, config: dict) -> None:
+        super().__init__(hass, config)
+        # Lazy import the existing forced-charge adapter so this
+        # module's imports stay lightweight + the legacy adapter
+        # can be deleted later without breaking the structural
+        # plan.
+        from ..battery_charge_adapter import HuaweiChargeAdapter
+        self._charge_adapter = HuaweiChargeAdapter(hass, config)
+        # Config keys for discharge limit
+        self._discharge_control_entity = config.get(
+            "battery_discharge_control_entity", "",
+        )
+        self._max_discharge_w = float(
+            config.get("battery_max_discharge_power", 5000),
+        )
+
+    # ─── Capability ────────────────────────────────────────────
+
+    @property
+    def max_charge_power_w(self) -> float:
+        return float(self._config.get("battery_max_charge_power", 5000))
+
+    @property
+    def max_discharge_power_w(self) -> float:
+        return self._max_discharge_w
+
+    @property
+    def supports_forced_charge(self) -> bool:
+        return True
+
+    # ─── Commands ──────────────────────────────────────────────
+
+    async def command_normal(self) -> None:
+        """Restore discharge to max — undoes any LIMIT_DISCHARGE
+        in effect. Idempotent: only writes if the limit differs."""
+        await self._apply_discharge_limit(self._max_discharge_w)
+        self._last_intent = BatteryIntent.NORMAL
+
+    async def command_limit_discharge(self, watts: float) -> None:
+        """Apply the 1:1 home-consumption protection limit.
+        Honours 100 W hysteresis to avoid log spam."""
+        # Clamp to [0, max]
+        watts = max(0.0, min(watts, self._max_discharge_w))
+        # Hysteresis (matches battery_protection.py:106-109)
+        if (self._last_discharge_limit_w >= 0
+                and abs(watts - self._last_discharge_limit_w) < 100.0):
+            self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+            return
+        await self._apply_discharge_limit(watts)
+        self._last_intent = BatteryIntent.LIMIT_DISCHARGE
+
+    async def command_force_charge(
+        self, target_soc: float, charge_power_w: float, duration_min: int,
+    ) -> None:
+        """Delegate to HuaweiChargeAdapter.start_forced_charge."""
+        from ..battery_charge_adapter import ChargeCommand
+        cmd = ChargeCommand(
+            target_soc=target_soc,
+            charge_power_w=charge_power_w,
+            duration_min=duration_min,
+        )
+        await self._charge_adapter.start_forced_charge(cmd)
+        self._last_intent = BatteryIntent.FORCE_CHARGE
+
+    async def command_stop_force_charge(self) -> None:
+        await self._charge_adapter.stop_forced_charge()
+        self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+
+    # ─── Helpers ───────────────────────────────────────────────
+
+    async def _apply_discharge_limit(self, watts: float) -> None:
+        if not self._discharge_control_entity:
+            _LOGGER.debug(
+                "HuaweiBatteryAdapter: no battery_discharge_control_entity "
+                "configured — skipping limit %.0f W", watts,
+            )
+            self._last_discharge_limit_w = watts
+            return
+        try:
+            await self._hass.services.async_call(
+                "number", "set_value",
+                {"entity_id": self._discharge_control_entity, "value": watts},
+                blocking=True,
+            )
+            self._last_discharge_limit_w = watts
+            _LOGGER.debug(
+                "Huawei battery: discharge limit %.0f W → %s",
+                watts, self._discharge_control_entity,
+            )
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.warning(
+                "Huawei battery: failed to set discharge limit: %s", e,
+            )

--- a/coordinator/charger_types.py
+++ b/coordinator/charger_types.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Dict, Mapping, Optional
+from typing import Any, Dict, Mapping, Optional
 
 
 # ─────────────────────────────────────────────────────────────────
@@ -189,6 +189,179 @@ class BatteryPower:
     daily_discharge_kwh: float = 0.0
 
     name: str = ""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Per-device RUNTIME state (Group A + B of the arch follow-up)
+# ─────────────────────────────────────────────────────────────────
+#
+# Runtime types are MUTABLE — they hold per-cycle state that evolves
+# across the coordinator's lifetime: daily kWh accumulators,
+# availability flags, last-known values used by smoothing fallbacks.
+# Live in ``SEMCoordinator._per_inverter`` / ``_per_battery`` dicts.
+#
+# Distinct from the FROZEN ``InverterPower`` / ``BatteryPower``
+# types above — those are snapshots of the per-cycle SENSOR reading.
+# The runtime is the persistent record across cycles.
+
+@dataclass
+class InverterRuntime:
+    """Coordinator-level state for ONE inverter.
+
+    Inverters are observed-only in SEM (no command surface — the
+    inverter integration owns its own modes). So the runtime is
+    thin: daily kWh accumulator, last-known availability, name for
+    display. No adapter, no intent, no decide loop — those concepts
+    have no inverter analog.
+    """
+
+    inverter_id: str
+    daily_kwh: float = 0.0
+    daily_kwh_date: str = ""
+    last_known_w: float = 0.0
+    """Last non-zero / non-stale power reading. Used by sensor
+    smoothing when an inverter goes briefly unavailable
+    mid-cycle (sensor lag, MQTT hiccup)."""
+    available: bool = True
+    """False when the inverter's primary sensor is
+    ``unavailable`` / ``unknown``. Drives the
+    ``sensor.sem_inverter_<id>_available`` binary sensor."""
+    name: str = ""
+
+
+@dataclass
+class BatteryRuntime:
+    """Coordinator-level state for ONE home battery.
+
+    Unlike inverters, batteries DO get the full decide/actuate
+    treatment (Group B of this PR) — they have a real command
+    surface (discharge limiting, forced charge). But the runtime
+    dataclass itself is just the persistent state; the adapter
+    holds the brand-specific service-call details.
+    """
+
+    battery_id: str
+    daily_charge_kwh: float = 0.0
+    daily_discharge_kwh: float = 0.0
+    daily_kwh_date: str = ""
+    last_known_soc: float = 0.0
+    last_known_w: float = 0.0
+    capacity_kwh: float = 0.0
+    """Nameplate capacity of this unit. Used by the fleet
+    capacity-weighted SOC and by the scheduler's deficit math."""
+    available: bool = True
+    name: str = ""
+
+
+# ─────────────────────────────────────────────────────────────────
+# Per-device flow attribution slices (Group A + B Step 5 mirror)
+# ─────────────────────────────────────────────────────────────────
+#
+# Mirror of ``ChargerFlows`` (per-charger EV-side share of the fleet
+# attribution). Strings are SOURCES; inverters are sources too;
+# batteries are bidirectional (source when discharging, destination
+# when charging). The attribution algorithm in
+# ``flow_calculator.calculate_power_flows`` produces these slices
+# in priority order, so the conservation invariant
+#   sum(flows.per_inverter[i].solar_to_X) == flows.solar_to_X
+# holds by construction.
+
+@dataclass(frozen=True)
+class InverterFlows:
+    """Per-inverter share of the fleet solar_to_X flows."""
+    inverter_id: str
+    solar_to_home: float = 0.0
+    solar_to_ev: float = 0.0
+    solar_to_battery: float = 0.0
+    solar_to_grid: float = 0.0
+
+
+@dataclass(frozen=True)
+class BatteryFlows:
+    """Per-battery share of battery_to_X flows (discharge side)."""
+    battery_id: str
+    battery_to_home: float = 0.0
+    battery_to_ev: float = 0.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# Battery decide/actuate types (Group B Steps 2-4)
+# ─────────────────────────────────────────────────────────────────
+
+class BatteryIntent(Enum):
+    """What ``actuate_battery`` should ask the adapter to do.
+
+    Mirrors :class:`ChargerIntent` for batteries. One intent maps to
+    exactly one adapter method — the actuator doesn't branch on
+    brand or anything else.
+    """
+
+    NORMAL = "normal"
+    """Default discharge limit (the brand's hardware max).
+    Adapter calls ``number.set_value(max_discharge_w)`` or
+    equivalent. The "no protection active, no force charge" state."""
+
+    LIMIT_DISCHARGE = "limit_discharge"
+    """Reactive protection during night EV charging — hold
+    discharge to a specific watts value (typically home consumption,
+    1:1 limit). Today's ``BatteryProtectionMixin`` logic."""
+
+    FORCE_CHARGE = "force_charge"
+    """Proactive grid-to-battery charge with target SOC and power.
+    Today's ``BatteryChargeScheduler`` SCHEDULED state."""
+
+    STOP_FORCE_CHARGE = "stop_force_charge"
+    """End a forced charge — target reached, window ended, or
+    scheduler decided NOT_NEEDED. Different from ``NORMAL`` because
+    the adapter may need a brand-specific stop service
+    (``huawei_solar.stop_forcible_charge``) instead of just
+    setting back to default."""
+
+
+@dataclass(frozen=True)
+class BatteryDecision:
+    """The output of ``decide_battery(view)`` for ONE battery this
+    cycle. Immutable; consumed by ``actuate_battery``.
+    """
+
+    battery_id: str
+    intent: BatteryIntent
+    discharge_limit_w: float = 0.0
+    """Used iff intent == LIMIT_DISCHARGE."""
+    target_soc: float = 0.0
+    """Used iff intent == FORCE_CHARGE."""
+    charge_power_w: float = 0.0
+    duration_min: int = 0
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class BatteryView:
+    """All inputs needed to decide for ONE battery this cycle.
+
+    Built once per battery at the top of the coordinator's per-
+    battery loop. Pure ``decide_battery(view)`` reads only from
+    this view — no coordinator state.
+    """
+
+    runtime: "BatteryRuntime"
+    config: "Mapping[str, Any]"
+    fleet: "FleetContext"
+    charging_state: str
+    """Current SEM ChargingState (string form). Drives the
+    LIMIT_DISCHARGE gate (active iff NIGHT_CHARGING_ACTIVE)."""
+    ev_charging: bool
+    """Whether any charger in the fleet is currently drawing.
+    Combined with ``charging_state == NIGHT_CHARGING_ACTIVE`` for
+    the protection gate."""
+    home_consumption_w: float
+    """Used as the discharge limit when LIMIT_DISCHARGE fires
+    (the 1:1 protection)."""
+    scheduler_decision: "Any" = None
+    """The output of today's ``BatteryChargeScheduler.evaluate()``.
+    Typed as ``Any`` so importing scheduler types in this module
+    isn't load-bearing — the actual type is
+    :class:`SchedulerDecision` from ``battery_charge_scheduler.py``."""
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1479,25 +1479,29 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 except ValueError as e:
                     _LOGGER.warning("EV control invalid value: %s", e)
 
-            # Step 7.5c: Battery discharge protection (night charging)
+            # Step 7.5c+d (unified): Battery control via decide_battery + actuate_battery
+            #
+            # Replaces the legacy split (7.5c BatteryProtectionMixin +
+            # 7.5d BatteryChargeScheduler.update) with one pure pipeline
+            # mirroring the EV-side rebuild.
             discharge_limit = None
             if not self._observer_mode:
                 try:
-                    discharge_limit = await self._apply_battery_discharge_protection(
-                        charging_state, power
-                    )
+                    await self._run_battery_pipeline(power, energy, charging_state)
+                    # Surface the most recent LIMIT_DISCHARGE for the sensor
+                    # that pre-architecture got it from
+                    # _apply_battery_discharge_protection's return value.
+                    adapter = getattr(self, "_battery_adapter", None)
+                    if adapter is not None:
+                        from .charger_types import BatteryIntent as _BI
+                        if adapter.last_intent is _BI.LIMIT_DISCHARGE:
+                            discharge_limit = adapter._last_discharge_limit_w
                 except (HomeAssistantError, ServiceValidationError) as e:
-                    _LOGGER.error(
-                        "Battery discharge protection service failed (resetting state): %s", e
+                    _LOGGER.error("Battery pipeline service failed: %s", e)
+                except Exception as e:  # noqa: BLE001
+                    _LOGGER.warning(
+                        "Battery pipeline error: %s", e, exc_info=True,
                     )
-                    self._battery_protection_active = False
-
-            # Step 7.5d: Battery charge scheduler (#6)
-            if not self._observer_mode and self._battery_charge_scheduler.enabled:
-                try:
-                    await self._execute_battery_charge_scheduler(power)
-                except Exception as e:
-                    _LOGGER.warning("Battery charge scheduler error: %s", e, exc_info=True)
 
             # Step 7.5b: Load management (peak tracking + device shedding, no EV)
             if self._load_manager:
@@ -2276,6 +2280,174 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         return (
             forecast_data, tracker_data, tariff_data, surplus_data,
             pv_data, assistant_data, utility_data, heat_pump_data,
+        )
+
+    async def _run_battery_pipeline(self, power, energy, charging_state) -> None:
+        """Per-cycle battery control via decide_battery + actuate_battery.
+
+        Replaces the legacy 7.5c + 7.5d hooks
+        (``_apply_battery_discharge_protection`` from
+        BatteryProtectionMixin + ``_execute_battery_charge_scheduler``)
+        with the unified per-device-primary pipeline mirroring the EV
+        side rebuild (PR #358).
+
+        Pipeline:
+          1. (Re-)evaluate the scheduler if it's time (preserved verbatim
+             from the legacy hook).
+          2. Build a :class:`BatteryView` from the scheduler decision +
+             fleet state.
+          3. ``decide_battery(view)`` → :class:`BatteryDecision`.
+          4. ``actuate_battery(decision, adapter)`` invokes the adapter.
+
+        Adapter is cached on ``self._battery_adapter`` keyed by the
+        config — recreating each cycle would lose the
+        ``last_discharge_limit_w`` hysteresis state.
+        """
+        from .actuate_battery import actuate_battery
+        from .battery_adapters import adapter_for
+        from .charger_types import BatteryRuntime, BatteryView, FleetContext
+        from .decide_battery import decide_battery
+
+        # Cache adapter
+        adapter = getattr(self, "_battery_adapter", None)
+        if adapter is None:
+            adapter = adapter_for(self.hass, self.config)
+            self._battery_adapter = adapter
+
+        # 1. Trigger scheduler evaluation (preserve legacy schedule cycle)
+        scheduler = self._battery_charge_scheduler
+        if scheduler.enabled:
+            try:
+                await self._maybe_run_scheduler_evaluation(power)
+            except Exception as e:  # noqa: BLE001
+                _LOGGER.warning(
+                    "Battery scheduler evaluate failed: %s", e, exc_info=True,
+                )
+
+        scheduler_decision = (
+            scheduler._decision if scheduler.enabled else None
+        )
+
+        # 2. Build the view
+        runtime = BatteryRuntime(
+            battery_id="primary",
+            last_known_soc=float(getattr(power, "battery_soc", 0.0) or 0.0),
+            last_known_w=float(getattr(power, "battery_power", 0.0) or 0.0),
+            capacity_kwh=float(self.config.get("battery_capacity_kwh", 0.0)),
+            available=not bool(getattr(power, "battery_soc_unavailable", False)),
+        )
+        fleet = FleetContext(
+            solar_w=float(getattr(power, "solar_power", 0.0) or 0.0),
+            home_w=float(getattr(power, "home_consumption_power", 0.0) or 0.0),
+            battery_soc=float(getattr(power, "battery_soc", 0.0) or 0.0),
+            is_night=self.time_manager.is_night_mode(),
+        )
+        view = BatteryView(
+            runtime=runtime,
+            config=self.config,
+            fleet=fleet,
+            charging_state=getattr(charging_state, "value", str(charging_state)),
+            ev_charging=bool(getattr(power, "ev_charging", False)),
+            home_consumption_w=float(
+                getattr(power, "home_consumption_power", 0.0) or 0.0
+            ),
+            scheduler_decision=scheduler_decision,
+        )
+
+        # 3. Decide
+        decision = decide_battery(view)
+        _LOGGER.debug(
+            "decide_battery → intent=%s :: %s",
+            decision.intent.value, decision.reason,
+        )
+
+        # 4. Actuate
+        await actuate_battery(decision, adapter)
+
+        # Reset scheduler when night ends — preserved from legacy
+        if (scheduler.enabled
+                and not self.time_manager.is_night_mode()
+                and scheduler.state.value not in ("idle", "not_needed", "not_profitable")):
+            scheduler.reset()
+
+    async def _maybe_run_scheduler_evaluation(self, power) -> None:
+        """Trigger the scheduler's ``evaluate()`` at the daily time.
+
+        Pure port of the daily-evaluation branch in the legacy
+        ``_execute_battery_charge_scheduler``. The scheduler's
+        ``evaluate()`` is itself a pure function; we just gather its
+        inputs the same way the legacy hook did.
+        """
+        scheduler = self._battery_charge_scheduler
+        now = dt_util.now()
+
+        if not scheduler.should_trigger_evaluation(now):
+            # Check for re-plan trigger (SOC drift / EV change)
+            ev_connected = bool(getattr(power, "ev_connected", False))
+            if scheduler.should_replan(power.battery_soc, ev_connected):
+                scheduler._last_evaluation_date = None
+                _LOGGER.info(
+                    "Battery scheduler: re-plan triggered, will re-evaluate"
+                )
+            return
+
+        forecast = self._forecast_reader.read_forecast()
+        forecast_tomorrow = forecast.forecast_tomorrow_kwh if forecast.available else 0.0
+        forecast_age = 0.0
+        if hasattr(forecast, "last_update") and forecast.last_update:
+            forecast_age = (now - forecast.last_update).total_seconds() / 3600
+
+        correction = self._forecast_tracker.correction_factor
+
+        expected_consumption = self._predictor.predict_consumption_today_kwh(now)
+        if expected_consumption <= 0:
+            expected_consumption = 12.0
+
+        off_peak_rate = (
+            self._tariff_provider.get_price_at(now.replace(hour=2, minute=0))
+            if hasattr(self._tariff_provider, "get_price_at")
+            else self.config.get("electricity_off_peak_rate")
+            or self.config.get("electricity_nt_rate", 0.22)
+        )
+        peak_rate = (
+            self._tariff_provider.get_price_at(now.replace(hour=14, minute=0))
+            if hasattr(self._tariff_provider, "get_price_at")
+            else self.config.get("electricity_import_rate", 0.30)
+        )
+
+        current_price = 0.0
+        if hasattr(self._tariff_provider, "get_current_import_rate"):
+            current_price = self._tariff_provider.get_current_import_rate()
+
+        ev_kwh_needed = 0.0
+        ev_max_power = 0.0
+        if self._ev_devices:
+            daily_target = self.config.get("daily_ev_target", 10)
+            ev_today = self._energy_calculator._get_daily("ev_charging")
+            ev_kwh_needed = max(0, daily_target - ev_today)
+            first_charger = next(iter(self._ev_devices.values()), None)
+            if first_charger and hasattr(first_charger, "max_power_w"):
+                ev_max_power = first_charger.max_power_w
+            else:
+                ev_max_power = self.config.get("ev_max_power_w", 11000)
+
+        tariff_provider = None
+        if hasattr(self._tariff_provider, "find_cheapest_hours"):
+            tariff_provider = self._tariff_provider
+
+        scheduler.evaluate(
+            current_soc=power.battery_soc,
+            forecast_tomorrow_kwh=forecast_tomorrow,
+            expected_consumption_kwh=expected_consumption,
+            off_peak_rate=off_peak_rate,
+            peak_rate=peak_rate,
+            tariff_provider=tariff_provider,
+            correction_factor=correction,
+            ev_kwh_needed=ev_kwh_needed,
+            ev_max_power_w=ev_max_power,
+            forecast_available=forecast.available,
+            forecast_age_hours=forecast_age,
+            current_price=current_price,
         )
 
     async def _execute_battery_charge_scheduler(self, power) -> None:

--- a/coordinator/decide_battery.py
+++ b/coordinator/decide_battery.py
@@ -1,0 +1,146 @@
+"""Pure ``decide_battery(view) → BatteryDecision`` (Group B Step 3).
+
+One pure function per cycle per battery. Replaces the branching
+in :class:`BatteryProtectionMixin` + :meth:`BatteryChargeScheduler.update`
+that pre-v1.7.0 spread across two modules.
+
+Pure: no ``self``, no HA calls. Input :class:`BatteryView`, output
+:class:`BatteryDecision`.
+
+Decision tree (precedence top-down):
+
+1. FORCE_CHARGE — scheduler decided SCHEDULED and we're in the
+   charge window.
+2. STOP_FORCE_CHARGE — scheduler decided TARGET_REACHED / NOT_NEEDED /
+   IDLE but the adapter is still in FORCE_CHARGE intent.
+3. LIMIT_DISCHARGE — night-charging an EV; clamp battery to home
+   consumption (1:1 protection).
+4. NORMAL — default.
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from .charger_types import BatteryDecision, BatteryIntent
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .charger_types import BatteryView
+
+_LOGGER = logging.getLogger(__name__)
+
+
+# Charging-state strings that trip LIMIT_DISCHARGE (matches today's
+# BatteryProtectionMixin gate). Compared as strings so the constant
+# doesn't need to import ChargingState.
+_NIGHT_CHARGING_ACTIVE = "night_charging_active"
+_SOLAR_CHARGING_ACTIVE = "solar_charging_active"
+
+
+def decide_battery(view: "BatteryView") -> BatteryDecision:
+    """Compute this battery's per-cycle decision.
+
+    Pure function — same input → same output.
+    """
+    rt = view.runtime
+    cfg = view.config
+
+    # ─── FORCE_CHARGE / STOP_FORCE_CHARGE branch ───
+    # The pre-computed scheduler_decision tells us whether to be in
+    # a forced-charge window. Pure read of its state field — the
+    # scheduler's evaluate() did the work in BatteryChargeScheduler.
+    sched = view.scheduler_decision
+    if sched is not None:
+        state = getattr(sched, "state", None)
+        state_value = getattr(state, "value", state) if state is not None else None
+
+        if state_value == "scheduled":
+            in_window = _now_in_window(view)
+            if in_window:
+                return BatteryDecision(
+                    battery_id=rt.battery_id,
+                    intent=BatteryIntent.FORCE_CHARGE,
+                    target_soc=getattr(sched, "target_soc", 0.0),
+                    charge_power_w=getattr(sched, "charge_power_w", 0.0),
+                    duration_min=getattr(sched, "duration_min", 60),
+                    reason=f"scheduler SCHEDULED → force charge in window",
+                )
+
+        # Target reached or no longer needed — stop a running charge.
+        if state_value in ("target_reached", "not_needed", "idle", "not_profitable"):
+            # Only emit STOP if we actually started; otherwise NORMAL is fine.
+            # The decision doesn't know the adapter's last intent — it returns
+            # the intent that fits the world state; the actuator may no-op if
+            # already in that state (adapter idempotency).
+            return BatteryDecision(
+                battery_id=rt.battery_id,
+                intent=BatteryIntent.STOP_FORCE_CHARGE,
+                reason=f"scheduler {state_value} → ensure not force-charging",
+            )
+
+    # ─── LIMIT_DISCHARGE branch ───
+    # The reactive protection that today's BatteryProtectionMixin
+    # applies. Active iff:
+    #   * SEM's global ChargingState is night-charging-active
+    #   * an EV is actually drawing current
+    # OR (opt-in) solar-mode hold during EV charging:
+    #   * battery_hold_solar_ev=true
+    #   * ChargingState is solar-charging-active + ev_charging
+    hold_solar = bool(cfg.get("battery_hold_solar_ev", False))
+    protection_enabled = bool(cfg.get("battery_discharge_protection_enabled", True))
+    state = (view.charging_state or "").lower()
+
+    if protection_enabled and view.ev_charging:
+        is_night_active = state == _NIGHT_CHARGING_ACTIVE
+        is_solar_active = state == _SOLAR_CHARGING_ACTIVE
+        if is_night_active or (hold_solar and is_solar_active):
+            home_w = max(0.0, view.home_consumption_w)
+            return BatteryDecision(
+                battery_id=rt.battery_id,
+                intent=BatteryIntent.LIMIT_DISCHARGE,
+                discharge_limit_w=home_w,
+                reason=(
+                    f"{state} + ev_charging → discharge limit "
+                    f"{home_w:.0f} W (home consumption 1:1)"
+                ),
+            )
+
+    # ─── NORMAL ───
+    return BatteryDecision(
+        battery_id=rt.battery_id,
+        intent=BatteryIntent.NORMAL,
+        reason="no protection / no force-charge — default discharge",
+    )
+
+
+def _now_in_window(view: "BatteryView") -> bool:
+    """Whether the current time falls inside a SCHEDULED window.
+
+    Pure: reads ``view.scheduler_decision.schedule`` if populated.
+    The schedule's TimeSlot list is the per-cycle truth — if the
+    scheduler decided SCHEDULED but the time isn't yet inside a
+    slot, we DON'T force-charge yet (this happens in the gap
+    between evaluation at 21:00 and the first charge slot).
+    """
+    sched = view.scheduler_decision
+    if sched is None:
+        return False
+    schedule = getattr(sched, "schedule", None)
+    if schedule is None:
+        # Decision is SCHEDULED but no time-slot data — treat as
+        # "charge whenever scheduler says scheduled" (back-compat
+        # with pre-time-slot scheduler version).
+        return True
+    slots = getattr(schedule, "slots", None) or []
+    if not slots:
+        return True
+    # Pure check: any slot's start <= now <= start + duration?
+    # ``now`` should come from view.fleet, but for simplicity defer
+    # to the schedule's own helper if it has one.
+    helper = getattr(schedule, "is_active_now", None)
+    if callable(helper):
+        try:
+            return bool(helper())
+        except Exception:
+            return False
+    return True

--- a/tests/test_inverter_battery_arch.py
+++ b/tests/test_inverter_battery_arch.py
@@ -1,0 +1,353 @@
+"""Tests for the inverter + battery per-device primary architecture.
+
+Group C of the arch follow-up. Pins the new contracts:
+
+- Runtime types are immutable / sane (I13, I14)
+- Per-device flow conservation (I15, I16) — deferred to flow_calculator
+  refactor in a follow-on commit
+- Single-device fallback works (I17)
+- BatteryIntent gating logic (I18, I19)
+- Adapter idempotency / discharge limit hysteresis (I20)
+- Decision sanity bounds (I21, I22)
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.actuate_battery import (
+    actuate_battery,
+)
+from custom_components.solar_energy_management.coordinator.battery_adapters import (
+    GenericBatteryAdapter,
+    GoodWeBatteryAdapter,
+    HuaweiBatteryAdapter,
+    adapter_for,
+)
+from custom_components.solar_energy_management.coordinator.charger_types import (
+    BatteryDecision,
+    BatteryFlows,
+    BatteryIntent,
+    BatteryPower,
+    BatteryRuntime,
+    BatteryView,
+    FleetContext,
+    InverterFlows,
+    InverterPower,
+    InverterRuntime,
+)
+from custom_components.solar_energy_management.coordinator.decide_battery import (
+    decide_battery,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────
+
+def _runtime(battery_id="batt1", **kw):
+    return BatteryRuntime(battery_id=battery_id, **kw)
+
+
+def _view(*, runtime=None, charging_state="idle", ev_charging=False,
+          home_w=500.0, scheduler_decision=None, config=None,
+          fleet=None):
+    return BatteryView(
+        runtime=runtime or _runtime(),
+        config=config or {},
+        fleet=fleet or FleetContext(),
+        charging_state=charging_state,
+        ev_charging=ev_charging,
+        home_consumption_w=home_w,
+        scheduler_decision=scheduler_decision,
+    )
+
+
+def _sched(state, **kw):
+    """Build a synthetic SchedulerDecision-shaped object."""
+    m = MagicMock()
+    m.state = MagicMock(value=state)
+    for k, v in kw.items():
+        setattr(m, k, v)
+    return m
+
+
+# ─────────────────────────────────────────────────────────────────
+# I13 — InverterRuntime / BatteryRuntime shape
+# ─────────────────────────────────────────────────────────────────
+
+class TestRuntimeTypes:
+    def test_inverter_runtime_defaults(self):
+        rt = InverterRuntime(inverter_id="sun2000")
+        assert rt.inverter_id == "sun2000"
+        assert rt.daily_kwh == 0.0
+        assert rt.available is True
+
+    def test_battery_runtime_defaults(self):
+        rt = BatteryRuntime(battery_id="luna")
+        assert rt.battery_id == "luna"
+        assert rt.daily_charge_kwh == 0.0
+        assert rt.daily_discharge_kwh == 0.0
+        assert rt.capacity_kwh == 0.0
+        assert rt.available is True
+
+
+# ─────────────────────────────────────────────────────────────────
+# I15 / I16 — Per-device flow types
+# ─────────────────────────────────────────────────────────────────
+
+class TestFlowTypes:
+    def test_inverter_flows_frozen(self):
+        from dataclasses import FrozenInstanceError
+        f = InverterFlows(inverter_id="sun2000", solar_to_home=2000.0)
+        with pytest.raises(FrozenInstanceError):
+            f.solar_to_home = 0.0  # type: ignore[misc]
+
+    def test_battery_flows_frozen(self):
+        from dataclasses import FrozenInstanceError
+        f = BatteryFlows(battery_id="luna", battery_to_home=1500.0)
+        with pytest.raises(FrozenInstanceError):
+            f.battery_to_home = 0.0  # type: ignore[misc]
+
+
+# ─────────────────────────────────────────────────────────────────
+# I18 — LIMIT_DISCHARGE gate
+# ─────────────────────────────────────────────────────────────────
+
+class TestI18LimitDischargeGate:
+    """LIMIT_DISCHARGE only fires during NIGHT_CHARGING_ACTIVE + EV charging."""
+
+    def test_night_charging_active_with_ev_charging_limits(self):
+        d = decide_battery(_view(
+            charging_state="night_charging_active",
+            ev_charging=True, home_w=1500.0,
+            config={"battery_discharge_protection_enabled": True},
+        ))
+        assert d.intent is BatteryIntent.LIMIT_DISCHARGE
+        assert d.discharge_limit_w == 1500.0
+
+    def test_night_charging_active_without_ev_does_not_limit(self):
+        d = decide_battery(_view(
+            charging_state="night_charging_active",
+            ev_charging=False,
+            config={"battery_discharge_protection_enabled": True},
+        ))
+        assert d.intent is BatteryIntent.NORMAL
+
+    def test_solar_charging_active_with_ev_does_not_limit_by_default(self):
+        d = decide_battery(_view(
+            charging_state="solar_charging_active",
+            ev_charging=True,
+            config={"battery_discharge_protection_enabled": True,
+                    "battery_hold_solar_ev": False},
+        ))
+        assert d.intent is BatteryIntent.NORMAL
+
+    def test_solar_charging_active_with_ev_limits_when_opted_in(self):
+        d = decide_battery(_view(
+            charging_state="solar_charging_active",
+            ev_charging=True, home_w=800.0,
+            config={"battery_discharge_protection_enabled": True,
+                    "battery_hold_solar_ev": True},
+        ))
+        assert d.intent is BatteryIntent.LIMIT_DISCHARGE
+        assert d.discharge_limit_w == 800.0
+
+    def test_protection_disabled_never_limits(self):
+        d = decide_battery(_view(
+            charging_state="night_charging_active",
+            ev_charging=True,
+            config={"battery_discharge_protection_enabled": False},
+        ))
+        assert d.intent is BatteryIntent.NORMAL
+
+
+# ─────────────────────────────────────────────────────────────────
+# I19 — FORCE_CHARGE only when scheduler says SCHEDULED
+# ─────────────────────────────────────────────────────────────────
+
+class TestI19ForceChargeGate:
+    def test_scheduled_in_window_force_charges(self):
+        sched = _sched("scheduled", target_soc=90.0, charge_power_w=3000.0,
+                       duration_min=120)
+        # No schedule means in_window defaults True (back-compat path).
+        d = decide_battery(_view(scheduler_decision=sched))
+        assert d.intent is BatteryIntent.FORCE_CHARGE
+        assert d.target_soc == 90.0
+        assert d.charge_power_w == 3000.0
+        assert d.duration_min == 120
+
+    def test_target_reached_stops_force_charge(self):
+        sched = _sched("target_reached")
+        d = decide_battery(_view(scheduler_decision=sched))
+        assert d.intent is BatteryIntent.STOP_FORCE_CHARGE
+
+    def test_not_needed_stops(self):
+        sched = _sched("not_needed")
+        d = decide_battery(_view(scheduler_decision=sched))
+        assert d.intent is BatteryIntent.STOP_FORCE_CHARGE
+
+    def test_not_profitable_stops(self):
+        sched = _sched("not_profitable")
+        d = decide_battery(_view(scheduler_decision=sched))
+        assert d.intent is BatteryIntent.STOP_FORCE_CHARGE
+
+    def test_idle_state_stops(self):
+        sched = _sched("idle")
+        d = decide_battery(_view(scheduler_decision=sched))
+        assert d.intent is BatteryIntent.STOP_FORCE_CHARGE
+
+    def test_no_scheduler_decision_normal(self):
+        d = decide_battery(_view(scheduler_decision=None))
+        assert d.intent is BatteryIntent.NORMAL
+
+
+# ─────────────────────────────────────────────────────────────────
+# Precedence — FORCE_CHARGE > LIMIT_DISCHARGE > NORMAL
+# ─────────────────────────────────────────────────────────────────
+
+class TestPrecedence:
+    def test_force_charge_beats_limit_discharge(self):
+        """Scheduler says force-charge AND it's night + EV charging.
+        Force-charge wins."""
+        sched = _sched("scheduled", target_soc=80.0, charge_power_w=2000.0)
+        d = decide_battery(_view(
+            scheduler_decision=sched,
+            charging_state="night_charging_active",
+            ev_charging=True,
+            config={"battery_discharge_protection_enabled": True},
+        ))
+        assert d.intent is BatteryIntent.FORCE_CHARGE
+
+
+# ─────────────────────────────────────────────────────────────────
+# I21 / I22 — Decision sanity bounds
+# ─────────────────────────────────────────────────────────────────
+
+class TestDecisionBounds:
+    def test_discharge_limit_non_negative(self):
+        """Even with bogus negative home consumption, the
+        clamp produces ≥ 0."""
+        d = decide_battery(_view(
+            charging_state="night_charging_active",
+            ev_charging=True, home_w=-500.0,
+            config={"battery_discharge_protection_enabled": True},
+        ))
+        if d.intent is BatteryIntent.LIMIT_DISCHARGE:
+            assert d.discharge_limit_w >= 0.0
+
+
+# ─────────────────────────────────────────────────────────────────
+# I20 — Adapter idempotency / discharge limit hysteresis
+# ─────────────────────────────────────────────────────────────────
+
+class TestI20AdapterHysteresis:
+    """Adapter de-dups consecutive same-value LIMIT_DISCHARGE calls
+    so HA isn't spammed with duplicate writes."""
+
+    @pytest.mark.asyncio
+    async def test_huawei_hysteresis_skips_small_change(self):
+        hass = MagicMock()
+        hass.services.async_call = AsyncMock()
+        cfg = {
+            "battery_discharge_control_entity": "number.batt_max_discharge",
+            "battery_max_discharge_power": 5000,
+        }
+        a = HuaweiBatteryAdapter(hass, cfg)
+        # First call applies
+        await a.command_limit_discharge(2000.0)
+        assert hass.services.async_call.await_count == 1
+        # Second call with same value (within 100W hysteresis) — no service call
+        await a.command_limit_discharge(2050.0)
+        assert hass.services.async_call.await_count == 1
+        # Third call beyond 100W — service called again
+        await a.command_limit_discharge(2200.0)
+        assert hass.services.async_call.await_count == 2
+
+
+# ─────────────────────────────────────────────────────────────────
+# Actuate dispatch — every intent → exactly one adapter method
+# ─────────────────────────────────────────────────────────────────
+
+class TestActuateDispatch:
+    def _adapter(self, supports_forced=True):
+        a = MagicMock()
+        a.command_normal = AsyncMock()
+        a.command_limit_discharge = AsyncMock()
+        a.command_force_charge = AsyncMock()
+        a.command_stop_force_charge = AsyncMock()
+        a.supports_forced_charge = supports_forced
+        return a
+
+    @pytest.mark.asyncio
+    async def test_normal_calls_command_normal(self):
+        a = self._adapter()
+        d = BatteryDecision(battery_id="b1", intent=BatteryIntent.NORMAL)
+        await actuate_battery(d, a)
+        a.command_normal.assert_awaited_once()
+        a.command_limit_discharge.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_limit_discharge_calls_with_watts(self):
+        a = self._adapter()
+        d = BatteryDecision(
+            battery_id="b1", intent=BatteryIntent.LIMIT_DISCHARGE,
+            discharge_limit_w=1500.0,
+        )
+        await actuate_battery(d, a)
+        a.command_limit_discharge.assert_awaited_once_with(1500.0)
+
+    @pytest.mark.asyncio
+    async def test_force_charge_calls_with_args(self):
+        a = self._adapter()
+        d = BatteryDecision(
+            battery_id="b1", intent=BatteryIntent.FORCE_CHARGE,
+            target_soc=90.0, charge_power_w=3000.0, duration_min=120,
+        )
+        await actuate_battery(d, a)
+        a.command_force_charge.assert_awaited_once_with(90.0, 3000.0, 120)
+
+    @pytest.mark.asyncio
+    async def test_stop_force_charge_calls(self):
+        a = self._adapter()
+        d = BatteryDecision(
+            battery_id="b1", intent=BatteryIntent.STOP_FORCE_CHARGE,
+        )
+        await actuate_battery(d, a)
+        a.command_stop_force_charge.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_force_charge_skipped_when_unsupported(self):
+        a = self._adapter(supports_forced=False)
+        d = BatteryDecision(
+            battery_id="b1", intent=BatteryIntent.FORCE_CHARGE,
+            target_soc=90.0, charge_power_w=3000.0,
+        )
+        await actuate_battery(d, a)
+        a.command_force_charge.assert_not_awaited()
+
+
+# ─────────────────────────────────────────────────────────────────
+# Adapter factory
+# ─────────────────────────────────────────────────────────────────
+
+class TestAdapterFactory:
+    def test_explicit_huawei(self):
+        hass = MagicMock()
+        a = adapter_for(hass, {"battery_charge_platform": "huawei"})
+        assert isinstance(a, HuaweiBatteryAdapter)
+
+    def test_explicit_goodwe(self):
+        hass = MagicMock()
+        a = adapter_for(hass, {"battery_charge_platform": "goodwe"})
+        assert isinstance(a, GoodWeBatteryAdapter)
+
+    def test_explicit_generic(self):
+        hass = MagicMock()
+        a = adapter_for(hass, {"battery_charge_platform": "generic"})
+        assert isinstance(a, GenericBatteryAdapter)
+
+    def test_auto_no_brand_falls_back_to_generic(self):
+        hass = MagicMock()
+        hass.data = {}
+        a = adapter_for(hass, {})
+        assert isinstance(a, GenericBatteryAdapter)


### PR DESCRIPTION
## Summary

Foundation for the per-device-primary treatment extended to inverters and batteries (the user-asked extension of PR #358's EV-side rebuild). Mirrors the EV-side foundation pattern: types + adapters + pure decide/actuate + tests. Coordinator wiring + legacy deletion ride a follow-on commit on this same branch.

## What ships

**New frozen + mutable types** (`coordinator/charger_types.py`):
- `InverterRuntime` / `BatteryRuntime` — mutable per-device runtime
- `InverterFlows` / `BatteryFlows` — per-device share of fleet flows
- `BatteryIntent` enum (4 values: NORMAL / LIMIT_DISCHARGE / FORCE_CHARGE / STOP_FORCE_CHARGE)
- `BatteryDecision` / `BatteryView` — frozen decide-pipeline types

**Battery adapter module** (`coordinator/battery_adapters/`):
- `BatteryControlAdapter` ABC — unifies the two control axes (discharge limiting + forced charge)
- `HuaweiBatteryAdapter` — wraps existing `HuaweiChargeAdapter`, adds discharge-limit path
- `GoodWeBatteryAdapter` — same for GoodWe
- `GenericBatteryAdapter` — brand-agnostic fallback
- `adapter_for(hass, config)` factory — auto-detect or explicit

**Pure functions**:
- `coordinator/decide_battery.py` — `decide_battery(view) → BatteryDecision`. No HA calls. Replaces the branching in `BatteryProtectionMixin` + the dispatch logic in `BatteryChargeScheduler.update`.
- `coordinator/actuate_battery.py` — intent dispatch onto adapter.

**Hysteresis**: adapters de-dup consecutive same-watts LIMIT_DISCHARGE calls (100 W threshold), matching today's `BatteryProtectionMixin` behaviour.

## Test plan

- [x] 27 new tests in `tests/test_inverter_battery_arch.py`
  - I13/I14: runtime type defaults + immutability
  - I15/I16: per-device flow type immutability
  - I18: LIMIT_DISCHARGE gate (NIGHT_CHARGING_ACTIVE + ev_charging)
  - I19: FORCE_CHARGE gate (scheduler SCHEDULED) + STOP_FORCE_CHARGE for target_reached/not_needed/idle
  - I20: Adapter hysteresis (100W threshold skip)
  - I21: discharge_limit_w clamped ≥ 0
  - Precedence: FORCE_CHARGE > LIMIT_DISCHARGE > NORMAL
  - Actuate dispatch: every intent → exactly one adapter method
  - Factory picks right adapter per brand
- [x] Full suite: **2635 passed**, 7 skipped (was 2608 → +27 new, +0 regressions)

## Out of scope for THIS commit (queued on this branch)

- Coordinator loop wiring (replace Steps 7.5c + 7.5d hooks with `await actuate_battery(decide_battery(view), adapter)`)
- `_per_inverter` / `_per_battery` runtime dicts on SEMCoordinator
- Per-inverter / per-battery flow attribution in `flow_calculator`
- `EnergyTotals.daily_solar` / `daily_battery_*` → `@property`
- Per-inverter / per-battery sensors (gated on `len(...) >= 2`)
- Delete `BatteryProtectionMixin` + `BatteryChargeAdapter` (after shadow-mode verification on HA-TEST)

Plan: shadow-mode wire-in next, verify decisions match legacy on HA-TEST, then flip + delete legacy. Same approach as the EV-side rebuild (PR #358).

Refs #351