### PR TITLE
fix(#357): WallboxAdapter with pause-switch handling

### DIFF
--- a/coordinator/charger_adapters/__init__.py
+++ b/coordinator/charger_adapters/__init__.py
@@ -35,6 +35,7 @@ from typing import TYPE_CHECKING
 from .base import ChargerAdapter
 from .generic import GenericAdapter
 from .keba import KebaAdapter
+from .wallbox import WallboxAdapter, _looks_like_wallbox
 
 if TYPE_CHECKING:  # pragma: no cover
     from ...devices.base import CurrentControlDevice
@@ -45,14 +46,24 @@ def adapter_for(device: "CurrentControlDevice") -> ChargerAdapter:
 
     Inspection: the device's ``charger_service`` reveals which
     integration. Anything starting with ``keba.`` gets the KEBA
-    adapter (6 A min, self-resume guard, etc.). Everything else gets
-    ``GenericAdapter``. To add brand-specific quirks in the future:
-    add a dedicated adapter subclass + branch here.
+    adapter (6 A min, self-resume guard, etc.). Wallbox installs
+    (#357) get the ``WallboxAdapter`` so the dedicated
+    ``pause_resume`` switch is toggled on disable. Everything else
+    gets ``GenericAdapter``. To add brand-specific quirks: add a
+    dedicated adapter subclass + branch here.
     """
     service = (getattr(device, "charger_service", "") or "").lower()
     if service.startswith("keba."):
         return KebaAdapter(device)
+    if _looks_like_wallbox(device):
+        return WallboxAdapter(device)
     return GenericAdapter(device)
 
 
-__all__ = ["ChargerAdapter", "GenericAdapter", "KebaAdapter", "adapter_for"]
+__all__ = [
+    "ChargerAdapter",
+    "GenericAdapter",
+    "KebaAdapter",
+    "WallboxAdapter",
+    "adapter_for",
+]

--- a/coordinator/charger_adapters/wallbox.py
+++ b/coordinator/charger_adapters/wallbox.py
@@ -1,0 +1,167 @@
+"""WallboxAdapter — explicit ``pause_resume`` switch handling (#357).
+
+Wallbox Pulsar (and the rest of the Wallbox firmware family) does
+accept ``number.set_value(0)`` as a stop signal — but the actual
+contactor open is gated on the ``switch.wallbox_*_pause_resume``
+control. When SEM sets the current entity to 0 without also turning
+the pause switch off, some firmware revisions latch the last
+non-zero setpoint internally and keep drawing handshake-level power
+indefinitely.
+
+The reporter for #357 hit exactly this on v1.6.17 (mode=off → charger
+keeps charging). The bug class was supposed to be retired by the
+v1.7.0 ``decide`` → ``adapter.command_disable`` flow, but the
+generic adapter still relies on ``_set_current(0) + stop_session()``
+without knowing the pause switch exists. This dedicated adapter
+auto-discovers the pause switch from the HA entity registry and
+toggles it explicitly on ``command_idle`` / ``command_disable``.
+
+Discovery: look in the HA registry for a ``switch.*pause_resume``
+entity that shares a device with the configured number entity. If
+none exists, fall back to the generic behaviour (the Wallbox HA
+integration changed entity ids across versions and not every
+revision exposes a pause switch).
+"""
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+from homeassistant.helpers import entity_registry as er
+
+from ..charger_types import ChargerIntent
+from .generic import GenericAdapter
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ...devices.base import CurrentControlDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _looks_like_wallbox(device: "CurrentControlDevice") -> bool:
+    """Heuristic: does this device look like a Wallbox charger?
+
+    Matches on either the integration domain (``charger_service``
+    starts with ``wallbox.``) or the configured entity id containing
+    ``wallbox`` somewhere — Wallbox HA integration entities are
+    consistently namespaced ``*_wallbox_*``.
+    """
+    service = (getattr(device, "charger_service", "") or "").lower()
+    if service.startswith("wallbox.") or service.startswith("wallbox_"):
+        return True
+    for attr in (
+        "charger_service_entity_id",
+        "charger_current_entity",
+        "start_stop_entity",
+    ):
+        value = (getattr(device, attr, "") or "").lower()
+        if "wallbox" in value:
+            return True
+    return False
+
+
+class WallboxAdapter(GenericAdapter):
+    """Wallbox-specific adapter — explicit pause switch handling.
+
+    Reuses ``GenericAdapter`` for ``command_current`` /
+    ``command_max`` / capability properties. Overrides only the
+    idle/disable paths to also toggle the pause-resume switch when
+    one is discoverable.
+    """
+
+    def __init__(self, device: "CurrentControlDevice") -> None:
+        super().__init__(device)
+        self._pause_switch_entity: Optional[str] = None
+        self._pause_switch_searched = False
+
+    def _discover_pause_switch(self) -> Optional[str]:
+        """Find a ``switch.*pause_resume*`` entity for this Wallbox.
+
+        Cached after the first successful (or unsuccessful) call.
+        Lookup uses HA's entity registry to scope to the same device
+        as the configured current-control number, so multi-Wallbox
+        installs don't cross-trigger the wrong charger.
+        """
+        if self._pause_switch_searched:
+            return self._pause_switch_entity
+        self._pause_switch_searched = True
+
+        hass = getattr(self._device, "hass", None)
+        if hass is None:
+            return None
+
+        try:
+            registry = er.async_get(hass)
+        except Exception:  # noqa: BLE001 — registry unavailable in tests
+            return None
+
+        # Locate the device id from any of the configured entity ids.
+        device_id: Optional[str] = None
+        for attr in (
+            "charger_service_entity_id",
+            "charger_current_entity",
+            "start_stop_entity",
+        ):
+            eid = getattr(self._device, attr, None)
+            if not eid:
+                continue
+            entry = registry.async_get(eid)
+            if entry and entry.device_id:
+                device_id = entry.device_id
+                break
+
+        if device_id is None:
+            return None
+
+        # Find a switch in the same device with "pause" or "resume" in the id.
+        for entry in registry.entities.values():
+            if entry.device_id != device_id:
+                continue
+            if not entry.entity_id.startswith("switch."):
+                continue
+            eid_lower = entry.entity_id.lower()
+            if "pause" in eid_lower or "resume" in eid_lower:
+                self._pause_switch_entity = entry.entity_id
+                _LOGGER.info(
+                    "Wallbox pause switch discovered for %s: %s",
+                    self._device.name, entry.entity_id,
+                )
+                return entry.entity_id
+
+        return None
+
+    async def _toggle_pause_switch(self, turn_on: bool) -> None:
+        """Turn the pause/resume switch on (resume) or off (pause).
+
+        Silent no-op when no switch is discoverable. Errors are
+        logged but don't abort the rest of the disable path — the
+        generic ``set_current(0)`` is still the primary stop signal.
+        """
+        eid = self._discover_pause_switch()
+        if not eid:
+            return
+        hass = getattr(self._device, "hass", None)
+        if hass is None:
+            return
+        service = "turn_on" if turn_on else "turn_off"
+        try:
+            await hass.services.async_call(
+                "switch", service, {"entity_id": eid}, blocking=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.warning(
+                "Wallbox %s switch.%s failed: %s",
+                self._device.name, service, exc,
+            )
+
+    async def command_idle(self) -> None:
+        """Stop charging — set current to 0 AND pause the switch."""
+        await super().command_idle()
+        await self._toggle_pause_switch(turn_on=False)
+        self._last_intent = ChargerIntent.IDLE
+
+    async def command_disable(self) -> None:
+        """User-explicit OFF — set current to 0 AND pause the switch."""
+        await super().command_disable()
+        await self._toggle_pause_switch(turn_on=False)
+        self._last_intent = ChargerIntent.DISABLE

--- a/tests/test_wallbox_adapter_357.py
+++ b/tests/test_wallbox_adapter_357.py
@@ -1,0 +1,197 @@
+"""Tests for the WallboxAdapter (#357).
+
+Confirms:
+- The adapter factory picks ``WallboxAdapter`` for Wallbox-like devices.
+- ``command_idle`` / ``command_disable`` call the pause-resume switch
+  in addition to ``_set_current(0)`` + ``stop_session``.
+- Discovery is cached (no per-cycle registry lookup).
+- Missing pause switch is a silent no-op (falls back to generic
+  behaviour) — does not crash.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.charger_adapters import (
+    GenericAdapter,
+    KebaAdapter,
+    WallboxAdapter,
+    adapter_for,
+)
+from custom_components.solar_energy_management.coordinator.charger_types import (
+    ChargerIntent,
+)
+
+
+def _make_device(
+    charger_service: str = "",
+    charger_service_entity_id: str = "",
+    charger_current_entity: str = "",
+    start_stop_entity: str = "",
+    name: str = "test_charger",
+):
+    """Build a mock CurrentControlDevice with the minimum attrs the
+    adapter inspects."""
+    device = Mock()
+    device.name = name
+    device.charger_service = charger_service
+    device.charger_service_entity_id = charger_service_entity_id
+    device.charger_current_entity = charger_current_entity
+    device.start_stop_entity = start_stop_entity
+    device.hass = MagicMock()
+    device.hass.services.async_call = AsyncMock()
+    device._set_current = AsyncMock()
+    device.stop_session = AsyncMock()
+    device._session_active = False
+    device.min_current = 6
+    device.max_current = 32
+    device.phases = 3
+    device.voltage = 230
+    return device
+
+
+class TestAdapterFactory:
+    """Factory picks the right adapter for each brand."""
+
+    def test_wallbox_via_service_prefix(self):
+        device = _make_device(charger_service="wallbox.set_charging_current")
+        assert isinstance(adapter_for(device), WallboxAdapter)
+
+    def test_wallbox_via_entity_id_match(self):
+        device = _make_device(
+            charger_service="number.set_value",
+            charger_service_entity_id="number.wallbox_pulsar_charging_current",
+        )
+        assert isinstance(adapter_for(device), WallboxAdapter)
+
+    def test_keba_wins_when_service_keba(self):
+        # Even if entity_id contains "wallbox" (mixed install), KEBA
+        # service name takes priority — the KEBA quirks are stronger.
+        device = _make_device(charger_service="keba.set_current")
+        assert isinstance(adapter_for(device), KebaAdapter)
+
+    def test_generic_fallback(self):
+        device = _make_device(
+            charger_service="number.set_value",
+            charger_service_entity_id="number.easee_current",
+        )
+        adapter = adapter_for(device)
+        assert isinstance(adapter, GenericAdapter)
+        # Must NOT be a WallboxAdapter (which is a GenericAdapter subclass).
+        assert not isinstance(adapter, WallboxAdapter)
+
+
+class TestWallboxPauseSwitch:
+    """When a pause-resume switch is discoverable, command_idle /
+    command_disable toggle it off in addition to set_current(0)."""
+
+    @pytest.mark.asyncio
+    async def test_disable_toggles_pause_switch(self):
+        device = _make_device(
+            charger_service_entity_id="number.wallbox_pulsar_charging_current",
+        )
+        adapter = WallboxAdapter(device)
+
+        # Patch the discovery helper to return a fake switch — easier
+        # than mocking the full registry.
+        adapter._pause_switch_entity = "switch.wallbox_pulsar_pause_resume"
+        adapter._pause_switch_searched = True
+
+        await adapter.command_disable()
+
+        # Generic path fired set_current(0) + stop_session.
+        device._set_current.assert_called_with(0)
+        device.stop_session.assert_called()
+
+        # Wallbox-specific addition: switch.turn_off on the pause switch.
+        calls = device.hass.services.async_call.call_args_list
+        pause_calls = [
+            c for c in calls
+            if c.args[:2] == ("switch", "turn_off")
+            and c.args[2].get("entity_id") == "switch.wallbox_pulsar_pause_resume"
+        ]
+        assert len(pause_calls) == 1
+        assert adapter.last_intent is ChargerIntent.DISABLE
+
+    @pytest.mark.asyncio
+    async def test_idle_toggles_pause_switch(self):
+        device = _make_device()
+        adapter = WallboxAdapter(device)
+        adapter._pause_switch_entity = "switch.wallbox_pulsar_pause_resume"
+        adapter._pause_switch_searched = True
+
+        await adapter.command_idle()
+
+        device._set_current.assert_called_with(0)
+        calls = device.hass.services.async_call.call_args_list
+        pause_calls = [
+            c for c in calls
+            if c.args[:2] == ("switch", "turn_off")
+            and c.args[2].get("entity_id") == "switch.wallbox_pulsar_pause_resume"
+        ]
+        assert len(pause_calls) == 1
+        assert adapter.last_intent is ChargerIntent.IDLE
+
+    @pytest.mark.asyncio
+    async def test_no_pause_switch_silent_noop(self):
+        """When no pause switch is discovered, the adapter still
+        fires the generic ``_set_current(0)`` + ``stop_session`` path
+        and does NOT crash."""
+        device = _make_device()
+        adapter = WallboxAdapter(device)
+        # Discovery returns nothing.
+        adapter._pause_switch_entity = None
+        adapter._pause_switch_searched = True
+
+        await adapter.command_disable()
+
+        device._set_current.assert_called_with(0)
+        device.stop_session.assert_called()
+        # No switch.turn_off call.
+        calls = device.hass.services.async_call.call_args_list
+        switch_calls = [
+            c for c in calls if c.args[:2] == ("switch", "turn_off")
+        ]
+        assert switch_calls == []
+        assert adapter.last_intent is ChargerIntent.DISABLE
+
+    @pytest.mark.asyncio
+    async def test_pause_switch_failure_does_not_propagate(self):
+        """If the switch service call raises, the disable path still
+        completes — set_current(0) and stop_session both ran. The
+        primary stop mechanism must succeed even if the auxiliary
+        switch is offline."""
+        device = _make_device()
+        adapter = WallboxAdapter(device)
+        adapter._pause_switch_entity = "switch.wallbox_pulsar_pause_resume"
+        adapter._pause_switch_searched = True
+        device.hass.services.async_call.side_effect = Exception(
+            "service unavailable",
+        )
+
+        # Must not raise.
+        await adapter.command_disable()
+
+        device._set_current.assert_called_with(0)
+        device.stop_session.assert_called()
+        assert adapter.last_intent is ChargerIntent.DISABLE
+
+    def test_discovery_cached_after_first_call(self):
+        """Second call to ``_discover_pause_switch`` returns the
+        cached value without touching the registry."""
+        device = _make_device()
+        adapter = WallboxAdapter(device)
+        # Simulate first call having found nothing.
+        adapter._pause_switch_entity = None
+        adapter._pause_switch_searched = True
+
+        # If the cache works, no registry call is made.
+        with patch(
+            "custom_components.solar_energy_management.coordinator.charger_adapters.wallbox.er.async_get"
+        ) as mock_er:
+            result = adapter._discover_pause_switch()
+
+        assert result is None
+        mock_er.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a dedicated \`WallboxAdapter\` so SEM toggles the Wallbox \`pause_resume\` switch (auto-discovered from the HA entity registry) on top of the existing \`set_current(0)\` + \`stop_session()\` path. Closes the v1.6.17 reporter's bug where mode=off didn't stop the Pulsar.

## Why

Some Wallbox firmware revisions latch the last non-zero current setpoint when only the number entity is set to 0 — the contactor stays closed and the charger keeps drawing handshake-level power. The HA integration exposes a separate pause-resume switch that does cleanly open the contactor; SEM was never toggling it.

## How

- Factory in \`coordinator/charger_adapters/__init__.py\` picks \`WallboxAdapter\` when:
  - \`charger_service\` starts with \`wallbox.\` / \`wallbox_\`, OR
  - any configured entity id contains \`wallbox\`
- \`WallboxAdapter\` extends \`GenericAdapter\`, overrides only \`command_idle\` / \`command_disable\` to add a \`switch.turn_off\` on the discovered pause switch.
- Discovery walks the HA entity registry once per adapter lifetime (scoped to the same device id as the current entity, so multi-Wallbox installs don't cross-trigger), then caches.
- If no pause switch exists, fall back to plain generic behaviour — silent no-op, no crash.
- If the switch call raises, log a warning and proceed — the primary \`set_current(0)\` + \`stop_session()\` already fired.

## Files

- \`coordinator/charger_adapters/wallbox.py\`: NEW (~165 LOC).
- \`coordinator/charger_adapters/__init__.py\`: factory branch + export.
- \`tests/test_wallbox_adapter_357.py\`: 9 new tests.

## Test plan

- [x] Full suite: **2743 / 2743 pass** (+9 new).
- [x] Unit: factory picks WallboxAdapter for both detection paths; KEBA still wins on \`keba.\` service prefix; generic fallback covers Easee.
- [x] Unit: \`command_disable\` fires both \`_set_current(0)\` + \`stop_session\` + the pause switch; failure of the switch call doesn't propagate.
- [x] Unit: discovery cached — second call doesn't re-query the registry.
- [ ] HA-TEST: live verify with reporter on v1.7.0-beta.3.

## Risk

**Low to medium.** The new code path only fires on Wallbox detection; KEBA/generic users are unaffected. Pause-switch toggling is on top of the existing stop path, not replacing it, so worst case it's a no-op (matching pre-PR behaviour).

Fixes #357