### PR TITLE
fix(#384): per-charger override fields in initial setup flow

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -386,7 +386,15 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     )
                 ),
 
-                # EV Charger Control (Optional - for chargers without number entity)
+                # EV Charger Control — pick ONE of the two paths below:
+                #   • Number entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …)
+                #   • Service call    (KEBA, Easee, Zaptec, OCPP, …)
+                vol.Optional(
+                    "ev_current_control_entity",
+                    description={"suggested_value": _opt_entity_default("ev_current_control_entity")},
+                ): selector.EntitySelector(
+                    selector.EntitySelectorConfig(domain="number")
+                ),
                 vol.Optional(
                     "ev_charger_service",
                     default=suggestions.get("ev_charger_service", ""),
@@ -421,9 +429,81 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         device_class="energy"
                     )
                 ),
-                # Vehicle SOC fields moved to OptionsFlow — they only matter
-                # when the user has a real vehicle SOC sensor, which most
-                # cars don't expose. Asking on install creates dead inputs.
+
+                # Per-charger tunables — parity with the Add/Edit flow (#384).
+                # All have sensible defaults so the user can ignore them.
+                vol.Optional(
+                    "ev_surplus_priority",
+                    default=5,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
+                ),
+                vol.Optional(
+                    "daily_ev_target",
+                    default=DEFAULT_DAILY_EV_TARGET,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0, max=100, step=0.5,
+                        unit_of_measurement="kWh", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "daily_ev_target_max",
+                    default=100,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0, max=100, step=0.5,
+                        unit_of_measurement="kWh", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "ev_night_initial_current",
+                    default=10,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=6, max=32, step=1,
+                        unit_of_measurement="A", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "ev_min_current",
+                    default=6,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=6, max=16, step=1,
+                        unit_of_measurement="A", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "ev_target_soc",
+                    default=80,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=50, max=100, step=5,
+                        unit_of_measurement="%", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "ev_target_soc_max",
+                    default=100,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=50, max=100, step=5,
+                        unit_of_measurement="%", mode="slider",
+                    )
+                ),
+                vol.Optional(
+                    "ev_battery_capacity_kwh",
+                    default=40,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=10, max=120, step=5,
+                        unit_of_measurement="kWh", mode="box",
+                    )
+                ),
+                # `vehicle_soc_entity` stays in OptionsFlow only — it requires a
+                # real vehicle SOC sensor, which most cars don't expose. Asking
+                # at install creates a dead input for the common case.
             }),
             errors=errors
         )
@@ -530,6 +610,12 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "ev_start_service", "ev_start_service_data",
                         "ev_stop_service", "ev_stop_service_data",
                         "ev_charger_needs_cycle", "ev_surplus_priority",
+                        # Per-charger overrides surfaced in the initial flow (#384)
+                        "ev_current_control_entity",
+                        "daily_ev_target", "daily_ev_target_max",
+                        "ev_night_initial_current", "ev_min_current",
+                        "ev_target_soc", "ev_target_soc_max",
+                        "ev_battery_capacity_kwh",
                     ]
                     charger_0 = {"id": "ev_charger", "name": "EV Charger"}
                     for k in _EV_KEYS:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -307,6 +307,90 @@ class TestSolarEnergyManagementConfigFlow:
         assert data["observer_mode"] is False
 
     @pytest.mark.asyncio
