### PR TITLE
fix(#359): percentile-based tariff price classification

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -1439,6 +1439,23 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): selector.EntitySelector(
                     selector.EntitySelectorConfig(domain="sensor")
                 ),
+                # #359 — dynamic-tariff price classification mode. The
+                # legacy fixed thresholds (0.15 / 0.35 CHF) mis-bucketed
+                # everything as "normal" on UK/AU/NL providers whose
+                # daily range is 0.05–0.80 €/kWh. Percentile (default)
+                # bucket relative to today's 24-hour price distribution.
+                vol.Optional(
+                    "tariff_classification_mode",
+                    default=_c("tariff_classification_mode", "percentile"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {"value": "percentile", "label": "Percentile (relative to today's prices)"},
+                            {"value": "static", "label": "Static (fixed cheap/expensive thresholds)"},
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(
                     "electricity_import_rate",
                     default=_c("electricity_import_rate", 0.3387),

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -179,6 +179,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 cheap_threshold=config.get("cheap_price_threshold", 0.15),
                 expensive_threshold=config.get("expensive_price_threshold", 0.35),
                 currency=currency,
+                # #359: percentile is the new default for users on
+                # Tibber/Octopus/Amber/Nordpool where today's range
+                # determines what "cheap" means — the static 0.15/0.35
+                # CHF cutoffs misclassified the whole day on dynamic
+                # tariffs.
+                classification_mode=config.get(
+                    "tariff_classification_mode", "percentile",
+                ),
             )
         elif tariff_mode == "calendar":
             schedule = {}  # Was config.get("tariff_schedule", {}) — never set via UI

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -223,11 +223,21 @@ class DynamicTariffProvider(TariffProvider):
         cheap_threshold: float = 0.15,
         expensive_threshold: float = 0.35,
         currency: str = "CHF",
+        classification_mode: str = "percentile",
     ):
         self.hass = hass
         self.export_rate = export_rate
         self.cheap_threshold = cheap_threshold
         self.expensive_threshold = expensive_threshold
+        # #359: switch the default classification away from the static
+        # 0.15 / 0.35 CHF thresholds (worthless on Tibber-style tariffs
+        # ranging 0.10–0.80) to percentile-based bucketing over today's
+        # 24-hour price array. ``static`` preserved as an opt-out for
+        # users with flat tariffs / spike-prone markets.
+        self.classification_mode = (
+            classification_mode if classification_mode in ("static", "percentile")
+            else "percentile"
+        )
         self.currency = currency
         self._price_entity = price_entity
         self._provider_name = "unknown"
@@ -235,6 +245,10 @@ class DynamicTariffProvider(TariffProvider):
         self._feedin_entity: Optional[str] = feedin_entity
         self._prices_cache: List[PricePoint] = []
         self._last_cache_update: Optional[datetime] = None
+        # Cached percentile breakpoints, recomputed when today's price
+        # array changes. Keys: ``p10``, ``p25``, ``p75``, ``p90``.
+        self._percentile_breaks: Optional[Dict[str, float]] = None
+        self._percentile_breaks_for: Optional[str] = None  # date iso
 
     def detect_provider(self) -> Optional[str]:
         """Auto-detect available price integration."""
@@ -425,12 +439,63 @@ class DynamicTariffProvider(TariffProvider):
                 if prices:
                     break  # Found data in this source, stop
 
-        return sorted(prices, key=lambda p: p.timestamp)
+        prices = sorted(prices, key=lambda p: p.timestamp)
+
+        # #359: write back to the cache so ``_get_percentile_breaks``
+        # can compute today's distribution. The classification done
+        # in-line above used the cold cache (static fallback); now
+        # reclassify with percentile breaks if there's enough data.
+        # Single pass — cheap relative to the dozens of HA-state
+        # reads above. Date guard inside ``_get_percentile_breaks``
+        # keeps the calculation to once per day.
+        self._prices_cache = prices
+        self._percentile_breaks = None  # invalidate to force recompute
+        self._percentile_breaks_for = None
+        if self.classification_mode == "percentile" and prices:
+            for p in prices:
+                p.level = self._classify_price(p.price)
+
+        return prices
 
     def _classify_price(self, price: float) -> PriceLevel:
-        """Classify a price into levels."""
+        """Classify a price into levels.
+
+        v1.7.0 / #359: when ``classification_mode == "percentile"``,
+        bucket relative to today's price distribution:
+
+        - ``very_cheap`` — bottom 10%
+        - ``cheap``      — bottom 25%
+        - ``normal``     — 25 – 75%
+        - ``expensive``  — top 25%
+        - ``very_expensive`` — top 90%+
+
+        That works on Tibber / Octopus / Amber / Nordpool where the
+        absolute price range varies daily and the static 0.15 / 0.35
+        CHF cutoffs flag everything as ``normal`` (UK summer) or
+        ``very_expensive`` (winter peaks).
+
+        ``static`` preserves the legacy fixed-cutoff behaviour for
+        users with flat tariffs or unpredictable spike markets.
+        """
         if price < 0:
             return PriceLevel.NEGATIVE
+
+        if self.classification_mode == "percentile":
+            breaks = self._get_percentile_breaks()
+            if breaks is not None:
+                if price <= breaks["p10"]:
+                    return PriceLevel.VERY_CHEAP
+                if price <= breaks["p25"]:
+                    return PriceLevel.CHEAP
+                if price >= breaks["p90"]:
+                    return PriceLevel.VERY_EXPENSIVE
+                if price >= breaks["p75"]:
+                    return PriceLevel.EXPENSIVE
+                return PriceLevel.NORMAL
+            # Fall through to static when we can't compute percentiles
+            # yet (cold start, single price point).
+
+        # Static thresholds (legacy + fallback).
         if price < self.cheap_threshold * 0.5:
             return PriceLevel.VERY_CHEAP
         if price < self.cheap_threshold:
@@ -440,6 +505,56 @@ class DynamicTariffProvider(TariffProvider):
         if price > self.expensive_threshold:
             return PriceLevel.EXPENSIVE
         return PriceLevel.NORMAL
+
+    def _get_percentile_breaks(self) -> Optional[Dict[str, float]]:
+        """Compute today's percentile breakpoints from the cached
+        price array. Returns ``None`` when there's not enough data
+        (< 4 points) for percentiles to be meaningful.
+
+        Cached per calendar date so the calculation runs at most once
+        per day (the underlying ``_prices_cache`` is updated by the
+        usual cache-invalidation path)."""
+        if not self._prices_cache:
+            return None
+
+        today = dt_util.now().date()
+        today_key = today.isoformat()
+        if (
+            self._percentile_breaks is not None
+            and self._percentile_breaks_for == today_key
+        ):
+            return self._percentile_breaks
+
+        today_prices = sorted(
+            p.price for p in self._prices_cache
+            if p.timestamp.date() == today and p.price is not None
+        )
+        if len(today_prices) < 4:
+            return None
+
+        def _quantile(sorted_values: List[float], q: float) -> float:
+            # Plain nearest-rank quantile — good enough for 24/48-point
+            # arrays; avoids a numpy dependency.
+            if not sorted_values:
+                return 0.0
+            idx = max(
+                0,
+                min(
+                    len(sorted_values) - 1,
+                    int(round(q * (len(sorted_values) - 1))),
+                ),
+            )
+            return sorted_values[idx]
+
+        breaks = {
+            "p10": _quantile(today_prices, 0.10),
+            "p25": _quantile(today_prices, 0.25),
+            "p75": _quantile(today_prices, 0.75),
+            "p90": _quantile(today_prices, 0.90),
+        }
+        self._percentile_breaks = breaks
+        self._percentile_breaks_for = today_key
+        return breaks
 
     def get_current_import_rate(self) -> float:
         return self._read_current_price()

--- a/tests/test_tariff_percentile_359.py
+++ b/tests/test_tariff_percentile_359.py
@@ -1,0 +1,172 @@
+"""Tests for percentile-based tariff classification (#359).
+
+The static 0.15 / 0.35 CHF cutoffs mis-bucket prices on dynamic
+tariffs whose daily range is 0.05–0.80 €/kWh (Tibber / Octopus /
+Amber / Nordpool). Percentile mode buckets relative to today's
+distribution.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.tariff.tariff_provider import (
+    DynamicTariffProvider,
+    PriceLevel,
+    PricePoint,
+)
+from homeassistant.util import dt as dt_util
+
+
+def _make_provider(mode: str = "percentile") -> DynamicTariffProvider:
+    hass = MagicMock()
+    return DynamicTariffProvider(
+        hass,
+        price_entity="sensor.fake_tariff",
+        classification_mode=mode,
+    )
+
+
+def _today_prices(values: list[float]) -> list[PricePoint]:
+    today = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    return [
+        PricePoint(
+            timestamp=today + timedelta(hours=i),
+            price=v,
+            currency="EUR",
+            level=PriceLevel.NORMAL,
+        )
+        for i, v in enumerate(values)
+    ]
+
+
+class TestClassificationModeSelect:
+    def test_default_is_percentile(self):
+        p = _make_provider()
+        assert p.classification_mode == "percentile"
+
+    def test_explicit_static(self):
+        p = _make_provider("static")
+        assert p.classification_mode == "static"
+
+    def test_invalid_falls_back_to_percentile(self):
+        # Anything unknown defaults to the safer percentile path.
+        hass = MagicMock()
+        p = DynamicTariffProvider(
+            hass, classification_mode="garbage",
+        )
+        assert p.classification_mode == "percentile"
+
+
+class TestPercentileBucketing:
+    def test_bottom_10_pct_is_very_cheap(self):
+        # 24h Tibber-style distribution from €0.10 to €0.80.
+        prices = list(range(10, 81, 3))  # 24 values: 10, 13, ..., 79
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([v / 100 for v in prices])
+
+        # 0.10 is below the 10th percentile of the distribution.
+        assert p._classify_price(0.10) is PriceLevel.VERY_CHEAP
+
+    def test_25_to_75_is_normal(self):
+        prices = list(range(10, 81, 3))
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([v / 100 for v in prices])
+
+        # Middle of the distribution.
+        assert p._classify_price(0.45) is PriceLevel.NORMAL
+
+    def test_top_25_pct_is_expensive(self):
+        prices = list(range(10, 81, 3))
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([v / 100 for v in prices])
+
+        # 0.70 is in the top quartile but below p90.
+        assert p._classify_price(0.70) is PriceLevel.EXPENSIVE
+
+    def test_top_10_pct_is_very_expensive(self):
+        prices = list(range(10, 81, 3))
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([v / 100 for v in prices])
+
+        # 0.79 — top of the distribution.
+        assert p._classify_price(0.79) is PriceLevel.VERY_EXPENSIVE
+
+    def test_negative_always_negative_regardless_of_mode(self):
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.10, 0.20, 0.30, 0.40])
+
+        # Negative price (spot-market overproduction).
+        assert p._classify_price(-0.05) is PriceLevel.NEGATIVE
+
+    def test_cold_start_falls_back_to_static(self):
+        """Before _prices_cache is populated, percentile mode must
+        fall back to the legacy static thresholds — otherwise the
+        very first sensor read would be unclassified."""
+        p = _make_provider("percentile")
+        # No cache yet.
+        assert p._prices_cache == []
+        # Static says < 0.15 = CHEAP, > 0.35 = EXPENSIVE.
+        assert p._classify_price(0.10) is PriceLevel.CHEAP
+        assert p._classify_price(0.50) is PriceLevel.EXPENSIVE
+        assert p._classify_price(0.25) is PriceLevel.NORMAL
+
+    def test_insufficient_data_falls_back_to_static(self):
+        """3 prices isn't enough for meaningful percentiles — fall
+        back to static."""
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.10, 0.20, 0.30])
+
+        # Bucket using static thresholds.
+        assert p._classify_price(0.10) is PriceLevel.CHEAP
+
+
+class TestStaticMode:
+    """Static mode (opt-out) ignores percentiles even when cache is
+    populated — useful for users with flat tariffs."""
+
+    def test_static_uses_fixed_cutoffs(self):
+        p = _make_provider("static")
+        p._prices_cache = _today_prices(
+            [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80]
+        )
+
+        # Should use the fixed 0.15 / 0.35 cutoffs regardless of
+        # the populated cache.
+        assert p._classify_price(0.10) is PriceLevel.CHEAP   # < 0.15
+        assert p._classify_price(0.07) is PriceLevel.VERY_CHEAP  # < 0.075
+        assert p._classify_price(0.25) is PriceLevel.NORMAL  # 0.15..0.35
+        assert p._classify_price(0.40) is PriceLevel.EXPENSIVE  # > 0.35
+        assert p._classify_price(0.55) is PriceLevel.VERY_EXPENSIVE  # > 0.525
+
+
+class TestPercentileCaching:
+    def test_breaks_cached_per_day(self):
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.10, 0.20, 0.30, 0.40, 0.50])
+
+        # First call populates the cache.
+        breaks1 = p._get_percentile_breaks()
+        assert breaks1 is not None
+        # Second call returns the same dict instance from cache.
+        breaks2 = p._get_percentile_breaks()
+        assert breaks2 is breaks1
+
+    def test_breaks_invalidated_on_cache_change(self):
+        """When ``_prices_cache`` is replaced by ``_read_prices_list``
+        the explicit invalidation in that path clears the cached
+        breakpoints."""
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.10, 0.20, 0.30, 0.40, 0.50])
+
+        breaks1 = p._get_percentile_breaks()
+        # Simulate ``_read_prices_list`` updating the cache.
+        p._prices_cache = _today_prices([0.50, 0.60, 0.70, 0.80, 0.90])
+        p._percentile_breaks = None
+        p._percentile_breaks_for = None
+
+        breaks2 = p._get_percentile_breaks()
+        assert breaks2 is not None
+        assert breaks2["p10"] != breaks1["p10"]


### PR DESCRIPTION
## Summary

Switches the default dynamic-tariff classification from fixed 0.15/0.35 CHF cutoffs to percentile bucketing computed from today's 24h price array. Static mode preserved as opt-out.

## Why

On Tibber/Octopus/Amber/Nordpool, daily price ranges swing €0.05–€0.80. The static cutoffs flagged everything "Normal" all day during obviously expensive midday hours — the price-level sensor was useless on the providers dynamic mode exists for.

## Buckets (percentile mode)

- \`very_cheap\` — bottom 10%
- \`cheap\`      — bottom 25%
- \`normal\`     — 25–75%
- \`expensive\`  — top 25%
- \`very_expensive\` — top 90%+

\`NEGATIVE\` is still flagged regardless of mode.

## Files

- \`tariff/tariff_provider.py\`: \`classification_mode\` ctor arg, \`_get_percentile_breaks\` helper, rewritten \`_classify_price\`, cache write-back in \`_read_prices_list\`.
- \`coordinator/coordinator.py\`: pass \`classification_mode\` from config.
- \`config_flow.py\`: \`tariff_classification_mode\` dropdown in tariff step (default \`percentile\`).
- \`tests/test_tariff_percentile_359.py\`: 13 new tests.

## Test plan

- [x] Full suite: **2747 / 2747 pass** (+13 new).
- [x] Unit: cold start falls back to static; bottom-10/top-10 buckets fire correctly on 24-point distribution; negative prices stay NEGATIVE; static opt-out ignores percentiles even with populated cache; per-day caching + invalidation.
- [ ] HA-TEST: synthetic dynamic tariff already configured on HA-TEST — verify the price-level chip reflects relative-to-today bucketing.

## Risk

**Medium.** Default behaviour changes for existing dynamic-tariff users. Mitigations:
- Static mode preserved (single dropdown click to opt back in).
- Cold-start fallback to static keeps the very first sensor read sensible.
- Cache invalidation is explicit per cache rewrite (no stale-day leak).

Fixes #359