### PR TITLE
fix: stall detector must not anchor SOC=100% when SEM never commanded charge

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -306,6 +306,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # False-stall guard: consecutive failed re-enables + "car full" latch (#243)
         self._ev_reenable_attempts: int = 0
         self._ev_charge_refused: bool = False
+        # Highest commanded amps across all chargers in the most recent
+        # decide() cycle. Gates the fleet-level "0W means full" stall
+        # path so it can't fire when SEM itself decided not to charge
+        # (e.g. solar_only with surplus below the 3-phase 6 A floor —
+        # the stall detector would otherwise falsely anchor SOC at 100 %).
+        self._last_commanded_amps_fleet: int = 0
 
         # Session cost tracking (primary charger + per-charger dict)
         self._session_data = SessionData()
@@ -1277,6 +1283,11 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 # Reset before the loop so a removed charger's stale
                 # state doesn't fire on the next cycle.
                 self._effective_states_per_charger = {}
+                # Reset the fleet-level commanded-amps tracker so the
+                # stall path can tell "SEM isn't asking for charge this
+                # cycle" from "SEM asked but EV refused" (see comment on
+                # ``_last_commanded_amps_fleet`` in __init__).
+                self._last_commanded_amps_fleet = 0
                 # Pre-cache the per-charger configs once for the night
                 # gate below — inline lookup is the same pattern other
                 # branches use here. (#277 Phase B)
@@ -1495,6 +1506,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             solar_committed_w=self._solar_committed_w_per_cycle,
                         )
                         decision = decide_v2(view)
+                        # Track the highest commanded current across the
+                        # fleet so the stall-detection path (line ~3725)
+                        # can distinguish "SEM idle, EV at 0W is correct"
+                        # from "SEM commanding, EV refused → really full".
+                        if decision.commanded_amps > self._last_commanded_amps_fleet:
+                            self._last_commanded_amps_fleet = decision.commanded_amps
                         _LOGGER.debug(
                             "decide %s mode=%s → intent=%s amps=%d budget=%.0fW :: %s",
                             cid, per_mode, decision.intent.value,
@@ -3715,8 +3732,14 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     })
             self._ev_taper_detector.reset_session()
 
-        # Stall detection → full charge: if car is connected, SEM is sending current,
-        # but power stays 0W for extended period, the car is full (BMS refusing).
+        # Stall detection → full charge: if car is connected AND SEM has
+        # been commanding a charge AND the EV still draws 0 W for ~3 min,
+        # the BMS is refusing further current and the car is genuinely
+        # full. The ``commanded_amps_fleet >= 6`` gate is the load-bearing
+        # bit: without it, ``solar_only`` with insufficient surplus
+        # (e.g. cloudy day, 869 W < 3-phase 4 140 W floor) trips the
+        # stall and falsely anchors SOC at 100 %, after which
+        # ``charge_needed`` stays False forever and the EV never starts.
         # Legacy single-detector stall path; runs only when multi-charger
         # isn't configured (per-charger stall lives on
         # ``_ev_stalled_since_per_charger``). Demo of the v1.6.16
@@ -3724,6 +3747,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # bytecode rather than a comment line above the read.
         if (power.ev_connected and not power.ev_charging
                 and power.ev_power.as_fleet_total("legacy single-detector stall path") < 50
+                and self._last_commanded_amps_fleet >= 6
                 and not self._ev_taper_detector._full_detected):
             stall_count = getattr(self, '_full_stall_count', 0) + 1
             self._full_stall_count = stall_count

