### PR TITLE
fix(#359): tariff percentile classifier — convert timestamps to local tz

### DIFF
--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -21,6 +21,24 @@ from homeassistant.util import dt as dt_util
 _LOGGER = logging.getLogger(__name__)
 
 
+def _local_date(timestamp: datetime):
+    """Return the calendar date of ``timestamp`` in HA's local tz.
+
+    #359: providers vary on what tz they emit — Tibber uses local,
+    Nordpool is often UTC. A bare ``timestamp.date()`` on a UTC-tagged
+    datetime returns the UTC date, which silently mismatches the local
+    ``today`` (Europe/Amsterdam, +02:00 in summer) and empties the
+    'today's prices' array → percentile breaks return None → static
+    thresholds apply → €0.30 reported as ``normal`` (RienduPre).
+
+    Naive datetimes (no tz info) pass through unchanged so old tests
+    and call sites that build their own clocks aren't disturbed.
+    """
+    if timestamp.tzinfo is None:
+        return timestamp.date()
+    return dt_util.as_local(timestamp).date()
+
+
 class PriceLevel(Enum):
     """Electricity price classification."""
     NEGATIVE = "negative"
@@ -525,11 +543,24 @@ class DynamicTariffProvider(TariffProvider):
         ):
             return self._percentile_breaks
 
+        # #359 follow-up: convert each timestamp into HA's local tz before
+        # taking .date(). Providers vary on what tz they emit — Tibber is
+        # local, Nordpool is often UTC — and a naked .date() on a UTC
+        # timestamp returns the UTC date, which doesn't match the local
+        # ``today`` and silently empties the array → fall-through to the
+        # static thresholds → €0.30 reported as ``normal`` even on a day
+        # where it's the peak (RienduPre, NL, #359 "Not solved").
         today_prices = sorted(
             p.price for p in self._prices_cache
-            if p.timestamp.date() == today and p.price is not None
+            if _local_date(p.timestamp) == today
+            and p.price is not None
         )
         if len(today_prices) < 4:
+            _LOGGER.debug(
+                "tariff/#359: percentile fallback — today's price array "
+                "has %d / %d points (need ≥4); using static thresholds",
+                len(today_prices), len(self._prices_cache),
+            )
             return None
 
         def _quantile(sorted_values: List[float], q: float) -> float:
@@ -559,7 +590,18 @@ class DynamicTariffProvider(TariffProvider):
         # narrower than that is functionally flat, so fall through to
         # the static path.
         if (breaks["p90"] - breaks["p10"]) < 0.01:
+            _LOGGER.debug(
+                "tariff/#359: degenerate distribution — p90-p10=%.4f < 0.01 "
+                "(%d today points); using static thresholds",
+                breaks["p90"] - breaks["p10"], len(today_prices),
+            )
             return None
+        _LOGGER.debug(
+            "tariff/#359: percentile breaks for %s — p10=%.4f p25=%.4f "
+            "p75=%.4f p90=%.4f (%d today points)",
+            today_key, breaks["p10"], breaks["p25"], breaks["p75"],
+            breaks["p90"], len(today_prices),
+        )
         self._percentile_breaks = breaks
         self._percentile_breaks_for = today_key
         return breaks
@@ -612,7 +654,13 @@ class DynamicTariffProvider(TariffProvider):
         )
 
         if prices:
-            today_prices = [p.price for p in prices if p.timestamp.date() == dt_util.now().date()]
+            # #359: use the timestamp's local-tz date — see _get_percentile_breaks
+            # for the same UTC-vs-local pitfall.
+            today = dt_util.now().date()
+            today_prices = [
+                p.price for p in prices
+                if _local_date(p.timestamp) == today
+            ]
             if today_prices:
                 data.today_min_price = min(today_prices)
                 data.today_max_price = max(today_prices)

--- a/tests/test_tariff_percentile_359.py
+++ b/tests/test_tariff_percentile_359.py
@@ -191,3 +191,103 @@ class TestPercentileCaching:
         breaks2 = p._get_percentile_breaks()
         assert breaks2 is not None
         assert breaks2["p10"] != breaks1["p10"]
