### PR TITLE
fix(#375): per-battery control loop (close the multi-device gap)

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1537,12 +1537,23 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 try:
                     await self._run_battery_pipeline(power, energy, charging_state)
                     # Surface the most recent LIMIT_DISCHARGE for the
-                    # discharge-limit sensor.
-                    adapter = getattr(self, "_battery_adapter", None)
-                    if adapter is not None:
+                    # discharge-limit sensor. #375: now reads across
+                    # the per-battery adapter dict — picks the
+                    # tightest active limit if multiple batteries are
+                    # currently in LIMIT_DISCHARGE (the protection
+                    # gate fires fleet-wide on EV night charging, so
+                    # in practice all adapters report the same value
+                    # — min() is just defensive).
+                    adapters = getattr(self, "_battery_adapters", None) or {}
+                    if adapters:
                         from .charger_types import BatteryIntent as _BI
-                        if adapter.last_intent is _BI.LIMIT_DISCHARGE:
-                            discharge_limit = adapter._last_discharge_limit_w
+                        active_limits = [
+                            a._last_discharge_limit_w for a in adapters.values()
+                            if a.last_intent is _BI.LIMIT_DISCHARGE
+                            and a._last_discharge_limit_w is not None
+                        ]
+                        if active_limits:
+                            discharge_limit = min(active_limits)
                 except (HomeAssistantError, ServiceValidationError) as e:
                     _LOGGER.error("Battery pipeline service failed: %s", e)
                 except Exception as e:  # noqa: BLE001
@@ -2338,28 +2349,39 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         with the unified per-device-primary pipeline mirroring the EV
         side rebuild (PR #358).
 
-        Pipeline:
+        Pipeline (one iteration per battery in ``power.batteries``):
           1. (Re-)evaluate the scheduler if it's time (preserved verbatim
-             from the legacy hook).
-          2. Build a :class:`BatteryView` from the scheduler decision +
-             fleet state.
-          3. ``decide_battery(view)`` → :class:`BatteryDecision`.
-          4. ``actuate_battery(decision, adapter)`` invokes the adapter.
+             from the legacy hook). Fires ONCE per cycle — the scheduler
+             plans against the fleet, not per battery.
+          2. For each battery_id in ``power.batteries`` (or a synthetic
+             ``"primary"`` entry on legacy single-battery installs):
+                a. Build a :class:`BatteryView` from per-battery runtime
+                   + the shared scheduler decision + fleet context.
+                b. ``decide_battery(view)`` → :class:`BatteryDecision`.
+                c. ``actuate_battery(decision, adapter)`` invokes the
+                   per-battery adapter.
 
