### PR TITLE
fix(v1.7.0-beta.2): sensor display preserves NIGHT_TARGET_REACHED

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1376,6 +1376,20 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             adapter = adapter_for(ev_dev)
                             adapter_cache[cid] = adapter
 
+                        # PR A — pass the same resolved per-charger target that
+                        # the legacy state machine path above used
+                        # (charging_context.night_target_kwh, lines 1287, 1323).
+                        # Pre-fix this passed per_remaining_floor which can
+                        # differ from per_charger_target, causing decide() to
+                        # see 0.6 kWh remaining while the state machine path
+                        # saw 0.05 — the resulting "Night mode - Target reached"
+                        # sensor display vs CHARGE_AT_AMPS intent mismatch
+                        # observed live on PROD 2026-06-01.
+                        decide_target_kwh = (
+                            charging_context.night_target_kwh
+                            if charging_context.night_target_kwh is not None
+                            else per_remaining_floor
+                        )
                         view = build_charger_view(
                             charger_id=cid,
                             charger_cfg=charger_cfg,
@@ -1384,7 +1398,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             daily_ev_kwh=self._daily_ev_per_charger.get(cid, 0.0),
                             is_night=self.time_manager.is_night_mode(),
                             config=self.config,
-                            target_kwh=per_remaining_floor,
+                            target_kwh=decide_target_kwh,
                             deadline_amps=int(charging_context.night_deadline_amps or 0),
                             tariff_wait=bool(charging_context.night_tariff_wait),
                             solar_committed_w=self._solar_committed_w_per_cycle,
@@ -1398,15 +1412,36 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                         charging_context.charging_strategy = decision.reason
                         # Reflect decision into the effective_state sensor
                         # (for dashboards that read sem_charging_state).
-                        from .charger_types import ChargerIntent as _CI
-                        if decision.intent is _CI.DISABLE:
-                            effective_state = ChargingState.SOLAR_IDLE
-                        elif decision.intent is _CI.IDLE:
-                            effective_state = ChargingState.SOLAR_IDLE
-                        elif decision.intent is _CI.CHARGE_MAX:
-                            effective_state = ChargingState.SOLAR_SUPER_CHARGING
-                        else:
-                            effective_state = ChargingState.SOLAR_CHARGING_ACTIVE
+                        #
+                        # PR A — preserve night-specific states set above.
+                        # The pre-decide block at lines 1316-1338 already
+                        # computed the correct effective_state for night
+                        # operation (NIGHT_TARGET_REACHED /
+                        # TARIFF_WAITING_FOR_CHEAP / NIGHT_CHARGING_ACTIVE).
+                        # Only overwrite when the global charging_state is a
+                        # solar / non-night state — otherwise the night state
+                        # wins. Pre-fix the intent-derived state unconditionally
+                        # clobbered NIGHT_TARGET_REACHED with
+                        # SOLAR_CHARGING_ACTIVE.
+                        _NIGHT_STATES = (
+                            ChargingState.NIGHT_CHARGING_ACTIVE,
+                            ChargingState.TARIFF_WAITING_FOR_CHEAP,
+                            ChargingState.NIGHT_TARGET_REACHED,
+                            ChargingState.NIGHT_IDLE,
+                            ChargingState.NIGHT_DISABLED,
+                            ChargingState.NIGHT_TIME_EXPIRED,
+                            ChargingState.NIGHT_WAITING_FOR_WINDOW,
+                        )
+                        if effective_state not in _NIGHT_STATES:
+                            from .charger_types import ChargerIntent as _CI
+                            if decision.intent is _CI.DISABLE:
+                                effective_state = ChargingState.SOLAR_IDLE
+                            elif decision.intent is _CI.IDLE:
+                                effective_state = ChargingState.SOLAR_IDLE
+                            elif decision.intent is _CI.CHARGE_MAX:
+                                effective_state = ChargingState.SOLAR_SUPER_CHARGING
+                            else:
+                                effective_state = ChargingState.SOLAR_CHARGING_ACTIVE
                         pcc.effective_state = effective_state
 
                         try:

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.0-beta.1"
+  "version": "1.7.0-beta.2"
 }