+    async def test_ev_charger_step_schema_exposes_per_charger_fields(self, mock_hass):
+        """#384 Part 2: the initial flow exposes the per-charger override fields.
+
+        Without `ev_current_control_entity`, Wallbox-style chargers (number
+        entity, no service call) couldn't be configured at install — the user
+        had to finish setup then edit. The full per-charger override set is
+        also exposed so the install doesn't lag behind the Add/Edit flow.
+        """
+        energy_config = _make_energy_dashboard_config()
+        flow = _create_flow(mock_hass)
+        flow._energy_dashboard_config = energy_config
+
+        mock_detector = MagicMock()
+        mock_detector.get_suggested_ev_defaults.return_value = {}
+
+        with patch(
+            "custom_components.solar_energy_management.config_flow.HardwareDetector",
+            return_value=mock_detector,
+        ), patch(
+            "custom_components.solar_energy_management.config_flow.discover_ev_charger_from_registry",
+            return_value={},
+        ):
+            result = await flow.async_step_ev_charger(user_input=None)
+
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "ev_charger"
+        schema_keys = {str(k) for k in result["data_schema"].schema.keys()}
+        for key in (
+            "ev_current_control_entity",
+            "ev_surplus_priority",
+            "daily_ev_target",
+            "daily_ev_target_max",
+            "ev_night_initial_current",
+            "ev_min_current",
+            "ev_target_soc",
+            "ev_target_soc_max",
+            "ev_battery_capacity_kwh",
+        ):
+            assert key in schema_keys, f"#384: {key} missing from initial ev_charger schema"
+
+    @pytest.mark.asyncio
+    async def test_hardware_step_migrates_per_charger_fields(self, mock_hass):
+        """#384 Part 2: per-charger overrides set at install land in ev_chargers[0]."""
+        energy_config = _make_energy_dashboard_config()
+        flow = _create_flow(mock_hass)
+        flow._energy_dashboard_config = energy_config
+        flow._data = {
+            **energy_config.to_dict(),
+            **VALID_EV_INPUT,
+            "observer_mode": False,
+            # New per-charger overrides set in the initial flow
+            "ev_current_control_entity": "number.wallbox_max_charging_current",
+            "ev_surplus_priority": 7,
+            "daily_ev_target": 12.5,
+            "daily_ev_target_max": 30.0,
+            "ev_night_initial_current": 16,
+            "ev_min_current": 8,
+            "ev_target_soc": 85,
+            "ev_target_soc_max": 95,
+            "ev_battery_capacity_kwh": 60,
+        }
+
+        flow.async_set_unique_id = AsyncMock()
+        flow._abort_if_unique_id_configured = MagicMock()
+
+        with patch(
+            "custom_components.solar_energy_management.config_flow.discover_inverter_from_registry",
+            return_value="number.batteries_maximale_entladeleistung",
+        ):
+            result = await flow.async_step_hardware(user_input=VALID_HARDWARE_INPUT)
+
+        assert result["type"] == FlowResultType.CREATE_ENTRY
+        charger_0 = result["data"]["ev_chargers"][0]
+        assert charger_0["ev_current_control_entity"] == "number.wallbox_max_charging_current"
+        assert charger_0["ev_surplus_priority"] == 7
+        assert charger_0["daily_ev_target"] == 12.5
+        assert charger_0["daily_ev_target_max"] == 30.0
+        assert charger_0["ev_night_initial_current"] == 16
+        assert charger_0["ev_min_current"] == 8
+        assert charger_0["ev_target_soc"] == 85
+        assert charger_0["ev_target_soc_max"] == 95
+        assert charger_0["ev_battery_capacity_kwh"] == 60
+
+    @pytest.mark.asyncio
     async def test_hardware_step_no_inverter_detected_uses_empty(self, mock_hass):
         """If discover_inverter_from_registry returns None, the key is set to ''."""
         energy_config = _make_energy_dashboard_config()

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "Nabíječka EV",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "Služba nastavení proudu nabíječky (volitelné)",
           "ev_charger_service_entity_id": "Cílová entita služby nabíječky (volitelné)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/da.json
