### PR TITLE
fix(#384): expand ev_charger_add translations across all 15 languages

### DIFF
--- a/translations/cs.json
+++ b/translations/cs.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Přidat EV nabíječku",
+        "description": "Nakonfigurujte novou EV nabíječku. SEM rozdělí přebytek z fotovoltaiky mezi nabíječky podle priority.\n\nPro řízení proudu použijte BUĎ entitu number (Wallbox, go-eCharger), NEBO službu (KEBA). Druhé pole nechte prázdné.",
         "data": {
+          "charger_name": "Název nabíječky",
+          "ev_connected_sensor": "Stav připojení EV",
+          "ev_charging_sensor": "Stav nabíjení EV",
+          "ev_charging_power_sensor": "Nabíjecí výkon EV",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Priorita přebytku (1=nejvyšší)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit solárního nabíjení (kWh)",
           "ev_target_soc_max": "Limit solárního nabíjení (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
           "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce."
         }

--- a/translations/da.json
+++ b/translations/da.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Tilføj EV-oplader",
+        "description": "Konfigurer en ny EV-oplader. SEM fordeler soloverskuddet mellem opladerne efter prioritet.\n\nTil strømstyring, brug ENTEN number-entiteten (Wallbox, go-eCharger) ELLER tjenesten (KEBA). Lad den anden være tom.",
         "data": {
+          "charger_name": "Ladernavn",
+          "ev_connected_sensor": "EV Forbindelsesstatus",
+          "ev_charging_sensor": "EV Ladestatus",
+          "ev_charging_power_sensor": "EV Ladeeffekt",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Overskudsprioritet (1=højeste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solopladningsgrænse (kWh)",
           "ev_target_soc_max": "Solopladningsgrænse (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
           "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen."
         }

--- a/translations/de.json
+++ b/translations/de.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "EV-Lader hinzufügen",
+        "description": "Einen neuen EV-Lader konfigurieren. SEM verteilt den Solarüberschuss nach Priorität auf alle Lader.\n\nFür die Stromsteuerung ENTWEDER die Number-Entität (Wallbox, go-eCharger) ODER den Service (KEBA) verwenden. Das jeweils andere Feld leer lassen.",
         "data": {
+          "charger_name": "Ladername",
+          "ev_connected_sensor": "EV Verbindungsstatus",
+          "ev_charging_sensor": "EV Ladestatus",
+          "ev_charging_power_sensor": "EV Ladeleistung",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Überschuss-Priorität (1=höchste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solar-Ladelimit (kWh)",
           "ev_target_soc_max": "Solar-Ladelimit (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Solarüberschuss lädt bis hierhin, dann Stopp. Auf Voll lassen, um frei aus der Sonne zu laden.",
           "ev_target_soc_max": "Solarüberschuss lädt bis zu diesem SOC, dann Stopp. Auf 100% lassen, um frei aus der Sonne zu laden."
         }

--- a/translations/en.json
+++ b/translations/en.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Add EV Charger",
+        "description": "Configure a new EV charger. SEM will distribute surplus power across chargers by priority.\n\nFor current control, use EITHER the number entity (Wallbox, go-eCharger) OR the service (KEBA). Leave the other blank.",
         "data": {
+          "charger_name": "Charger Name",
+          "ev_connected_sensor": "EV Connected Status",
+          "ev_charging_sensor": "EV Charging Status",
+          "ev_charging_power_sensor": "EV Charging Power",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solar charge limit (kWh)",
           "ev_target_soc_max": "Solar charge limit (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Solar surplus charges up to this, then stops. Leave at full to charge freely from sun.",
           "ev_target_soc_max": "Solar surplus charges up to this SOC, then stops. Leave at 100% to charge freely from sun."
         }

--- a/translations/es.json
+++ b/translations/es.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Añadir cargador EV",
+        "description": "Configura un nuevo cargador EV. SEM distribuirá el excedente solar entre los cargadores según la prioridad.\n\nPara el control de corriente, usa O BIEN la entidad number (Wallbox, go-eCharger) O BIEN el servicio (KEBA). Deja el otro en blanco.",
         "data": {
+          "charger_name": "Nombre del cargador",
+          "ev_connected_sensor": "EV Connected Status",
+          "ev_charging_sensor": "EV Charging Status",
+          "ev_charging_power_sensor": "EV Charging Power",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Límite de carga solar (kWh)",
           "ev_target_soc_max": "Límite de carga solar (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
           "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol."
         }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Lisää EV-laturi",
+        "description": "Määritä uusi EV-laturi. SEM jakaa aurinkoylijäämän laturien kesken prioriteetin mukaan.\n\nVirran ohjaukseen käytä JOKO number-entiteettiä (Wallbox, go-eCharger) TAI palvelua (KEBA). Jätä toinen tyhjäksi.",
         "data": {
+          "charger_name": "Laturin nimi",
+          "ev_connected_sensor": "Sähköauto yhdistetty",
+          "ev_charging_sensor": "Sähköauton lataustila",
+          "ev_charging_power_sensor": "Sähköauton latausteho",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Aurinkolatauksen raja (kWh)",
           "ev_target_soc_max": "Aurinkolatauksen raja (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
           "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta."
         }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Ajouter un chargeur EV",
+        "description": "Configurez un nouveau chargeur EV. SEM répartira le surplus solaire entre les chargeurs selon leur priorité.\n\nPour le contrôle du courant, utilisez SOIT l'entité number (Wallbox, go-eCharger) SOIT le service (KEBA). Laissez l'autre vide.",
         "data": {
+          "charger_name": "Nom du chargeur",
+          "ev_connected_sensor": "EV Connected Status",
+          "ev_charging_sensor": "EV Charging Status",
+          "ev_charging_power_sensor": "EV Charging Power",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Priorité surplus (1=plus haute)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de charge solaire (kWh)",
           "ev_target_soc_max": "Limite de charge solaire (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
           "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil."
         }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "EV-töltő hozzáadása",
+        "description": "Új EV-töltő konfigurálása. A SEM a szolár-többletet a töltők között prioritás alapján osztja el.\n\nÁramszabályozáshoz használja VAGY a number entitást (Wallbox, go-eCharger), VAGY a szolgáltatást (KEBA). A másikat hagyja üresen.",
         "data": {
+          "charger_name": "Töltő neve",
+          "ev_connected_sensor": "EV Csatlakoztatva",
+          "ev_charging_sensor": "EV Töltési állapot",
+          "ev_charging_power_sensor": "EV Töltési teljesítmény",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Napelemes töltési limit (kWh)",
           "ev_target_soc_max": "Napelemes töltési limit (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
           "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból."
         }

--- a/translations/it.json
+++ b/translations/it.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Aggiungi caricatore EV",
+        "description": "Configura un nuovo caricatore EV. SEM distribuirà l'eccedenza solare tra i caricatori in base alla priorità.\n\nPer il controllo della corrente, usa O l'entità number (Wallbox, go-eCharger) O il servizio (KEBA). Lascia vuoto l'altro.",
         "data": {
+          "charger_name": "Nome caricatore",
+          "ev_connected_sensor": "EV Connected Status",
+          "ev_charging_sensor": "EV Charging Status",
+          "ev_charging_power_sensor": "EV Charging Power",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite di carica solare (kWh)",
           "ev_target_soc_max": "Limite di carica solare (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
           "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole."
         }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "EV-lader toevoegen",
+        "description": "Configureer een nieuwe EV-lader. SEM verdeelt zonneoverschot over laders op basis van prioriteit.\n\nGebruik voor stroomregeling OFWEL de number-entiteit (Wallbox, go-eCharger) OFWEL de service (KEBA). Laat de andere leeg.",
         "data": {
+          "charger_name": "Ladernaam",
+          "ev_connected_sensor": "EV verbonden status",
+          "ev_charging_sensor": "EV laadstatus",
+          "ev_charging_power_sensor": "EV laadvermogen",
+          "ev_charger_service": "Lader stroom-instel service (optioneel)",
+          "ev_charger_service_entity_id": "Doel-entiteit voor laderservice (optioneel)",
+          "ev_surplus_priority": "Overschotprioriteit (1 = hoogste)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Zonne-laadlimiet (kWh)",
           "ev_target_soc_max": "Zonne-laadlimiet (SOC %)"
         },
         "data_description": {
+          "charger_name": "Weergavenaam voor deze laadpaal in het dashboard.",
+          "ev_connected_sensor": "Binaire sensor die aangeeft of een voertuig is aangesloten op deze laadpaal.",
+          "ev_charging_sensor": "Binaire sensor die aangeeft of deze laadpaal actief vermogen levert.",
+          "ev_charging_power_sensor": "Numerieke sensor (W) die het vermogen toont dat door deze laadpaal wordt geleverd.",
+          "ev_charger_service": "HA-service die wordt gebruikt om de laadstroom in te stellen. Gebruiken voor KEBA of Easee.",
+          "ev_charger_service_entity_id": "Entiteit-ID dat als doel van de serviceaanroep wordt meegegeven. Laat leeg indien niet nodig.",
+          "ev_surplus_priority": "Volgorde van overschotverdeling over meerdere laadpalen. Lager getal = hogere prioriteit.",
+          "ev_current_control_entity": "Number-entiteit die wordt gebruikt om de laadstroom (A) in te stellen. Gebruiken voor Wallbox, go-eCharger en vergelijkbare laadpalen.",
           "daily_ev_target_max": "Zonne-overschot laadt tot deze waarde en stopt dan. Laat op vol staan om vrij op zon te laden.",
           "ev_target_soc_max": "Zonne-overschot laadt tot deze SOC en stopt dan. Laat op 100% staan om vrij op zon te laden."
         }

--- a/translations/no.json
+++ b/translations/no.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Legg til EV-lader",
+        "description": "Konfigurer en ny EV-lader. SEM fordeler soloverskuddet mellom laderne etter prioritet.\n\nFor strømstyring, bruk ENTEN number-entiteten (Wallbox, go-eCharger) ELLER tjenesten (KEBA). La den andre stå tom.",
         "data": {
+          "charger_name": "Ladernavn",
+          "ev_connected_sensor": "EV Tilkoblingsstatus",
+          "ev_charging_sensor": "EV Ladestatus",
+          "ev_charging_power_sensor": "EV Ladeeffekt",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladegrense (kWh)",
           "ev_target_soc_max": "Solladegrense (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
           "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol."
         }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Dodaj ładowarkę EV",
+        "description": "Skonfiguruj nową ładowarkę EV. SEM rozdzieli nadwyżkę fotowoltaiczną pomiędzy ładowarki według priorytetu.\n\nDo sterowania prądem użyj ALBO encji number (Wallbox, go-eCharger) ALBO usługi (KEBA). Drugie pole pozostaw puste.",
         "data": {
+          "charger_name": "Nazwa ładowarki",
+          "ev_connected_sensor": "Status podłączenia EV",
+          "ev_charging_sensor": "Status ładowania EV",
+          "ev_charging_power_sensor": "Moc ładowania EV",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit ładowania słonecznego (kWh)",
           "ev_target_soc_max": "Limit ładowania słonecznego (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
           "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca."
         }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Adicionar carregador EV",
+        "description": "Configure um novo carregador EV. O SEM distribui o excedente solar pelos carregadores por ordem de prioridade.\n\nPara o controlo de corrente, use OU a entidade number (Wallbox, go-eCharger) OU o serviço (KEBA). Deixe o outro em branco.",
         "data": {
+          "charger_name": "Nome do carregador",
+          "ev_connected_sensor": "Estado de conexão VE",
+          "ev_charging_sensor": "Estado de carregamento VE",
+          "ev_charging_power_sensor": "Potência de carregamento VE",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de carga solar (kWh)",
           "ev_target_soc_max": "Limite de carga solar (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
           "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol."
         }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Adăugare încărcător EV",
+        "description": "Configurați un nou încărcător EV. SEM va distribui surplusul solar între încărcătoare în funcție de prioritate.\n\nPentru controlul curentului, folosiți FIE entitatea number (Wallbox, go-eCharger), FIE serviciul (KEBA). Lăsați celălalt necompletat.",
         "data": {
+          "charger_name": "Nume încărcător",
+          "ev_connected_sensor": "Stare conectare VE",
+          "ev_charging_sensor": "Stare încărcare VE",
+          "ev_charging_power_sensor": "Putere încărcare VE",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limită încărcare solară (kWh)",
           "ev_target_soc_max": "Limită încărcare solară (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
           "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare."
         }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -371,11 +371,29 @@
         }
       },
       "ev_charger_add": {
+        "title": "Lägg till EV-laddare",
+        "description": "Konfigurera en ny EV-laddare. SEM fördelar solöverskottet mellan laddarna efter prioritet.\n\nFör strömstyrning, använd ANTINGEN number-entiteten (Wallbox, go-eCharger) ELLER tjänsten (KEBA). Lämna den andra tom.",
         "data": {
+          "charger_name": "Laddarnamn",
+          "ev_connected_sensor": "EV Anslutningsstatus",
+          "ev_charging_sensor": "EV Laddningsstatus",
+          "ev_charging_power_sensor": "EV Laddningseffekt",
+          "ev_charger_service": "Charger Set-Current Service (optional)",
+          "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
+          "ev_surplus_priority": "Surplus Priority (1=highest)",
+          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladdningsgräns (kWh)",
           "ev_target_soc_max": "Solladdningsgräns (SOC %)"
         },
         "data_description": {
+          "charger_name": "Friendly name for this charger shown in the dashboard.",
+          "ev_connected_sensor": "Binary sensor that reports whether a vehicle is plugged into this charger.",
+          "ev_charging_sensor": "Binary sensor that reports whether this charger is actively delivering power.",
+          "ev_charging_power_sensor": "Numeric sensor (W) reporting power delivered by this charger.",
+          "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
+          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
+          "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
+          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
           "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
           "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen."
         }


### PR DESCRIPTION
## Summary
- Refs #384.
- The Add EV Charger options-flow step had translation coverage for only two fields (Solar charge limit kWh / SOC%) — the rest of the form fell back to the raw key, which is the sparse/un-explained Add form @RienduPre reported on his Wallbox Pulsar setup.
- Mirror the existing \`ev_charger_edit\` \`data\` / \`data_description\` into \`ev_charger_add\` for each language (the field set is identical) and add per-language "Add EV Charger" titles + a two-paragraph description that flags the EITHER number-entity OR service-call trade-off up front.
- 15 files, +270 lines, no code changes.

## Out of scope
- Where \`ev_charger_edit\` itself left a string untranslated (e.g. de.json's \`ev_charger_service\` is still English), the Add form inherits the same partial translation. Fixing those upstream gaps is a separate sweep.
- The structural fact that the Add flow has more fields than the Initial flow (issue #384 part 2 — initial flow is missing \`ev_current_control_entity\` for Wallbox-style chargers) is tracked separately.

## Test plan
- [ ] HA-TEST: Settings → SEM → Configure → Add EV Charger → verify field labels + descriptions render in English
- [ ] Switch HA-TEST language to German → verify German title + description + labels render
- [ ] Hassfest / HACS validate JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)