+
+
+class TestTimezoneSkew359Followup:
+    """#359 follow-up — RienduPre reported €0.30 still showing as ``normal``
+    after the percentile fix shipped in beta.3. Root cause was the date
+    filter doing ``p.timestamp.date()`` directly: providers like Nordpool
+    emit UTC timestamps, so on a non-UTC HA install the array filtered
+    by 'today' could come up empty or partial → percentiles return None →
+    silent fall-through to static thresholds → 0.30 = NORMAL.
+    """
+
+    def test_utc_timestamps_count_as_local_today(self):
+        """Provider emits UTC, HA tz = Europe/Amsterdam (+02:00). A
+        full 24h of prices tagged in UTC must still be recognised as
+        'today' once converted to local."""
+        from datetime import timezone
+        try:
+            import zoneinfo
+            ams = zoneinfo.ZoneInfo("Europe/Amsterdam")
+        except Exception:
+            pytest.skip("zoneinfo unavailable")
+
+        original_tz = dt_util.get_default_time_zone()
+        dt_util.set_default_time_zone(ams)
+        try:
+            # Local "today" — anchor at noon local so the day boundary
+            # isn't ambiguous regardless of when the test runs.
+            local_today_noon = dt_util.now().replace(
+                hour=12, minute=0, second=0, microsecond=0
+            )
+            # Build 24 hourly prices in UTC for the LOCAL today, spanning
+            # 00:00 → 23:00 local. The first and last entries land on
+            # different UTC dates, which is precisely the case the
+            # pre-fix code lost.
+            local_midnight = local_today_noon.replace(hour=0)
+            prices = []
+            for i in range(24):
+                local_dt = local_midnight + timedelta(hours=i)
+                # Convert to UTC — this is what Nordpool stores.
+                utc_dt = local_dt.astimezone(timezone.utc)
+                prices.append(PricePoint(
+                    timestamp=utc_dt,
+                    price=0.10 + i * 0.025,  # 0.10 → 0.685, full spread
+                    currency="EUR",
+                    level=PriceLevel.NORMAL,
+                ))
+
+            p = _make_provider("percentile")
+            p._prices_cache = prices
+
+            breaks = p._get_percentile_breaks()
+            assert breaks is not None, (
+                "TZ skew: UTC-tagged prices for today must be "
+                "recognised after as_local() conversion"
+            )
+            # With prices 0.10..0.685 step 0.025, p75 ≈ 0.525. Use a
+            # value that's clearly above p75 to confirm we're really
+            # using percentile (and not silently fell back to static
+            # where 0.55 would also be EXPENSIVE; the load-bearing
+            # assertion is `breaks is not None` above).
+            assert p._classify_price(0.60) is PriceLevel.EXPENSIVE
+        finally:
+            dt_util.set_default_time_zone(original_tz)
+
+    def test_utc_timestamps_pre_fix_would_have_emptied_today_array(self):
+        """Sanity test: without the as_local() fix, the old filter
+        ``p.timestamp.date() == today`` would lose every UTC point
+        whose UTC date differs from local. We can't easily run the
+        pre-fix code here, but we can prove that today's-local date
+        ≠ UTC date for some of the points and verify the FIXED filter
+        still picks them up."""
+        from datetime import timezone
+        try:
+            import zoneinfo
+            ams = zoneinfo.ZoneInfo("Europe/Amsterdam")
+        except Exception:
+            pytest.skip("zoneinfo unavailable")
+
+        original_tz = dt_util.get_default_time_zone()
+        dt_util.set_default_time_zone(ams)
+        try:
+            local_today_noon = dt_util.now().replace(
+                hour=12, minute=0, second=0, microsecond=0
+            )
+            local_today = local_today_noon.date()
+            # The early-morning local slot (01:00 local) is the previous
+            # UTC date in summer (DST +02:00) — i.e. 23:00 UTC the day before.
+            local_01 = local_today_noon.replace(hour=1)
+            utc_repr = local_01.astimezone(timezone.utc)
+            # The naive comparison would treat utc_repr.date() as
+            # yesterday — that's the bug we're guarding against.
+            naive_date = utc_repr.date()
+            fixed_date = dt_util.as_local(utc_repr).date()
+            assert fixed_date == local_today
+            # If this assertion fails the test environment isn't on +02:00,
+            # in which case the pitfall doesn't apply.
+            if naive_date != fixed_date:
+                assert naive_date < local_today  # would be lost pre-fix
+        finally:
+            dt_util.set_default_time_zone(original_tz)


### PR DESCRIPTION
## Summary

RienduPre reopened #359 — even after the percentile fix in v1.7.0-beta.3 (PR #373), his Dutch install was still labelling €0.30 as ``normal`` / ``cheap``.

## Root cause

\`_get_percentile_breaks\` and \`get_tariff_data\` filtered today's prices with a naked \`p.timestamp.date()\`. Providers vary on the tz they emit:

- Tibber → local
- **Nordpool → often UTC**

On a +02:00 install (Europe/Amsterdam, summer), a UTC-tagged price at 22:00–23:59 UTC = 00:00–01:59 next day local. The bare \`.date()\` returns the UTC date, which **silently mismatches the local \`today\`** — today's filtered array drops below the 4-point minimum, percentiles return None, and the classifier falls back to the static 0.15 / 0.35 cutoffs. €0.30 < 0.35 → NORMAL. Exactly the symptom.

## Fix

New helper \`_local_date(timestamp)\` converts via \`dt_util.as_local\` when the timestamp is tz-aware and passes naive datetimes through unchanged. The naive pass-through is important — existing tariff tests mock the whole \`dt_util\` module and build naive clocks; this keeps them green without needing changes.

Same helper used in:
- \`_get_percentile_breaks\` — the load-bearing call
- \`get_tariff_data\` — keeps today_min / today_max / today_avg consistent

## Diagnostics

Three new DEBUG log lines so future repro is easier:
- \"percentile fallback — today's price array has X/Y points\" (typical failure mode pre-fix)
- \"degenerate distribution — p90-p10=X\" (the M1 flat-day guard trips)
- \"percentile breaks for <date> — p10/p25/p75/p90\" (happy path — users can sanity-check)

## Tests

| Test | What it asserts |
|---|---|
| \`test_utc_timestamps_count_as_local_today\` | HA tz = Europe/Amsterdam, 24h of UTC prices straddling midnight local → breaks compute, >p75 value classifies EXPENSIVE |
| \`test_utc_timestamps_pre_fix_would_have_emptied_today_array\` | Proves the local-tz date vs naive-UTC date diverge for early-morning local slots, i.e. the pitfall is real |

**2927 / 2927 tests pass locally.**

## Release path

Lands on develop, will go out in the next beta tag.

Refs #359