+++ b/translations/da.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Lader",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV-Lader",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV-Lader Strom-Service (optional)",
           "ev_charger_service_entity_id": "EV-Lader Service-Zielentität (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -13,24 +13,42 @@
       },
       "ev_charger": {
         "title": "EV Charger",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
           "ev_charging_power_sensor": "🚗 EV Charging Power — power delivered to vehicle (W)",
-          "ev_charger_service": "EV Charger Set-Current Service (optional)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_charger_service": "EV Charger Set-Current Service (KEBA-style chargers)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Charger",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "Sähköauton laturi",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Charger",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Töltő",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/it.json
+++ b/translations/it.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Charger",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Lader",
-        "description": "SEM heeft je EV Lader(s) automatisch ingelezen vanuit de Home Assistant entity registry. Controleer of deze kloppen en klik op **Submit** — normaal gesproken zou alles moeten kloppen. Optionele velden kunnen leeg gelaten worden.",
+        "description": "SEM heeft je EV Lader(s) automatisch ingelezen vanuit de Home Assistant entity registry. Controleer of deze kloppen en klik op **Submit** — normaal gesproken zou alles moeten kloppen. Optionele velden kunnen leeg gelaten worden.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Verbonden — voertuig stekker",
           "ev_charging_sensor": "⚡ EV Laden Actief — huidige laadstatus",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Lader Stroom Service (optioneel)",
           "ev_charger_service_entity_id": "EV Lader Service Entiteit (optioneel)",
           "ev_current_sensor": "⚡ EV Laadstroom — amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Totale Energie — geleverde energie (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Totale Energie — geleverde energie (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binaire sensor die aangeeft we je electrische auto is aangesloten op de lader. Automatische detectie voor de volgende merken: KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binaire sensor die aangeeft of je lader actief aan opladen is. Automatische detectie vanuit je lader intergratie.",
           "ev_charging_power_sensor": "Numerieke sensor (W) die rapporteert met hoeveel vermogen je electrische auto oplaadt. Automatische detectie vanuit je lader intergratie.",
-          "ev_charger_service": "Home Assistant service die aangeroepen moet worden om de lader amperage aan te passent (bijvoorbeeld keba.set_current, easee.set_charger_max_limit). Automatisch ingevuld voor KEBA. Laat dit veld leeg voor laders die een number entiry gebruiken.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entiteits ID die gebruikt wordt in de service call.",
           "ev_current_sensor": "Optioneell. Numerieke sensor (A) die het werkelijke stroomverbruik rapporteert. Wordt gebruikt voor diagnostiek.",
-          "ev_total_energy_sensor": "Optioneel. Cumulatieve kWh sensor voor de totale energie die je electrische auto heeft ontvangen."
+          "ev_total_energy_sensor": "Optioneel. Cumulatieve kWh sensor voor de totale energie die je electrische auto heeft ontvangen.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/no.json
+++ b/translations/no.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Lader",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "Ładowarka EV",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "Carregador EV",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "Încărcător EV",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -13,7 +13,7 @@
       },
       "ev_charger": {
         "title": "EV Laddare",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.",
+        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
           "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
           "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
@@ -21,16 +21,34 @@
           "ev_charger_service": "EV Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
+          "ev_surplus_priority": "Surplus Priority",
+          "daily_ev_target": "Daily Charge Target (kWh)",
+          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
+          "ev_night_initial_current": "Night Start Current (A)",
+          "ev_min_current": "Minimum Charging Current (A)",
+          "ev_target_soc": "Target SOC Floor (%)",
+          "ev_target_soc_max": "Target SOC Ceiling (%)",
+          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
           "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
           "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank for chargers controlled via a number entity.",
+          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
+          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
+          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
+          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
+          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
+          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
+          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
+          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
+          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
         }
       },
       "hardware": {


### PR DESCRIPTION
## Summary

Part 2 of #384. RienduPre's Wallbox Pulsar couldn't be configured at install because the initial `ev_charger` step had no `ev_current_control_entity` field — Wallbox-style chargers (number entity, no service call) had no way to be controlled until the install was complete and the user dropped into Options → Edit.

PR #388 closed Part 1 (translation parity in the Add flow). This closes the structural gap.

## What changed

8 new optional fields surface in `async_step_ev_charger`:

| Field | Why |
|---|---|
| `ev_current_control_entity` | Hard blocker for Wallbox-style chargers |
| `ev_surplus_priority` | Per-charger surplus distribution weight |
| `daily_ev_target` / `_max` | Per-charger override of the kWh target band |
| `ev_night_initial_current` | Night-charging start current |
| `ev_min_current` | Hardware floor |
| `ev_target_soc` / `_max` | SOC target band |
| `ev_battery_capacity_kwh` | kWh ↔ SOC conversion |

`vehicle_soc_entity` deliberately stays in OptionsFlow — per the existing line-424 comment, asking on install creates a dead input for users without a vehicle SOC sensor.

`_EV_KEYS` bridge extended so the new flat install-time keys land inside `ev_chargers[0]` alongside the existing per-charger config.

Step description gains a one-line dual-path hint (Number Entity vs Service Call) so users see the choice up front.

## Translations

`ev_charger.data` / `data_description` extended across all 15 languages with English placeholders for the new keys — matches PR #388's pattern. Native translations can land in a follow-up sweep.

## Tests

- `test_ev_charger_step_schema_exposes_per_charger_fields` — asserts all 9 new fields appear in the schema.
- `test_hardware_step_migrates_per_charger_fields` — end-to-end install with overrides asserts they reach `ev_chargers[0]` via the bridge.

**2922 / 2922 tests pass locally.**

## Release path

Lands on `develop` and gets bundled into the next beta tag along with PR #385 (per-charger vehicle_soc, #383), PR #388 (#384 Part 1 translations), and PR #389 (stall detector fix).

Fixes #384