### PR TITLE
fix: battery session hysteresis (continuous discharge shows as 2-min bug)

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -316,6 +316,10 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Battery session tracking
         self._battery_session = BatterySessionData()
         self._battery_session_idle_count = 0
+        # #TBD — direction-change hysteresis counter. Counts cycles
+        # spent in the opposite direction of the active session;
+        # session only ends when this reaches OPPOSITE_CYCLES_TO_FLIP.
+        self._battery_session_opposite_count = 0
 
         # Per-charger night-skip safety counter latch (#351 M8). Maps
         # charger_id → bool; the legacy single-charger path uses the
@@ -3298,14 +3302,29 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
     ) -> None:
         """Track battery charge/discharge sessions with source attribution.
 
-        Similar to EV session tracking but adapted for battery:
-        - Charge session: starts when charge_power > 50W
-        - Discharge session: starts when discharge_power > 50W
-        - Session ends when power drops below 50W for 3 consecutive cycles
-        - Direction change ends current session and starts new one
+        Hysteresis on three axes so the session reflects the
+        user-visible continuous flow, not the inverter's micro-
+        rebalancing during sunset / cloud transits / load steps:
+
+        - **Power dead-band** = 200 W. Below this the cycle counts as
+          idle. Wider than the inverter's idle-state drift; still well
+          below any meaningful charge/discharge.
+        - **Idle cycles to end** = 18 (~3 min at the default 10 s
+          interval). A 30 s gap that comes back into discharge keeps
+          the session intact; 3 min of true idle ends it.
+        - **Direction-change cycles to flip** = 3. A single cycle of
+          the opposite direction (briefly +50 W of charge during a
+          discharge transient) does NOT end the session. Three in a
+          row does.
+
+        Pre-hysteresis (50 W / 3 idle / 1-cycle flip) caused
+        screenshots where the user's 1-hour continuous discharge was
+        reported as a 2-minute session because the inverter briefly
+        rebalanced through 0 W during the sunset transition (#TBD).
         """
-        POWER_THRESHOLD = 50.0
-        IDLE_CYCLES_TO_END = 3
+        POWER_THRESHOLD = 200.0
+        IDLE_CYCLES_TO_END = 18
+        OPPOSITE_CYCLES_TO_FLIP = 3
 
         charging = power.battery_charge_power > POWER_THRESHOLD
         discharging = power.battery_discharge_power > POWER_THRESHOLD
@@ -3319,13 +3338,31 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         else:
             current_type = "idle"
 
-        # Handle direction change — end current session, start new one
-        if session.active and current_type != "idle" and current_type != session.session_type:
-            session.active = False
-            _LOGGER.debug(
-                "Battery session ended (direction change): %s, %.2f kWh, %d min",
-                session.session_type, session.energy_kwh, session.duration_minutes,
-            )
+        # Direction-change hysteresis — require N consecutive cycles
+        # in the opposite direction before treating it as a real flip.
+        if (
+            session.active
+            and current_type != "idle"
+            and current_type != session.session_type
+        ):
+            self._battery_session_opposite_count += 1
+            if self._battery_session_opposite_count >= OPPOSITE_CYCLES_TO_FLIP:
+                session.active = False
+                self._battery_session_opposite_count = 0
+                _LOGGER.debug(
+                    "Battery session ended (direction flip after %d cycles): %s, %.2f kWh, %d min",
+                    OPPOSITE_CYCLES_TO_FLIP,
+                    session.session_type,
+                    session.energy_kwh,
+                    session.duration_minutes,
+                )
+            else:
+                # Transient opposite-direction blip — keep session
+                # alive but skip accumulation this cycle.
+                return
+        elif current_type == session.session_type:
+            # Matched the active session direction → reset the counter.
+            self._battery_session_opposite_count = 0
 
         # Handle idle — count consecutive idle cycles
         if current_type == "idle":
@@ -3333,6 +3370,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 self._battery_session_idle_count += 1
                 if self._battery_session_idle_count >= IDLE_CYCLES_TO_END:
                     session.active = False