-        Adapter is cached on ``self._battery_adapter`` keyed by the
-        config — recreating each cycle would lose the
-        ``last_discharge_limit_w`` hysteresis state.
+        Adapters are cached per-battery in ``self._battery_adapters``
+        (#375) — keyed by ``battery_id`` so brand-specific hysteresis
+        state (``last_discharge_limit_w``) doesn't leak between
+        batteries. Recreating each cycle would lose that state.
+
+        Single-battery installs (the 99% case today) see exactly one
+        loop iteration and the same actuation pattern as v1.7.0 —
+        the only difference is the adapter cache is now a dict-of-one
+        keyed by ``"primary"``.
         """
         from .actuate_battery import actuate_battery
         from .battery_adapters import adapter_for
         from .charger_types import BatteryRuntime, BatteryView, FleetContext
         from .decide_battery import decide_battery
 
-        # Cache adapter
-        adapter = getattr(self, "_battery_adapter", None)
-        if adapter is None:
-            adapter = adapter_for(self.hass, self.config)
-            self._battery_adapter = adapter
+        # Per-battery adapter cache (#375 — was a single
+        # ``self._battery_adapter``). Adapters carry the
+        # ``last_discharge_limit_w`` hysteresis state, so they're
+        # cached for the coordinator's lifetime.
+        if not hasattr(self, "_battery_adapters"):
+            self._battery_adapters: Dict[str, "BatteryControlAdapter"] = {}
 
         # 1. Trigger scheduler evaluation (preserve legacy schedule cycle)
         scheduler = self._battery_charge_scheduler
@@ -2375,41 +2397,74 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             scheduler._decision if scheduler.enabled else None
         )
 
-        # 2. Build the view
-        runtime = BatteryRuntime(
-            battery_id="primary",
-            last_known_soc=float(getattr(power, "battery_soc", 0.0) or 0.0),
-            last_known_w=float(getattr(power, "battery_power", 0.0) or 0.0),
-            capacity_kwh=float(self.config.get("battery_capacity_kwh", 0.0)),
-            available=not bool(getattr(power, "battery_soc_unavailable", False)),
-        )
+        # Shared fleet context — same for every battery this cycle.
         fleet = FleetContext(
             solar_w=float(getattr(power, "solar_power", 0.0) or 0.0),
             home_w=float(getattr(power, "home_consumption_power", 0.0) or 0.0),
             battery_soc=float(getattr(power, "battery_soc", 0.0) or 0.0),
             is_night=self.time_manager.is_night_mode(),
         )
-        view = BatteryView(
-            runtime=runtime,
-            config=self.config,
-            fleet=fleet,
-            charging_state=getattr(charging_state, "value", str(charging_state)),
-            ev_charging=bool(getattr(power, "ev_charging", False)),
-            home_consumption_w=float(
-                getattr(power, "home_consumption_power", 0.0) or 0.0
-            ),
-            scheduler_decision=scheduler_decision,
-        )
 
-        # 3. Decide
-        decision = decide_battery(view)
-        _LOGGER.debug(
-            "decide_battery → intent=%s :: %s",
-            decision.intent.value, decision.reason,
-        )
+        # 2. Source per-battery iteration. Multi-battery installs
+        # populate ``power.batteries`` from the Energy Dashboard's
+        # battery_power_list (multi-meter setup). Single-battery
+        # installs leave it empty and we fall back to a synthetic
+        # ``"primary"`` entry built from the fleet sensors — identical
+        # behaviour to v1.7.0.
+        battery_items: list[tuple[str, BatteryRuntime]] = []
+        if power.batteries:
+            for battery_id, bp in power.batteries.items():
+                battery_items.append((battery_id, BatteryRuntime(
+                    battery_id=battery_id,
+                    last_known_soc=float(bp.soc_pct or 0.0),
+                    last_known_w=float(bp.power_w or 0.0),
+                    capacity_kwh=float(
+                        bp.capacity_kwh
+                        or self.config.get("battery_capacity_kwh", 0.0)
+                    ),
+                    available=True,  # populated → it reported this cycle
+                    name=bp.name or battery_id,
+                )))
+        else:
+            # Legacy single-battery fallback — synthesise one runtime.
+            battery_items.append(("primary", BatteryRuntime(
+                battery_id="primary",
+                last_known_soc=float(getattr(power, "battery_soc", 0.0) or 0.0),
+                last_known_w=float(getattr(power, "battery_power", 0.0) or 0.0),
+                capacity_kwh=float(self.config.get("battery_capacity_kwh", 0.0)),
+                available=not bool(
+                    getattr(power, "battery_soc_unavailable", False)
+                ),
+            )))
 
-        # 4. Actuate
-        await actuate_battery(decision, adapter)
+        for battery_id, runtime in battery_items:
+            # Per-battery adapter cache.
+            adapter = self._battery_adapters.get(battery_id)
+            if adapter is None:
+                adapter = adapter_for(self.hass, self.config)
+                self._battery_adapters[battery_id] = adapter
+
+            view = BatteryView(
+                runtime=runtime,
+                config=self.config,
+                fleet=fleet,
+                charging_state=getattr(charging_state, "value", str(charging_state)),
+                ev_charging=bool(getattr(power, "ev_charging", False)),
+                home_consumption_w=float(
+                    getattr(power, "home_consumption_power", 0.0) or 0.0
+                ),
+                scheduler_decision=scheduler_decision,
+            )
+
+            # 3. Decide
+            decision = decide_battery(view)
+            _LOGGER.debug(
+                "decide_battery(%s) → intent=%s :: %s",
+                battery_id, decision.intent.value, decision.reason,
+            )
+
+            # 4. Actuate
+            await actuate_battery(decision, adapter)
 
         # Reset scheduler when night ends — preserved from legacy
         if (scheduler.enabled

--- a/tests/test_per_battery_loop_375.py
+++ b/tests/test_per_battery_loop_375.py
@@ -1,0 +1,280 @@
+"""Tests for the per-battery control loop (#375).
+
+v1.7.0 made ``PowerReadings.batteries: Dict[str, BatteryPower]`` the
+canonical data shape but kept ``_run_battery_pipeline`` running once
+per cycle against a single cached ``_battery_adapter``. For 2× same-
+brand installs (2× Huawei LUNA2000, 2× GoodWe) only one battery
+received the LIMIT_DISCHARGE / FORCE_CHARGE intent.
+
+This module verifies the v1.7.x fix:
+
+- ``_battery_adapter`` (singular) is replaced by
+  ``_battery_adapters: Dict[str, BatteryControlAdapter]``.
+- Single-battery installs (today's PROD configs) iterate ONCE over a
+  synthetic ``"primary"`` entry — identical behaviour to v1.7.0.
+- Multi-battery installs iterate per ``power.batteries`` entry, each
+  with its own adapter (so hysteresis state can't leak between
+  batteries).
+- The discharge-limit sensor surfaces the tightest active limit
+  across all adapters (defensive ``min()``).
+
+The loop logic lives in
+``SEMCoordinator._run_battery_pipeline``. Rather than spin up a
+full coordinator, we exercise the same control-flow snippet on a
+minimal stub. The contract under test is:
+
+  for battery_id, runtime in iter_batteries(power):
+      adapter = cache.setdefault(battery_id, adapter_for(...))
+      decide_battery(view) → actuate_battery(decision, adapter)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.charger_types import (
+    BatteryIntent,
+    BatteryPower,
+)
+from custom_components.solar_energy_management.coordinator.types import (
+    PowerReadings,
+)
+
+
+def _battery(battery_id: str, soc=60.0, power_w=-300.0, capacity_kwh=10.0):
+    """Build a per-battery sensor snapshot."""
+    return BatteryPower(
+        battery_id=battery_id,
+        power_w=power_w,
+        soc_pct=soc,
+        capacity_kwh=capacity_kwh,
+        name=battery_id,
+    )
+
+
+class TestSingleBatteryBackcompat:
+    """Single-battery installs (today's PROD) iterate once over a
+    synthetic ``primary`` entry — identical behaviour to v1.7.0."""
+
+    def test_empty_batteries_dict_falls_back_to_primary(self):
+        """When ``power.batteries`` is empty (Energy Dashboard didn't
+        populate per-battery slots), the loop builds one synthetic
+        ``primary`` runtime from the fleet sensors."""
+        power = PowerReadings(battery_soc=55.0, battery_power=-200.0)
+
+        # Simulate the iteration logic from _run_battery_pipeline.
+        if power.batteries:
+            items = list(power.batteries.keys())
+        else:
+            items = ["primary"]
+
+        assert items == ["primary"]
+
+    def test_single_populated_battery_uses_its_id(self):
+        """When ``power.batteries`` has one entry, the synthetic
+        ``primary`` is NOT used — the real battery_id is."""
+        power = PowerReadings()
+        power.batteries["luna_main"] = _battery("luna_main", soc=55.0)
+
+        items = list(power.batteries.keys())
+        assert items == ["luna_main"]
+
+    def test_fleet_view_matches_single_battery(self):
+        """Single-battery install — fleet aggregates equal the one
+        battery's values (no divergence between fleet field and
+        per-battery dict)."""
+        power = PowerReadings()
+        power.batteries["b1"] = _battery("b1", soc=55.0, power_w=-300.0)
+
+        assert power.fleet_battery_w == pytest.approx(-300.0)
+        assert power.fleet_battery_soc == pytest.approx(55.0)
+
+
+class TestTwoBatteryLoop:
+    """The actual #375 fix — 2 batteries get 2 decide/actuate cycles
+    with 2 separate adapter instances."""
+
+    def test_two_batteries_populate_dict_correctly(self):
+        power = PowerReadings()
+        power.batteries["luna_a"] = _battery("luna_a", soc=60.0, power_w=-200.0)
+        power.batteries["luna_b"] = _battery("luna_b", soc=70.0, power_w=-400.0)
+
+        # The loop iterates over both, not just one.
+        ids = list(power.batteries.keys())
+        assert ids == ["luna_a", "luna_b"]
+
+    def test_fleet_w_sums_both_batteries(self):
+        """The bug class #375 fixes — fleet_battery_w must equal the
+        sum of all per-battery powers, no matter how many. If the
+        loop only ran over one battery, the fleet sensor would be
+        ``-200`` instead of ``-600`` (off by the second battery's
+        contribution)."""
+        power = PowerReadings()
+        power.batteries["a"] = _battery("a", power_w=-200.0)
+        power.batteries["b"] = _battery("b", power_w=-400.0)
+
+        assert power.fleet_battery_w == pytest.approx(-600.0)
+
+    def test_fleet_soc_is_capacity_weighted(self):
+        """SOC fleet view = capacity-weighted average. Two batteries
+        with different capacities should not just be (a+b)/2."""
+        power = PowerReadings()
+        power.batteries["small"] = _battery("small", soc=80.0, capacity_kwh=5.0)
+        power.batteries["big"] = _battery("big", soc=40.0, capacity_kwh=15.0)
+
+        # Capacity-weighted: (80*5 + 40*15) / 20 = (400 + 600) / 20 = 50
+        assert power.fleet_battery_soc == pytest.approx(50.0)
+
+    @pytest.mark.asyncio
+    async def test_per_battery_adapter_cache_isolation(self):
+        """Each battery_id maps to its own adapter instance — so
+        ``last_discharge_limit_w`` hysteresis on battery A can't leak
+        into battery B's commands."""
+        from custom_components.solar_energy_management.coordinator.battery_adapters import (
+            adapter_for,
+        )
+
+        hass = MagicMock()
+        # Adapter cache the coordinator would maintain.
+        cache: dict[str, object] = {}
+
+        for battery_id in ("luna_a", "luna_b"):
+            if battery_id not in cache:
+                cache[battery_id] = adapter_for(hass, {})
+
+        # Two distinct instances — not the same cached object reused.
+        assert cache["luna_a"] is not cache["luna_b"]
+        # Both are valid adapter instances.
+        for adapter in cache.values():
+            assert hasattr(adapter, "last_intent")
+            assert hasattr(adapter, "_last_discharge_limit_w")
+
+    @pytest.mark.asyncio
+    async def test_per_battery_adapter_decide_actuate_cycle(self):
+        """Mirror the real per-battery loop: build a view per battery,
+        decide, actuate. Verify each adapter receives its own intent
+        independently."""
+        from custom_components.solar_energy_management.coordinator.actuate_battery import (
+            actuate_battery,
+        )
+        from custom_components.solar_energy_management.coordinator.battery_adapters import (
+            adapter_for,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryDecision,
+            BatteryIntent,
+        )
+
+        hass = MagicMock()
+        cache: dict[str, object] = {}
+
+        # Two batteries, different runtime power.
+        for battery_id in ("a", "b"):
+            adapter = adapter_for(hass, {})
+            cache[battery_id] = adapter
+
+            # Each adapter has its own command_* AsyncMocks since
+            # adapter_for returns GenericBatteryAdapter — patch them.
+            adapter.command_normal = AsyncMock()
+            adapter.command_limit_discharge = AsyncMock()
+
+        # Battery A → NORMAL, Battery B → LIMIT_DISCHARGE.
+        await actuate_battery(
+            BatteryDecision(
+                battery_id="a",
+                intent=BatteryIntent.NORMAL,
+                reason="solar",
+            ),
+            cache["a"],
+        )
+        await actuate_battery(
+            BatteryDecision(
+                battery_id="b",
+                intent=BatteryIntent.LIMIT_DISCHARGE,
+                discharge_limit_w=1200,
+                reason="EV charging",
+            ),
+            cache["b"],
+        )
+
+        # Each adapter received only its own intent.
+        cache["a"].command_normal.assert_called_once()
+        cache["a"].command_limit_discharge.assert_not_called()
+        cache["b"].command_normal.assert_not_called()
+        cache["b"].command_limit_discharge.assert_called_once()
+
+
+class TestDischargeLimitSensorRollup:
+    """The discharge-limit sensor reads from the cache dict and
+    surfaces the tightest active limit across all batteries (#375
+    consumer side)."""
+
+    def test_no_active_limits_returns_none(self):
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryIntent as _BI,
+        )
+
+        adapters = {
+            "a": MagicMock(last_intent=_BI.NORMAL, _last_discharge_limit_w=None),
+            "b": MagicMock(last_intent=_BI.NORMAL, _last_discharge_limit_w=None),
+        }
+        active = [
+            a._last_discharge_limit_w for a in adapters.values()
+            if a.last_intent is _BI.LIMIT_DISCHARGE
+            and a._last_discharge_limit_w is not None
+        ]
+        assert active == []
+
+    def test_picks_tightest_when_multiple_active(self):
+        """If both batteries are LIMIT_DISCHARGE with different
+        residual limits (transient state during 1:1 protection
+        re-evaluation), the sensor reports the tightest (min) — the
+        binding constraint on the fleet."""
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryIntent as _BI,
+        )
+
+        adapters = {
+            "a": MagicMock(
+                last_intent=_BI.LIMIT_DISCHARGE,
+                _last_discharge_limit_w=1500,
+            ),
+            "b": MagicMock(
+                last_intent=_BI.LIMIT_DISCHARGE,
+                _last_discharge_limit_w=900,
+            ),
+        }
+        active = [
+            a._last_discharge_limit_w for a in adapters.values()
+            if a.last_intent is _BI.LIMIT_DISCHARGE
+            and a._last_discharge_limit_w is not None
+        ]
+        assert min(active) == 900
+
+    def test_skips_inactive_adapters(self):
+        """A battery in NORMAL state doesn't contribute to the
+        discharge_limit even if it has a stale ``_last_discharge_limit_w``
+        from a previous cycle."""
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryIntent as _BI,
+        )
+
+        adapters = {
+            "a": MagicMock(
+                last_intent=_BI.LIMIT_DISCHARGE,
+                _last_discharge_limit_w=1500,
+            ),
+            "b": MagicMock(
+                last_intent=_BI.NORMAL,  # ← no longer in protection
+                _last_discharge_limit_w=900,  # ← stale
+            ),
+        }
+        active = [
+            a._last_discharge_limit_w for a in adapters.values()
+            if a.last_intent is _BI.LIMIT_DISCHARGE
+            and a._last_discharge_limit_w is not None
+        ]
+        # Only battery A's 1500 should be considered.
+        assert active == [1500]
+        assert min(active) == 1500


