### PR TITLE
fix(#355): bump EV target slider max from 100 to 200 kWh

### DIFF
--- a/number.py
+++ b/number.py
@@ -345,7 +345,12 @@ async def async_setup_entry(
                     key=f"charger_{cid}_daily_ev_target",
                     name=f"{cname} Night Target",
                     native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-                    native_min_value=0, native_max_value=100, native_step=0.5,
+                    # #355: max raised 100 → 200 so the slider has drag room
+                    # when the user (or default) has Solar Max sitting at the
+                    # rail. Pre-fix a range slider with Min + Max both at 100
+                    # had zero space between the handles and could not be
+                    # dragged. Covers any practical EV battery size.
+                    native_min_value=0, native_max_value=200, native_step=0.5,
                     mode=NumberMode.SLIDER,
                 ), "daily_ev_target", full_config.get("daily_ev_target", 10)),
                 (NumberEntityDescription(
@@ -376,7 +381,10 @@ async def async_setup_entry(
                     key=f"charger_{cid}_daily_ev_target_max",
                     name=f"{cname} Solar Max",
                     native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
-                    native_min_value=0, native_max_value=100, native_step=0.5,
+                    # #355: max raised 100 → 200 — same reason as the Min slider
+                    # above. With both defaulting to 100 (full charge intent),
+                    # the range slider had zero drag room.
+                    native_min_value=0, native_max_value=200, native_step=0.5,
                     mode=NumberMode.SLIDER,
                     icon="mdi:solar-power-variant",
                 ), "daily_ev_target_max",


### PR DESCRIPTION
User #355 reported that the range slider became unmovable when both handles (Min Night Target + Max Solar Max) were at 100 kWh — the slider max value, no drag room.

Fix: bump `native_max_value` from 100 to 200 on both `daily_ev_target` and `daily_ev_target_max` slider descriptions. Covers any practical EV battery size; gives the slider room to drag even when defaults sit at 100. No default change, no semantic change downstream.

Closes #355