+                    self._battery_session_opposite_count = 0
                     _LOGGER.debug(
                         "Battery session ended (idle): %s, %.2f kWh, %d min",
                         session.session_type, session.energy_kwh, session.duration_minutes,

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.0-beta.11"
+  "version": "1.7.0-beta.12"
 }

--- a/tests/test_battery_session.py
+++ b/tests/test_battery_session.py
@@ -28,6 +28,7 @@ def _make_coordinator():
         coord.update_interval = timedelta(seconds=10)
         coord._battery_session = BatterySessionData()
         coord._battery_session_idle_count = 0
+        coord._battery_session_opposite_count = 0
         # Mock energy calculator with live import rate (used since #223 fix)
         coord._energy_calculator = type('MockCalc', (), {'_import_rate': 0.30})()
         return coord
@@ -74,75 +75,157 @@ class TestBatterySessionStart:
 class TestBatterySessionEnd:
     """Test session end via hysteresis."""
 
-    def test_session_ends_after_3_idle_cycles(self):
-        """Session ends after 3 consecutive idle cycles."""
+    def test_session_ends_after_idle_window(self):
+        """Session ends after 18 consecutive idle cycles (~3 min)."""
         coord = _make_coordinator()
-        # Start a charge session
         power_active = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
         flows = PowerFlows(solar_to_battery=500)
         coord._update_battery_session_tracking(power_active, flows)
         assert coord._battery_session.active is True
 
-        # 3 idle cycles
+        # 18 idle cycles → ends
         power_idle = PowerReadings(battery_charge_power=0, battery_discharge_power=0)
-        for i in range(3):
+        for _ in range(18):
             coord._update_battery_session_tracking(power_idle, PowerFlows())
 
         assert coord._battery_session.active is False
 
-    def test_session_survives_1_idle_cycle(self):
-        """Session survives 1 idle cycle (hysteresis)."""
+    def test_session_survives_short_idle_gap(self):
+        """A brief gap (well under the idle window) keeps the session
+        alive — the sunset/cloud-transit case that produced the
+        original "1 hour discharge → 2 min session" bug."""
         coord = _make_coordinator()
         power_active = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
         flows = PowerFlows(solar_to_battery=500)
         coord._update_battery_session_tracking(power_active, flows)
 
-        # 1 idle cycle
+        # 5 idle cycles (~50 s) — well below the 18-cycle threshold
         power_idle = PowerReadings(battery_charge_power=0, battery_discharge_power=0)
-        coord._update_battery_session_tracking(power_idle, PowerFlows())
+        for _ in range(5):
+            coord._update_battery_session_tracking(power_idle, PowerFlows())
 
         assert coord._battery_session.active is True
-        assert coord._battery_session_idle_count == 1
+        assert coord._battery_session_idle_count == 5
 
     def test_idle_counter_resets_on_active(self):
-        """Idle counter resets when power returns."""
+        """Idle counter resets when power returns above the dead-band."""
         coord = _make_coordinator()
         power_active = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
         flows = PowerFlows(solar_to_battery=500)
         coord._update_battery_session_tracking(power_active, flows)
 
-        # 2 idle cycles (not enough to end)
+        # 10 idle cycles (not enough to end — limit is 18)
         power_idle = PowerReadings(battery_charge_power=0, battery_discharge_power=0)
-        coord._update_battery_session_tracking(power_idle, PowerFlows())
-        coord._update_battery_session_tracking(power_idle, PowerFlows())
-        assert coord._battery_session_idle_count == 2
+        for _ in range(10):
+            coord._update_battery_session_tracking(power_idle, PowerFlows())
+        assert coord._battery_session_idle_count == 10
 
-        # Power returns — counter resets
+        # Power returns above the 200 W dead-band — counter resets
         coord._update_battery_session_tracking(power_active, flows)
         assert coord._battery_session_idle_count == 0
         assert coord._battery_session.active is True
 