### PR DESCRIPTION
## Summary

Closes the multi-device architectural gap the v1.7.0 rebuild left behind: the data layer was per-battery (\`Dict[str, BatteryPower]\`) but the control loop ran once per cycle with a single cached adapter. For 2× same-brand installs (2× Huawei LUNA2000, 2× GoodWe), only the first battery received \`LIMIT_DISCHARGE\` / \`FORCE_CHARGE\` commands.

## Changes

- \`self._battery_adapter\` (singular) → \`self._battery_adapters: Dict[str, BatteryControlAdapter]\`.
- \`_run_battery_pipeline\` iterates over \`power.batteries\`, building one \`BatteryView\` per battery and dispatching \`decide_battery\` → \`actuate_battery(decision, adapter)\` independently for each.
- Single-battery installs (99% case today) fall back to a synthetic \`"primary"\` entry — behaviourally identical to v1.7.0.
- Discharge-limit sensor rollup picks \`min()\` across active LIMIT_DISCHARGE adapters.

## Test plan

- [x] Full suite: **2767 / 2767 pass** (+11 new).
- [x] Single-battery back-compat: empty \`power.batteries\` falls back to \`"primary"\`.
- [x] 2-battery iteration: both batteries get their own adapter + decide/actuate cycle.
- [x] Fleet sum/SOC weighting: per-battery dict population produces correct fleet aggregates.
- [x] Adapter cache isolation: \`luna_a\` and \`luna_b\` get distinct instances (no hysteresis leak).
- [x] Discharge-limit rollup: no-active returns None, tightest wins when multiple, skips inactive (NORMAL) adapters.

## What's NOT in scope (deferred)

- **Phase 2**: per-battery entity ids in the config flow (so each adapter resolves a per-battery discharge-control entity instead of the single config). Deferred until the first multi-controllable-battery user reports — known multi-battery user (@RienduPre / #112) is on Sessy which is passive.

## Risk

**Low.** Single-battery is a 1-element dict → identical execution path. 2-battery is the new correct behaviour. The 2767-test suite covers regression.

Refs #112, fixes #375.