### PR TITLE
fix(#356): collapse hero metrics when per-charger sections render

### DIFF
--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -2809,7 +2809,27 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                             </svg>
                         </div>
 
-                        ${this._chargers.length>1?K:H`
+                        ${this._chargers.length>=1?H`
+                            <!-- #356: when at least one per-charger section
+                                 will render below, the hero only shows a
+                                 single status/power line. The per-charger
+                                 section repeats today/session/solar-share/
+                                 power for each charger, so duplicating them
+                                 here as well produced the "4 tiles per
+                                 charger" appearance the user reported. -->
+                            <div class="metrics-col compact">
+                                <div class="metric-row">
+                                    <span class="metric-label">${this._t("status")}</span>
+                                    <span class="${c}">${l}</span>
+                                </div>
+                                ${e?H`
+                                    <div class="metric-row power-row">
+                                        <span class="metric-label">${this._t("power")}</span>
+                                        <span class="metric-value power-value">${ht(i)}</span>
+                                    </div>
+                                `:K}
+                            </div>
+                        `:H`
                             <div class="metrics-col">
                                 <div class="metric-row">
                                     <span class="metric-label">${this._t("status")}</span>
@@ -2833,7 +2853,7 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                         `}
                     </div>
 
-                    ${this._chargers.length>1?K:H`
+                    ${this._chargers.length>=1?K:H`
                         <div class="bottom-bar">
                             <div class="chip">
                                 <span class="chip-label">${this._t("session_cost")}</span>

--- a/dashboard/card/src/cards/sem-ev-status-card.js
+++ b/dashboard/card/src/cards/sem-ev-status-card.js
@@ -733,7 +733,27 @@ class SEMEVStatusCard extends SEMLitBase {
                             </svg>
                         </div>
 
-                        ${this._chargers.length > 1 ? nothing : html`
+                        ${this._chargers.length >= 1 ? html`
+                            <!-- #356: when at least one per-charger section
+                                 will render below, the hero only shows a
+                                 single status/power line. The per-charger
+                                 section repeats today/session/solar-share/
+                                 power for each charger, so duplicating them
+                                 here as well produced the "4 tiles per
+                                 charger" appearance the user reported. -->
+                            <div class="metrics-col compact">
+                                <div class="metric-row">
+                                    <span class="metric-label">${this._t('status')}</span>
+                                    <span class="${statusClass}">${statusText}</span>
+                                </div>
+                                ${charging ? html`
+                                    <div class="metric-row power-row">
+                                        <span class="metric-label">${this._t('power')}</span>
+                                        <span class="metric-value power-value">${semFormatPower(power)}</span>
+                                    </div>
+                                ` : nothing}
+                            </div>
+                        ` : html`
                             <div class="metrics-col">
                                 <div class="metric-row">
                                     <span class="metric-label">${this._t('status')}</span>
@@ -757,7 +777,7 @@ class SEMEVStatusCard extends SEMLitBase {
                         `}
                     </div>
 
-                    ${this._chargers.length > 1 ? nothing : html`
+                    ${this._chargers.length >= 1 ? nothing : html`
                         <div class="bottom-bar">
                             <div class="chip">
                                 <span class="chip-label">${this._t('session_cost')}</span>


### PR DESCRIPTION
## Summary

\`sem-ev-status-card\` rendered both a 4-row "hero metrics" column AND a per-charger section repeating the same Power / Today / Solar Share data — producing the "4 tiles per charger" appearance the user reported.

Switch the gate from \`length > 1\` to \`length >= 1\`. When any charger sections will render, the hero collapses to just Status + (Power when charging). Zero-charger fallback keeps the full hero (legacy single-EV setups).

## Files

- \`dashboard/card/src/cards/sem-ev-status-card.js\`: gate switch + compact-hero branch.
- \`dashboard/card/dist/sem-cards.js\`: rebuilt bundle (cache-busted by the resource-URL content hash).

## Test plan

- [x] \`npm run build\` clean in 2s, no errors.
- [ ] HA-TEST: visit EV tab, confirm only one set of Power/Today/Solar Share visible per charger.
- [ ] HA-TEST: 0-charger fallback (disable EV in config) — confirm full hero shows.

## Risk

**Low.** Visual change only; no behaviour or data change. Falls back gracefully when no chargers exist.

Fixes #356