+    def test_dead_band_idles_low_power(self):
+        """Power below the 200 W dead-band counts as idle even though
+        > 0, because that's the inverter's micro-rebalance regime."""
+        coord = _make_coordinator()
+        power_active = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
+        coord._update_battery_session_tracking(power_active, PowerFlows(solar_to_battery=500))
+
+        # 150 W is below the new 200 W dead-band.
+        power_low = PowerReadings(battery_charge_power=150, battery_discharge_power=0)
+        coord._update_battery_session_tracking(power_low, PowerFlows())
+        # Session still active, idle counter ticks up.
+        assert coord._battery_session.active is True
+        assert coord._battery_session_idle_count == 1
+
 
 class TestBatterySessionDirectionChange:
-    """Test session handling on charge/discharge direction switch."""
+    """Direction-change hysteresis — single-cycle blips don't end the
+    session; sustained N-cycle reversal does (#TBD)."""
 
-    def test_direction_change_ends_session(self):
-        """Switching from charge to discharge ends current session and starts new."""
+    def test_single_cycle_blip_does_not_end_session(self):
+        """The user's screenshot scenario: a continuous discharge that
+        gets a single cycle of +500 W charge during a sunset transient.
+        Session must survive."""
         coord = _make_coordinator()
+        power_discharge = PowerReadings(battery_charge_power=0, battery_discharge_power=1100)
+        coord._update_battery_session_tracking(power_discharge, PowerFlows())
+        assert coord._battery_session.session_type == "discharge"
 
-        # Start charge session
+        # One cycle of charge (the transient).
+        power_blip = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
+        coord._update_battery_session_tracking(power_blip, PowerFlows(solar_to_battery=500))
+        assert coord._battery_session.active is True
+        assert coord._battery_session.session_type == "discharge"
+        assert coord._battery_session_opposite_count == 1
+
+        # Back to discharge — opposite counter resets.
+        coord._update_battery_session_tracking(power_discharge, PowerFlows())
+        assert coord._battery_session.active is True
+        assert coord._battery_session.session_type == "discharge"
+        assert coord._battery_session_opposite_count == 0
+
+    def test_sustained_opposite_direction_ends_session(self):
+        """Three consecutive cycles of opposite direction = real flip.
+        Old session ends, new one starts on the next active cycle."""
+        coord = _make_coordinator()
+        power_discharge = PowerReadings(battery_charge_power=0, battery_discharge_power=1100)
+        coord._update_battery_session_tracking(power_discharge, PowerFlows())
+        assert coord._battery_session.session_type == "discharge"
+
+        # 3 charge cycles in a row → flip after the third.
         power_charge = PowerReadings(battery_charge_power=500, battery_discharge_power=0)
+        for _ in range(3):
+            coord._update_battery_session_tracking(power_charge, PowerFlows(solar_to_battery=500))
+
+        # After 3 opposite cycles the old session ends + a new one
+        # starts on the same cycle (next call), now as charge.
         coord._update_battery_session_tracking(power_charge, PowerFlows(solar_to_battery=500))
+        assert coord._battery_session.active is True
         assert coord._battery_session.session_type == "charge"
 
-        # Switch to discharge
-        power_discharge = PowerReadings(battery_charge_power=0, battery_discharge_power=800)
-        coord._update_battery_session_tracking(power_discharge, PowerFlows())
+
+class TestBatterySessionRealWorld:
+    """Real-world scenarios from the #TBD investigation."""
+
+    def test_steady_one_hour_discharge_keeps_one_session(self):
+        """User's reported case: 1 hour of steady 1.1 kW discharge
+        with no fluctuations should produce one continuous session."""
+        coord = _make_coordinator()
+        power = PowerReadings(battery_charge_power=0, battery_discharge_power=1100)
+
+        # 1 hour at 10 s update interval = 360 cycles.
+        for _ in range(360):
+            coord._update_battery_session_tracking(power, PowerFlows())
 
         assert coord._battery_session.active is True
         assert coord._battery_session.session_type == "discharge"
