### PR TITLE
fix(#392): heartbeat writes refresh KEBA failsafe watchdog

### DIFF
--- a/devices/base.py
+++ b/devices/base.py
@@ -11,11 +11,21 @@ Device Types:
 """
 import asyncio
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, Optional
+
+# #392: KEBA's failsafe watchdog (and similar device-side timers on other
+# chargers) requires periodic *writes* to refresh — reads alone don't
+# count. SEM's _set_current dedup used to suppress writes when the
+# commanded value hadn't changed, which silently starved the watchdog
+# during steady-state charging until the device dropped to fallback and
+# charging halted. Heartbeat at half KEBA's default 300 s timeout.
+# Confirmed by KEBA Energy Automation support in evcc-io/evcc#21093.
+WRITE_HEARTBEAT_INTERVAL_S = 60.0
 
 from homeassistant.core import HomeAssistant
 
@@ -520,6 +530,11 @@ class CurrentControlDevice(ControllableDevice):
         self._phase_switch_hysteresis_up: float = 500  # W above 3p threshold to switch up
         self._phase_switch_hysteresis_down: float = 200  # W below 3p threshold to switch down
         self._current_setpoint: float = 0.0
+        # #392: monotonic timestamp of the last successful write to the
+        # device's current-control surface. Used by _set_current to decide
+        # whether to skip a same-value write (recent) or force a heartbeat
+        # refresh (interval elapsed).
+        self._last_write_at: float = 0.0
         self._session_active: bool = False
         self._min_power_change_interval = min_power_change_interval
 
@@ -598,6 +613,7 @@ class CurrentControlDevice(ControllableDevice):
         self._status.current_consumption_w = 0.0
         self._status.allocated_power_w = 0.0
         self._current_setpoint = 0.0
+        self._last_write_at = 0.0  # #392: reset heartbeat tracker on full stop
 
     async def adjust_power(self, available_watts: float) -> float:
         if not self.is_active:
@@ -615,8 +631,20 @@ class CurrentControlDevice(ControllableDevice):
         """Set charging current via entity or service."""
         current = round(current, 0)
 
-        # Skip if no change
-        if abs(current - self._current_setpoint) < 1.0 and self.is_active:
+        # #392 heartbeat dedup: skip the write only when the value didn't
+        # change AND we've written recently. Without the time guard, a long
+        # steady-state period (always_max holding 16 A, solar plateau) would
+        # silently starve KEBA's failsafe watchdog → device drops to fallback
+        # current → SEM still thinks it commanded 16 A and never re-writes.
+        # Forcing a same-value re-write at WRITE_HEARTBEAT_INTERVAL_S keeps
+        # the device watchdog refreshed and re-converges state after any
+        # silent device-side reset (replug, KEBA reboot, failsafe trip).
+        now = time.monotonic()
+        if (
+            abs(current - self._current_setpoint) < 1.0
+            and self.is_active
+            and (now - self._last_write_at) < WRITE_HEARTBEAT_INTERVAL_S
+        ):
             return self._status.current_consumption_w
 
         try:
@@ -644,6 +672,7 @@ class CurrentControlDevice(ControllableDevice):
                 )
 
             self._current_setpoint = current
+            self._last_write_at = now  # #392: heartbeat tracker
             self._record_power_change()
             consumed = self.current_to_watts(current) if current >= self.min_current else 0.0
             self._status.current_consumption_w = consumed
@@ -812,6 +841,7 @@ class CurrentControlDevice(ControllableDevice):
             self._status.state = DeviceState.IDLE
             self._status.current_consumption_w = 0.0
             self._current_setpoint = 0.0
+            self._last_write_at = 0.0  # #392: reset heartbeat tracker on session stop
 
             if stop_method is None:
                 # No brand-specific stop fired — relying on _set_current(0) alone.

--- a/tests/test_392_keba_heartbeat.py
+++ b/tests/test_392_keba_heartbeat.py
@@ -1,0 +1,173 @@
+"""Heartbeat write to KEBA-style chargers (#392).
+
+KEBA's failsafe watchdog requires periodic *writes* — reads alone don't
+refresh it (confirmed by KEBA Energy Automation support in
+evcc-io/evcc#21093 comment 13094565). SEM's _set_current dedup used to
+suppress writes when the commanded value hadn't changed, which silently
+starved the watchdog during steady-state charging.
+
+These tests pin the heartbeat behaviour in ``devices/base.py``:
+- same-value re-requests within the heartbeat window are skipped
+- once the window elapses, a same-value re-request goes through
+- value changes always write regardless of timing
+- inactive device writes regardless of timing (the dedup only ever fires
+  while the device is active)
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.devices.base import (
+    CurrentControlDevice,
+    DeviceState,
+    WRITE_HEARTBEAT_INTERVAL_S,
+)
+
+
+@pytest.fixture
+def mock_hass():
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    hass.services.has_service = MagicMock(return_value=True)
+    return hass
+
+
+@pytest.fixture
+def device(mock_hass):
+    return CurrentControlDevice(
+        hass=mock_hass,
+        device_id="ev_charger",
+        name="EV Charger",
+        priority=5,
+        min_current=6.0,
+        max_current=32.0,
+        phases=3,
+        voltage=230.0,
+        current_entity_id=None,
+        charger_service="keba.set_current",
+        charger_service_entity_id=None,
+    )
+
+
+def _set_clock(monkeypatch, t: float) -> None:
+    """Pin time.monotonic so the heartbeat window is deterministic."""
+    monkeypatch.setattr(
+        "custom_components.solar_energy_management.devices.base.time.monotonic",
+        lambda: t,
+    )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_window_constant_is_sane():
+    """The interval must be safely below KEBA's default 300 s failsafe
+    timeout — half is the recommended margin per the evcc thread."""
+    assert 30.0 <= WRITE_HEARTBEAT_INTERVAL_S <= 150.0
+
+
+@pytest.mark.asyncio
+async def test_same_value_within_window_skips_write(device, monkeypatch):
+    """First write goes through; second same-value write within
+    WRITE_HEARTBEAT_INTERVAL_S is suppressed (pre-#392 behaviour, still
+    correct for rapid same-value calls)."""
+    _set_clock(monkeypatch, 0.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1
+    assert device.is_active
+
+    # Re-request the same value 30 s later — still inside the window.
+    _set_clock(monkeypatch, 30.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1, (
+        "second same-value write inside the heartbeat window must be skipped"
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_value_past_window_writes_heartbeat(device, monkeypatch):
+    """#392 fix: after WRITE_HEARTBEAT_INTERVAL_S a same-value re-request
+    is no longer suppressed — the heartbeat write goes out and refreshes
+    KEBA's failsafe watchdog."""
+    _set_clock(monkeypatch, 0.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1
+
+    # Jump past the heartbeat window.
+    _set_clock(monkeypatch, WRITE_HEARTBEAT_INTERVAL_S + 1.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 2, (
+        "#392: heartbeat must fire once the window elapses"
+    )
+
+
+@pytest.mark.asyncio
+async def test_repeated_heartbeats_at_window_boundaries(device, monkeypatch):
+    """A long steady-state session should produce one heartbeat per
+    window — not flood the integration, not starve it."""
+    _set_clock(monkeypatch, 0.0)
+    await device._set_current(16)  # 1st write
+    assert device.hass.services.async_call.call_count == 1
+
+    # Advance ~5 heartbeat windows. We expect 5 additional writes total.
+    for i in range(1, 6):
+        _set_clock(monkeypatch, i * (WRITE_HEARTBEAT_INTERVAL_S + 1.0))
+        await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 6, (
+        "#392: one heartbeat write per elapsed window — no flood, no skip"
+    )
+
+
+@pytest.mark.asyncio
+async def test_value_change_writes_regardless_of_window(device, monkeypatch):
+    """Value changes are not heartbeat-gated — they always go through."""
+    _set_clock(monkeypatch, 0.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1
+
+    # Within the window, ask for a different value.
+    _set_clock(monkeypatch, 5.0)
+    await device._set_current(20)
+    assert device.hass.services.async_call.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_inactive_device_writes_regardless_of_window(device, monkeypatch):
+    """When the device is IDLE the dedup short-circuit never triggers —
+    activation writes always go through. Guards against a stale
+    _last_write_at preventing a fresh session start."""
+    _set_clock(monkeypatch, 0.0)
+    # Fake a stale write 1 s ago without setting is_active.
+    device._current_setpoint = 16.0
+    device._last_write_at = 0.0
+    device._status.state = DeviceState.IDLE
+
+    # Within the heartbeat window, asking for the same current must still
+    # write because is_active=False.
+    _set_clock(monkeypatch, 5.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_stale_setpoint_resyncs_after_window(device, monkeypatch):
+    """Companion bug to the heartbeat: if KEBA silently dropped to
+    fallback (failsafe trip, replug fallback) while SEM still thinks it
+    commanded 16 A, the pre-#392 dedup left the system stuck. After the
+    fix, the same-value write within one window forces a re-sync."""
+    _set_clock(monkeypatch, 0.0)
+    await device._set_current(16)
+    assert device.hass.services.async_call.call_count == 1
+
+    # KEBA silently dropped to 6 A (failsafe trip). SEM doesn't know.
+    # Time passes past the heartbeat window.
+    _set_clock(monkeypatch, WRITE_HEARTBEAT_INTERVAL_S + 1.0)
+    await device._set_current(16)
+    # The heartbeat write goes through with value 16 — KEBA accepts it
+    # and the device-side state re-converges. Without #392 this would
+    # have stayed skipped indefinitely.
+    assert device.hass.services.async_call.call_count == 2
+    last_call = device.hass.services.async_call.call_args_list[-1]
+    assert last_call.args[0] == "keba"
+    assert last_call.args[1] == "set_current"
+    assert last_call.args[2]["current"] == 16


### PR DESCRIPTION
Closes #392.

## TL;DR

KEBA's failsafe watchdog wants periodic *writes*; SEM was doing same-value reads-only during steady-state, watchdog timed out, max_current dropped, charging halted, no recovery. Add a 60 s heartbeat write past the existing dedup. Generalised to all current-controlled chargers — KEBA is the documented case but the pattern is universal.

## Root cause

`devices/base.py:_set_current` skipped when `|new − last| < 1 A` AND `is_active`, with no time component. Long steady-state periods (always_max @ 16 A, solar plateau) → zero packets to KEBA → 300 s failsafe timer expires → `max_current` → fallback → charging stops → SEM still thinks it commanded 16 A and the same dedup keeps blocking the re-converge write.

Confirmed by KEBA Energy Automation support in evcc-io/evcc#21093 comment 13094565:

> Simply reading the values is not sufficient in this case. You should [...] regularly renew its current specification, or confirm the 'enabled' status, or renew its failsafe settings.

evcc shipped the same shape in #21228 / #21849.

## Fix

- New `WRITE_HEARTBEAT_INTERVAL_S = 60.0` module-level constant.
- `_last_write_at: float` tracker per device.
- Dedup in `_set_current` now skips only when value unchanged AND last write was within the heartbeat window.
- Reset the tracker on `deactivate()` and `stop_session()` so a fresh session always opens with a write.

Side benefit — state divergence: after a silent device-side reset (replug fallback, failsafe trip, brief KEBA reboot), the same-value heartbeat write now re-converges device and SEM state within one window. No more "SEM thinks 16, KEBA at 6, stuck forever" mode.

## Tests

| Test | What it pins |
|---|---|
| `test_heartbeat_window_constant_is_sane` | 30–150 s — safely below KEBA's default 300 s timeout |
| `test_same_value_within_window_skips_write` | Pre-existing dedup behaviour preserved for rapid same-value calls |
| `test_same_value_past_window_writes_heartbeat` | The fix — write goes out once window elapses |
| `test_repeated_heartbeats_at_window_boundaries` | One heartbeat per window over a 5-window session — no flood, no skip |
| `test_value_change_writes_regardless_of_window` | Value changes are never heartbeat-gated |
| `test_inactive_device_writes_regardless_of_window` | Stale tracker can't block a fresh session start |
| `test_stale_setpoint_resyncs_after_window` | Companion bug closed — device-side silent reset re-converges in one window |

**2934 / 2934 tests pass locally.**

## Release path

Lands on develop, ships in **v1.7.0-beta.14** — the first release in the new music-assistant-style release-notes format.