### PR TITLE
fix(#352): manual grid_sign_invert option for Enphase

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -1334,6 +1334,17 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 ),
+                # #352 — Enphase + a handful of other installs report
+                # grid power with +import / -export polarity (opposite
+                # of SEM's convention). The Energy-Dashboard-counter
+                # auto-detect can't always stabilise on these (counters
+                # tick at coarse intervals). This toggle is the manual
+                # escape hatch: when ON, the raw read is negated and
+                # auto-detect is bypassed.
+                vol.Optional(
+                    "grid_sign_invert",
+                    default=_c("grid_sign_invert", False),
+                ): selector.BooleanSelector(),
             }),
             errors=errors,
         )

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -214,15 +214,25 @@ class SensorReader:
         # Calculate derived values
         readings.calculate_derived()
 
-        # Auto-detect grid sign convention using Energy Dashboard counters.
-        # SEM convention: negative = import, positive = export.
-        # Compares power sensor sign against import/export energy counter
-        # changes to determine if negation is needed.
-        needs_negate = self._detect_grid_sign(readings)
-
-        if needs_negate:
+        # Manual grid-sign override (#352): when the user sets
+        # ``grid_sign_invert: True`` the auto-detect path is bypassed
+        # entirely and the raw read is negated. Required for Enphase /
+        # other installs where the energy-counter heuristic can't
+        # stabilise.
+        manual_grid_invert = bool(self._raw_config.get("grid_sign_invert", False))
+        if manual_grid_invert:
             readings.grid_power = -readings.grid_power
             readings.calculate_derived()
+        else:
+            # Auto-detect grid sign convention using Energy Dashboard counters.
+            # SEM convention: negative = import, positive = export.
+            # Compares power sensor sign against import/export energy counter
+            # changes to determine if negation is needed.
+            needs_negate = self._detect_grid_sign(readings)
+
+            if needs_negate:
+                readings.grid_power = -readings.grid_power
+                readings.calculate_derived()
 
         # Auto-detect battery sign convention using Energy Dashboard counters.
         # SEM convention: positive = charge, negative = discharge.

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -292,6 +292,7 @@ The options flow is organized into these pages:
 | Assist floor SOC (%) | 60% | Once battery assist starts, it stays on until SOC drops here. This prevents rapid on/off cycling. Raise it if the battery cycles too often. |
 | Battery capacity (kWh) | 10 kWh | Your battery's usable capacity. Used for SOC target calculations and cost attribution. |
 | Max assist power (W) | 4500 W | Maximum battery discharge power allowed for EV charging. Set it to the lower of your battery's rated discharge power and your charger's maximum input. |
+| Invert grid sign | Off | Manual override for grid power polarity. SEM expects `negative = import, positive = export`. Enphase and a handful of other inverters report the opposite. Turn this on **only** if your "Daily Grid Import" stays at 0 while you are clearly drawing from the grid, or if the system diagram shows export when you are importing — see #352. When this is on the auto-detect path is bypassed. |
 
 ### Tariff and Pricing settings
 