-        # Energy should be from the new session (near zero), not carried over
-        assert coord._battery_session.energy_kwh < 0.01
+        # Energy: 1100 W × 3600 s / 3600 / 1000 = 1.1 kWh.
+        assert abs(coord._battery_session.energy_kwh - 1.1) < 0.05
+
+    def test_sunset_transient_keeps_session_alive(self):
+        """Sunset: solar tails off, battery starts discharging, has
+        occasional brief charge blips during inverter rebalance.
+        Session should remain a single continuous session."""
+        coord = _make_coordinator()
+        power_discharge = PowerReadings(battery_charge_power=0, battery_discharge_power=800)
+        power_blip_charge = PowerReadings(battery_charge_power=300, battery_discharge_power=0)
+
+        # 10 minutes of discharge
+        for _ in range(60):
+            coord._update_battery_session_tracking(power_discharge, PowerFlows())
+
+        # Single-cycle blip of charge (inverter rebalance)
+        coord._update_battery_session_tracking(power_blip_charge, PowerFlows(solar_to_battery=300))
+
+        # 10 more minutes of discharge
+        for _ in range(60):
+            coord._update_battery_session_tracking(power_discharge, PowerFlows())
+
+        # One continuous session, never flipped.
+        assert coord._battery_session.active is True
+        assert coord._battery_session.session_type == "discharge"
 
 
 class TestBatterySessionEnergyAccumulation:


### PR DESCRIPTION
## Summary

User reported a continuous 1-hour discharge showing as a **2-minute session** on the battery card. Root cause was over-tight thresholds in `_update_battery_session_tracking`.

## Cause

```
DISCHARGING
  Energy   0.03 kWh   ← correct for the recorded session
  Duration 2 min      ← session restarted within the last 2 minutes
  Avg power 950 W
```

The battery had been discharging continuously since sunset (~1 hour earlier), but:

- `POWER_THRESHOLD = 50 W` — lower than the inverter's idle-state drift. Cycles where the reading hovered ±50 W counted as "idle."
- `IDLE_CYCLES_TO_END = 3` (~30 s) — short enough that a single 30 s rebalance ended the session.
- Single-cycle direction-change reset — one cycle of +50 W charge during a discharge transient immediately flipped the session.

The data was fine. The policy was the bug.

## Fix

Three hysteresis tweaks:

| Threshold | Was | Now | Rationale |
|---|---|---|---|
| Power dead-band | 50 W | **200 W** | Above inverter idle drift; well below any meaningful flow. |
| Idle cycles to end | 3 | **18** | ~3 min — covers cloud transits + sunset rebalance. |
| Opposite-direction cycles to flip | 1 | **3** | Single-cycle blips don't end the session. |

New `_battery_session_opposite_count` counter mirrors the existing idle counter; resets whenever the cycle matches the active session direction.

## Test plan

- [x] **2910 / 2910 tests pass** (+5 new, 0 broken).
- New scenarios pinned:
  - 1-hour continuous discharge — 1 session, ~1.1 kWh.
  - Sunset transient (10 min discharge + 1 charge blip + 10 min discharge) — 1 session.
  - Single-cycle opposite blip — session survives.
  - 3 consecutive opposite cycles — clean flip.
  - 5-cycle gap — session keeps idle counter.
  - 18 consecutive idle cycles — session ends.
- [ ] HA-PROD: deploy ~30 min before sunset, watch `sensor.sem_battery_session_duration` increase past 60 min through the transition.

## Files

- `coordinator/coordinator.py:3296-3391` — hysteresis logic + new constants.
- `coordinator/coordinator.py:317-320` — initialize counter.
- `tests/test_battery_session.py` — updated + 5 new tests.
- `manifest.json` — `1.7.0-beta.11` → `1.7.0-beta.12`.

## Risk

**Low.** Pure threshold/state-machine tweak inside a single function. Session sensor schema unchanged. Persisting state across HA restarts is scoped out as a follow-up.