--- a/tests/test_ev_stall_gate_commanded_amps.py
+++ b/tests/test_ev_stall_gate_commanded_amps.py
@@ -1,0 +1,137 @@
+"""Regression: the fleet-level "0 W → 100 % SOC" stall detector must NOT
+fire when SEM itself isn't asking for charge.
+
+PROD symptom (HA-PROD, 2026-06-03): ``solar_only`` mode on a 3-phase
+KEBA — surplus 869 W < 6 A floor 4 140 W, so SEM correctly idles. After
+3 minutes of idle, the legacy stall path latched ``estimated_soc=100%``,
+which made ``charge_needed=False`` permanently, so the EV never started
+on later high-surplus cycles even after a real drive.
+
+The fix gates the stall block on
+``self._last_commanded_amps_fleet >= 6``: only the case where SEM was
+actively *commanding* 6+ A and the EV still drew 0 W counts as a real
+"BMS refusing further current" event. The reset to 0 happens at the
+top of every per-charger decide-loop.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _stall_gate(*, ev_connected, ev_charging, ev_power_w,
+                last_commanded_amps_fleet, full_detected):
+    """In-test mirror of the gate at coordinator.py ~3725.
+
+    Kept tiny + dependency-free so it doesn't have to import the
+    coordinator module (which pulls HomeAssistant). Two tests below
+    cross-check that ``coordinator.py`` still has the same gate.
+    """
+    return (
+        ev_connected
+        and not ev_charging
+        and ev_power_w < 50
+        and last_commanded_amps_fleet >= 6
+        and not full_detected
+    )
+
+
+class TestStallGateCommandedAmps:
+    def test_solar_only_idle_does_not_trip_stall(self):
+        """PROD reproduction: connected EV, SEM idle by decision (0 A
+        commanded because surplus < 3-phase floor), 0 W power. The gate
+        MUST stay False — otherwise SOC gets falsely anchored at 100 %."""
+        assert _stall_gate(
+            ev_connected=True,
+            ev_charging=False,
+            ev_power_w=0,
+            last_commanded_amps_fleet=0,
+            full_detected=False,
+        ) is False
+
+    def test_actively_commanding_and_ev_refusing_trips_stall(self):
+        """When SEM is asking for 6 A but the EV still draws 0 W, that's
+        a real BMS-refusing-further-current event — gate must fire."""
+        assert _stall_gate(
+            ev_connected=True,
+            ev_charging=False,
+            ev_power_w=0,
+            last_commanded_amps_fleet=6,
+            full_detected=False,
+        ) is True
+
+    def test_high_amps_commanded_also_trips(self):
+        assert _stall_gate(
+            ev_connected=True,
+            ev_charging=False,
+            ev_power_w=10,
+            last_commanded_amps_fleet=16,
+            full_detected=False,
+        ) is True
+
+    def test_already_full_short_circuits(self):
+        assert _stall_gate(
+            ev_connected=True,
+            ev_charging=False,
+            ev_power_w=0,
+            last_commanded_amps_fleet=16,
+            full_detected=True,
+        ) is False
+
+    def test_disconnected_short_circuits(self):
+        assert _stall_gate(
+            ev_connected=False,
+            ev_charging=False,
+            ev_power_w=0,
+            last_commanded_amps_fleet=16,
+            full_detected=False,
+        ) is False
+
+    def test_actually_charging_short_circuits(self):
+        """If the EV is reporting active charging, this isn't a stall."""
+        assert _stall_gate(
+            ev_connected=True,
+            ev_charging=True,
+            ev_power_w=3000,
+            last_commanded_amps_fleet=16,
+            full_detected=False,
+        ) is False
+
+
+class TestCoordinatorGateStaysAligned:
+    """If someone edits the gate in ``coordinator.py`` and forgets to
+    update the in-test mirror above, this test fails fast on CI."""
+
+    def test_coordinator_gate_contains_last_commanded_amps_check(self):
+        """The fleet-level stall block (legacy single-detector path) MUST
+        gate on ``self._last_commanded_amps_fleet``. Asserting the source
+        text rather than calling the method keeps the test free of the
+        coordinator's heavy init."""
+        import pathlib
+        coord_src = pathlib.Path(
+            __file__,
+        ).resolve().parent.parent.joinpath("coordinator/coordinator.py").read_text()
+
+        # The gate string we care about — both halves on the same logical
+        # ``if`` block. Substring search is enough because the formatting
+        # is stable (one statement per line).
+        assert "self._last_commanded_amps_fleet >= 6" in coord_src, (
+            "stall gate must check commanded amps — see "
+            "test_ev_stall_gate_commanded_amps for PROD repro context"
+        )
+
+    def test_reset_at_top_of_per_charger_loop_present(self):
+        import pathlib
+        coord_src = pathlib.Path(
+            __file__,
+        ).resolve().parent.parent.joinpath("coordinator/coordinator.py").read_text()
+        assert "self._last_commanded_amps_fleet = 0" in coord_src
+
+    def test_update_after_decision_present(self):
+        import pathlib
+        coord_src = pathlib.Path(
+            __file__,
+        ).resolve().parent.parent.joinpath("coordinator/coordinator.py").read_text()
+        assert (
+            "decision.commanded_amps > self._last_commanded_amps_fleet"
+            in coord_src
+        )


### PR DESCRIPTION
## Summary
- PROD repro (HA-PROD 2026-06-03): \`solar_only\` mode, 3-phase, surplus 869 W < 4 140 W 6 A floor → SEM correctly idles. After 3 min the legacy stall path latched \`estimated_soc=100\` and \`charge_needed=False\` permanently, so the EV could never start until a manual reset.
- Root cause: gate at coordinator.py:3725 checks \`connected and not charging and power < 50 W\` but the comment two lines up says "if car is connected, **SEM is sending current**". The "SEM is sending current" half of the predicate was missing.
- Fix: track \`_last_commanded_amps_fleet\` (highest amps any charger asked for this cycle, reset per cycle) and add \`>= 6\` to the gate. Real BMS-refusing events keep firing; "SEM idle by decision" cycles no longer do.

## Test plan
- [x] New test \`test_ev_stall_gate_commanded_amps.py\`: 9 cases including the exact PROD repro
- [x] Cross-check tests assert the coordinator source still contains the gate line — prevents silent regression
- [x] All other EV tests pass locally (test_v14_integration, test_multi_charger_control)
- [ ] HA-PROD deploy: clear the already-latched \`estimated_soc=100\` in storage before restart so the EV starts on the next high-surplus cycle (one-off; the code patch alone won't unstick existing installs)

## Out of scope
- Adding a \`reset_ev_intelligence\` service for users hit by the same false-latch in the wild — tracked for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)