--- a/tests/test_grid_sign_invert_352.py
+++ b/tests/test_grid_sign_invert_352.py
@@ -1,0 +1,128 @@
+"""Tests for the manual ``grid_sign_invert`` config option (#352).
+
+When the auto-detect path can't stabilise on a given inverter (Enphase
+has been the canonical case), the user can set ``grid_sign_invert:
+True`` on the integration's options entry. The raw sensor read is then
+negated unconditionally and the auto-detect path is bypassed entirely
+(no vote counting, no baseline drift).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, Mock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.sensor_reader import (
+    SensorReader,
+)
+
+
+def _state(value, unit="W"):
+    s = Mock()
+    s.state = str(value)
+    s.attributes = {"unit_of_measurement": unit}
+    return s
+
+
+def _ed_config(grid_power="sensor.grid_power"):
+    ed = Mock()
+    ed.solar_power = None
+    ed.solar_power_list = []
+    ed.battery_power = None
+    ed.battery_power_list = []
+    ed.battery_charge_energy = None
+    ed.battery_discharge_energy = None
+    ed.battery_charge_energy_list = []
+    ed.battery_discharge_energy_list = []
+    ed.grid_power = grid_power
+    ed.grid_import_power = grid_power
+    ed.grid_power_list = [grid_power]
+    ed.grid_import_energy = None
+    ed.grid_export_energy = None
+    ed.ev_power = None
+    ed.ev_energy = None
+    ed.ev_chargers = []
+    ed.has_battery = False
+    ed.has_solar = False
+    ed.has_grid = True
+    ed.has_ev = False
+    return ed
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.states = MagicMock()
+    return hass
+
+
+class TestGridSignInvertOption:
+    """The manual override negates ``grid_power`` and bypasses auto-detect."""
+
+    def test_invert_off_default_behaviour(self, mock_hass):
+        """With the flag off (default) auto-detect runs as before."""
+        mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
+        reader = SensorReader(mock_hass, {})  # no grid_sign_invert key
+        reader.set_energy_dashboard_config(_ed_config())
+
+        readings = reader.read_power()
+
+        # Auto-detect path: with no Energy Dashboard import/export
+        # counters configured, _detect_grid_sign returns False, so the
+        # raw read is preserved.
+        assert readings.grid_power == 2000
+
+    def test_invert_on_negates_grid_power(self, mock_hass):
+        """``grid_sign_invert: True`` flips a positive read to negative."""
+        mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
+        reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader.set_energy_dashboard_config(_ed_config())
+
+        readings = reader.read_power()
+
+        # Manual override applied: SEM convention is -import / +export,
+        # the inverter reported +import (2000), so the result is -2000.
+        assert readings.grid_power == -2000
+
+    def test_invert_on_negates_negative_read(self, mock_hass):
+        """A negative raw read flips to positive (export under SEM)."""
+        mock_hass.states.get = lambda eid: _state(-1500) if eid == "sensor.grid_power" else None
+        reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader.set_energy_dashboard_config(_ed_config())
+
+        readings = reader.read_power()
+
+        assert readings.grid_power == 1500
+
+    def test_invert_on_skips_autodetect_vote(self, mock_hass):
+        """Auto-detect state is not touched when the manual override fires."""
+        mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
+        reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader.set_energy_dashboard_config(_ed_config())
+
+        # Pre-conditions: auto-detect state untouched.
+        assert reader._grid_sign_votes == 0
+        assert reader._grid_sign_detected is False
+
+        # Run several cycles.
+        for _ in range(5):
+            reader.read_power()
+
+        # Post-conditions: auto-detect votes and the "detected" flag are
+        # still at their initial values because the manual override
+        # bypassed _detect_grid_sign() entirely.
+        assert reader._grid_sign_votes == 0
+        assert reader._grid_sign_detected is False
+        assert reader._grid_sign_inverted is False
+
+    def test_invert_zero_is_zero(self, mock_hass):
+        """0 → 0 under negation."""
+        mock_hass.states.get = lambda eid: _state(0) if eid == "sensor.grid_power" else None
+        reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader.set_energy_dashboard_config(_ed_config())
+
+        readings = reader.read_power()
+
+        # ``-0.0 == 0.0`` so the comparison is fine; we just want no
+        # crash and no spurious sign flip artefact.
+        assert readings.grid_power == 0


### PR DESCRIPTION
## Summary

Adds a manual escape-hatch for inverters where the energy-counter auto-detect can't stabilise (Enphase is the canonical case).

- New \`grid_sign_invert: bool\` config option, default \`False\`.
- When ON, the raw \`grid_power\` read is negated and the auto-detect path is bypassed entirely.
- Surfaced in the SOC-zone options step + documented in SETUP_GUIDE.

## Files

- \`coordinator/sensor_reader.py\`: branch in \`read_power\` before auto-detect call.
- \`config_flow.py\`: new \`BooleanSelector\` in \`async_step_settings\` (next to \`diagram_style\`).
- \`docs/SETUP_GUIDE.md\`: new row in the SOC-zone settings table.
- \`tests/test_grid_sign_invert_352.py\`: 5 new tests.

## Test plan

- [x] Full suite: **2739 / 2739 pass** (+5 new tests).
- [x] Unit: invert OFF preserves raw read; invert ON negates positive, negates negative, leaves 0 at 0.
- [x] Unit: invert ON bypasses auto-detect — \`_grid_sign_votes\`, \`_grid_sign_detected\`, \`_grid_sign_inverted\` all untouched after 5 cycles.
- [ ] HA-TEST: smoke verify the new toggle in the options flow appears with correct label/help.

## Risk

**Low.** Off by default → no behaviour change for existing users. The new branch in \`read_power\` is a 2-line if/else around the existing auto-detect call.

Fixes #352