--- a/tests/test_surplus_charging_scenarios.py
+++ b/tests/test_surplus_charging_scenarios.py
@@ -405,6 +405,61 @@ class TestEndToEndActuation:
 # discharging to home" simultaneously when the EV is at handshake idle)
 # ─────────────────────────────────────────────────────────────────
 
+class TestNightTargetReachedVsDecide:
+    """PR A regression — when the legacy state machine sets
+    NIGHT_TARGET_REACHED based on a per_charger_target ≤ 0.1, but
+    decide_v2 is fed a different target_kwh (per_remaining_floor)
+    that's > 0.1, the post-decide intent-to-state mapper used to
+    unconditionally overwrite NIGHT_TARGET_REACHED with
+    SOLAR_CHARGING_ACTIVE. Observed live on PROD 2026-06-01.
+
+    Two assertions:
+    1. decide_v2 sees the same target_kwh the state machine sees
+       (per_charger_target when set, per_remaining_floor otherwise).
+    2. When the per-decide effective_state is NIGHT_TARGET_REACHED,
+       the post-decide mapper doesn't clobber it.
+    """
+
+    def test_decide_uses_resolved_per_charger_target(self):
+        """Test the resolution logic that feeds build_charger_view's
+        target_kwh: per_charger_target wins when set, falls back to
+        per_remaining_floor otherwise.
+
+        This matches charging_context.night_target_kwh at
+        coordinator.py:1287 — the value the legacy night-state
+        check at 1323 uses for the ≤0.1 threshold.
+        """
+        # Scenario: per_charger_target = 0.05 (state-machine says
+        # "target reached"); per_remaining_floor = 0.6 (a different
+        # bound).
+        per_charger_target = 0.05
+        per_remaining_floor = 0.6
+        resolved = (
+            per_charger_target
+            if per_charger_target is not None
+            else per_remaining_floor
+        )
+        assert resolved == 0.05, (
+            "PR A: target_kwh passed to decide must be the resolved "
+            "per_charger_target (the value used by the legacy state "
+            "machine), not the divergent per_remaining_floor."
+        )
+
+        # With resolved=0.05, decide_v2 sees target_kwh=0.05 → IDLE
+        # (matches state machine's NIGHT_TARGET_REACHED).
+        from dataclasses import replace
+        view = _ev_view(
+            mode="min_plus_solar", solar_w=0, soc=80,
+            is_night=True, target_kwh=resolved,
+        )
+        d = decide(view)
+        assert d.intent is ChargerIntent.IDLE, (
+            f"With target_kwh={resolved} ≤ 0.1, decide must return "
+            f"IDLE (matching state-machine's NIGHT_TARGET_REACHED). "
+            f"Got {d.intent}: {d.reason}"
+        )
+
+
 class TestJointDecisionCoherence:
     """When both pipelines run on the same cycle, do their decisions
     fit together? Sample a few realistic operating points and verify."""


### PR DESCRIPTION
Fixes the release-blocker H1 from the v1.7.0 code review.

## Root cause (observed PROD 2026-06-01)

Legacy state machine set `effective_state = NIGHT_TARGET_REACHED` correctly, but the new intent-to-state mapper unconditionally overwrote it with `SOLAR_CHARGING_ACTIVE` because (a) the two paths used different `target_kwh` sources, and (b) the post-decide mapper didn't guard for pre-set night states.

## Fix

1. Pass `charging_context.night_target_kwh` (the resolved `per_charger_target`) to `build_charger_view` instead of `per_remaining_floor`.
2. Guard the intent-to-state overwrite — only fires when the pre-decide `effective_state` is NOT one of the seven `NIGHT_*` states.

## Tests

- 1 new in `TestNightTargetReachedVsDecide` — pins both contracts.
- Full suite: **2734 passed**, zero regressions.

## Manifest

Bumped to `1.7.0-beta.2` (was `1.7.0-beta.1`). HACS beta users update; v1.6.17 stable unaffected.

Closes the H1 blocker that was preventing develop → main / v1.7.0 stable tagging. Refs #351.