### PR TITLE
release: v1.7.0-beta.1

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.0"
+  "version": "1.7.0-beta.1"
 }


### PR DESCRIPTION
Bump manifest to `1.7.0-beta.1` for the architecture rebuild beta. CI gate before tagging.