### PR TITLE
chore: review infrastructure — CodeRabbit + pre-commit + first 5 ADRs

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,65 @@
+language: "en"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: false
+  review_status: true
+  collapse_walkthrough: true
+  auto_review:
+    enabled: true
+    drafts: false
+    base_branches:
+      - "develop"
+      - "main"
+  path_filters:
+    - "!dashboard/card/dist/sem-cards.js"
+    - "!dashboard/card/sem-localize.js"
+    - "!translations/*.json"
+    - "!**/__pycache__/**"
+    - "!**/*.snap"
+  path_instructions:
+    - path: "coordinator/ev_control.py"
+      instructions: |
+        FLEET-READ pattern: any read of power.ev_power inside the per-charger
+        loop body MUST be annotated with a `# FLEET-READ: <reason>` comment.
+        Prefer `self._this_charger_power(ev, power)` for the current charger's
+        draw. The AST lint at tests/test_ev_control_fleet_reads.py enforces
+        this and fails CI without the annotation. Flag any unannotated
+        access. See docs/MULTI_CHARGER.md for context.
+    - path: "coordinator/sensor_reader.py"
+      instructions: |
+        Sign-convention boundary: SEM convention is grid_power negative=import,
+        battery_power negative=discharge. ANY negation of a raw sensor read
+        belongs here, never downstream. If a per-platform autodetect needs
+        a flip, it goes in `_read_from_energy_dashboard`. Commit 00e449c
+        burned us when negation moved out of this file — flag any negation
+        added elsewhere.
+    - path: "coordinator/coordinator.py"
+      instructions: |
+        home_consumption_power is `max(0, solar + grid_import + batt_discharge
+        − ev − grid_export − batt_charge)`. The clamp is intentional — never
+        return `unknown` here, even on degenerate inputs. Fix upstream sign
+        bugs instead.
+    - path: "coordinator/types.py"
+      instructions: |
+        PerChargerContext owns the per-charger swap surface (#284-#291).
+        New per-charger fields belong on it, not as parallel `saved = {...}`
+        dicts. Flag any new shadow dicts that look like the old pattern.
+    - path: "devices/base.py"
+      instructions: |
+        WRITE_HEARTBEAT_INTERVAL_S (#392): the dedup in _set_current skips
+        writes only inside the heartbeat window. Don't reintroduce a naked
+        `if abs(current - setpoint) < 1.0` skip — that's the bug the
+        evcc community + KEBA support documented in evcc#21093.
+    - path: "tests/test_split_grid_integration.py"
+      instructions: |
+        Mandatory pipeline test per supported brand. Adding a new inverter
+        or charger to the README supported list requires a corresponding
+        scenario in this file. Flag PRs that add new brand defaults or
+        autodetect entries without a pipeline test.
+  tools:
+    ruff:
+      enabled: true
+chat:
+  auto_reply: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,46 @@
+# Pre-commit hooks for SEM.
+#
+# Install once:
+#     pip install pre-commit
+#     pre-commit install --hook-type pre-commit --hook-type pre-push
+#
+# Run all hooks against the whole tree:
+#     pre-commit run --all-files
+#
+# These hooks catch ~80% of what CI catches, in <5 s, before the 15-min
+# CI cycle starts. See CONTRIBUTING.md.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: '\.(svg|md)$'
+      - id: end-of-file-fixer
+        exclude: '\.(svg|json)$'
+      - id: check-yaml
+      - id: check-toml
+      - id: check-json
+        # The bundled card output is one giant line — don't reformat it.
+        exclude: '^dashboard/card/dist/'
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: ['--maxkb=512']
+        exclude: '^dashboard/card/dist/'
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format
+
+  # Local hooks — repo-specific gates.
+  - repo: local
+    hooks:
+      - id: hassfest-lite
+        name: hassfest manifest sanity (lite)
+        entry: python3 scripts/hassfest_lite.py
+        language: system
+        files: ^manifest\.json$
+        pass_filenames: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -116,6 +116,31 @@ A scenario YAML has a `config:` block (which becomes `coordinator.config`), an `
 - `develop` — integration branch, CI must pass
 - `feature/*` — work in progress, PR to develop when ready
 
+## Review Flow
+
+Lightweight by design — single maintainer, fast beta cadence.
+
+| Trigger | What runs | Cost |
+|---|---|---|
+| Every commit | Pre-commit hooks (Ruff format + lint, YAML/JSON/TOML check, `hassfest-lite`) | seconds, local |
+| Every PR | CI gates (Hassfest, HACS validation, pytest 3.12/3.13, card-test) + CodeRabbit AI review per [`.coderabbit.yaml`](.coderabbit.yaml) | ~15 min, no human time |
+| Optional second opinion on non-trivial PRs | `/codex review` for an independent AI take — useful when author = reviewer | ~2 min |
+| Crossing a complexity threshold (new device class, sign-convention change, new fitness function) | Write a 1-page [ADR](docs/adr/README.md) | 15–30 min, one-time |
+| Before each release | Soak on HA-TEST + `~/bin/validate-sem.sh` | already in the deploy script |
+
+### Setup pre-commit (one-time)
+
+```bash
+pip install pre-commit
+pre-commit install --hook-type pre-commit --hook-type pre-push
+```
+
+Now every `git commit` runs Ruff + sanity checks locally before CI burns 15 min. Skip with `--no-verify` only if you really mean it.
+
+### Architecture Decision Records
+
+When a decision is worth keeping (new device class, invariant change, refactor that reshapes a subsystem), add a one-pager to [`docs/adr/`](docs/adr/README.md) using the Nygard format. Bugfixes and routine feature work do NOT need an ADR.
+
 ## Questions?
 
 Open a [discussion](https://github.com/traktore-org/sem-community/discussions) or ask in the [HA Community thread](https://community.home-assistant.io/t/solar-energy-management-sem-smart-solar-ev-battery-orchestration/1003701).

--- a/docs/adr/0001-per-charger-context.md
+++ b/docs/adr/0001-per-charger-context.md
@@ -1,0 +1,45 @@
+# ADR 0001 — PerChargerContext owns the per-charger swap surface
+
+**Status:** Accepted (v1.6.7) · ratifies `coordinator/per_charger_context.py`
+
+## Context
+
+Between v1.6.0 and v1.6.6 SEM shipped four hotfixes for the same bug
+class: per-charger code paths reading the fleet-summed `power.ev_power`
+instead of the current charger's draw. Issues `#284`, `#285`, `#287`,
+`#291` were each one instance of the same shape — a parallel `saved =
+{...}` dict capturing per-charger state, missing one or two fields each
+time, and a `power.ev_power` read that should have been per-charger.
+
+The class of bug was structural — not a single missed call site, but a
+recurring pattern that the existing abstraction failed to prevent.
+
+## Decision
+
+**`PerChargerContext` is the single owner of the per-charger swap
+surface.**
+
+- All per-charger state that's swapped in/out across the loop body
+  lives on `PerChargerContext`, not in parallel dicts.
+- `self._this_charger_power(ev, power)` is the only sanctioned way to
+  read this charger's draw inside the per-charger loop body. The
+  result is cached as `this_power_w` at method top.
+- `# FLEET-READ: <reason>` is the opt-out annotation. The AST lint at
+  `tests/test_ev_control_fleet_reads.py` fails CI on any unannotated
+  `power.ev_power` read in `coordinator/ev_control.py`.
+
+## Consequences
+
+**Good.** The class is closed structurally rather than reactively.
+New per-charger fields go on `PerChargerContext`; reviewers don't have
+to remember to update parallel dicts. The AST lint is a permanent
+fitness function — adding a new fleet read without justifying it costs
+zero ongoing attention; the test catches it.
+
+**Open.** `effective_state` and `this_power_w` are still local
+variables / parallel dicts rather than fields on `PerChargerContext`.
+The lint is a stopgap; a `FleetEvPower` newtype would be structurally
+stronger but bigger refactor. Tracked for v1.7+.
+
+See [`docs/MULTI_CHARGER.md`](../MULTI_CHARGER.md) for the operational
+playbook.

--- a/docs/adr/0002-ev-budget-unified.md
+++ b/docs/adr/0002-ev-budget-unified.md
@@ -1,0 +1,49 @@
+# ADR 0002 — EVBudget is the single source of truth across publish, state machine, actuator, and multi-charger distribution
+
+**Status:** Accepted (v1.6.0)
+
+## Context
+
+Pre-v1.6, EV budgeting was computed independently in three places:
+
+1. The publish path that exposed `sensor.sem_ev_budget`
+2. The state machine that decided which mode to be in
+3. The actuator that translated mode → amps for the charger
+
+Plus a fourth, layered on top in multi-charger configs: a distribution
+step that split the global budget across chargers by priority. Each
+path had its own slightly different rounding, clamping, and minimum-
+amps handling. When the four diverged — as they always did — the
+sensor on the dashboard didn't match what the actuator commanded, the
+state machine flipped between modes the user didn't trigger, and
+multi-charger installs got unpredictable splits.
+
+## Decision
+
+**Canonical `EVBudget` dataclass is the single source of truth across
+all four paths.**
+
+Defined in `coordinator/ev_budget.py`. Computed once per coordinator
+cycle, consumed by:
+
+- the publish path (sensor reports exactly what's in the dataclass)
+- the state machine (modes branch off `EVBudget.intent`, not their own
+  recompute)
+- the actuator (amps come from `EVBudget.amps`, no second rounding)
+- the multi-charger distributor (operates on the same `EVBudget`,
+  produces per-charger `EVBudget` slices that follow the same shape)
+
+## Consequences
+
+**Good.** The dashboard's `sensor.sem_ev_budget` is by construction
+what the actuator will command. Mode transitions are deterministic
+from the dataclass. Multi-charger splits compose cleanly because the
+per-charger budget is the same type as the global one.
+
+**Open.** Phase D.2 cleanup (legacy `_calculate_ev_budget` method
+removal, demotion-guard removal) deferred to v1.7.0 after sustained
+soak — completed in v1.6.2 (PR #282). The unification phases
+A + B + B.5 + C + D.1 shipped in v1.6.0.
+
+See `coordinator/ev_budget.py` for the dataclass shape and helper
+predicates.

--- a/docs/adr/0003-sign-convention-boundary.md
+++ b/docs/adr/0003-sign-convention-boundary.md
@@ -1,0 +1,56 @@
+# ADR 0003 — Sign convention boundary lives at `sensor_reader`
+
+**Status:** Accepted (v1.4.0 onward — ratified after commit 00e449c rollback)
+
+## Context
+
+Different inverter brands emit sensor data with different sign
+conventions:
+
+| Quantity | Some brands | Others |
+|---|---|---|
+| Grid power | + = export, − = import | + = import, − = export |
+| Battery power | + = charge, − = discharge | + = discharge, − = charge |
+| Solar power | + only | + only |
+| EV power | + only | + only |
+
+SEM's internal convention is:
+
+| Quantity | SEM convention |
+|---|---|
+| `grid_power` | − = import, + = export |
+| `battery_power` | − = discharge, + = charge |
+
+Commit `00e449c` tried to normalise downstream by unconditionally
+negating, which broke Huawei (which already matched SEM's convention)
+and silently produced wrong-sign Sankey diagrams + wrong-sign battery
+SOC decisions.
+
+## Decision
+
+**All sign translation happens in `coordinator/sensor_reader.py`,
+specifically in `_read_from_energy_dashboard`. No other module
+negates raw sensor reads.**
+
+- Per-platform autodetect (Huawei / SMA / Fronius / etc.) belongs in
+  `sensor_reader`.
+- Downstream code (`PowerReadings.calculate_derived`, `FlowCalculator`,
+  the SOC-zone strategy, etc.) consumes the canonical SEM convention
+  and never re-checks signs.
+- If a future user reports the opposite sign on their inverter, the
+  fix is a per-platform autodetect entry in `sensor_reader`, never a
+  downstream negation.
+
+## Consequences
+
+**Good.** Sign bugs become structurally local — the only place a
+flip can happen is the one file that's responsible for it. Downstream
+code is simpler because there's nothing sign-dependent in it.
+
+**Risk.** The autodetect logic in `sensor_reader` is now load-bearing
+and needs to handle every supported brand's quirk. Mitigation:
+pipeline tests (ADR 0005) cover every supported brand's full chain,
+so any regression surfaces deterministically in CI.
+
+See [`CLAUDE.md`](../../CLAUDE.md#sign-convention-summary) for the
+operator-level summary and the commit `00e449c` postmortem.

--- a/docs/adr/0004-home-consumption-clamp.md
+++ b/docs/adr/0004-home-consumption-clamp.md
@@ -1,0 +1,52 @@
+# ADR 0004 — `home_consumption_power` is clamped to zero, never `unknown`
+
+**Status:** Accepted (v1.3.x onward, reaffirmed on every audit)
+
+## Context
+
+`home_consumption_power` is a derived sensor computed from the energy
+balance:
+
+```
+home = max(0, solar + grid_import + batt_discharge − ev − grid_export − batt_charge)
+```
+
+On a perfectly-calibrated install with synchronised sensor reads, the
+inner expression is `≥ 0` and the clamp is a no-op. In reality, sensor
+reads land a fraction of a second apart, integration polling lags, and
+the result drifts slightly negative for a single cycle here and there.
+
+Three options were on the table:
+
+1. Report `unknown` when the inner expression is negative
+2. Report the raw negative value
+3. Clamp to `0` and accept the brief under-report
+
+## Decision
+
+**Option 3: clamp to zero.**
+
+The user explicitly does not want `home_consumption_power` flipping to
+`unknown` mid-day. Their Energy Dashboard derivative falls off a cliff
+when an upstream sensor goes unknown — the integration is technically
+"correct" but the user's day looks broken.
+
+Negative home consumption is physically impossible (the home is a
+load, not a source), so the clamp is also the correct answer in the
+limit.
+
+## Consequences
+
+**Good.** The sensor never goes unknown. Energy Dashboard charts stay
+continuous. The user's mental model (home is always drawing) matches
+what they see.
+
+**Risk.** If the inner expression goes _persistently_ negative, the
+clamp masks a real sign bug elsewhere. Mitigation: SEM logs the inner
+value at DEBUG when it goes negative, and the sign-convention
+boundary (ADR 0003) keeps the class small enough that audits catch
+real bugs upstream.
+
+Code path: `coordinator/sensor_reader.py:_compute_home_consumption`.
+Do **not** add a `if balance < 0: return None` branch — that
+explicitly inverts this decision.

--- a/docs/adr/0005-pipeline-test-per-brand.md
+++ b/docs/adr/0005-pipeline-test-per-brand.md
@@ -1,0 +1,59 @@
+# ADR 0005 — Pipeline test per supported brand is mandatory
+
+**Status:** Accepted (v1.4.0 onward, after issue #129 postmortem)
+
+## Context
+
+Issue `#129` shipped a regression that all the unit tests passed:
+individual sign-convention helpers, individual sensor parsers, and
+individual flow calculators all returned the correct value when tested
+in isolation. But the full pipeline — Energy Dashboard config →
+`SensorReader` → `PowerReadings` → derived flows → final sensors — had
+a subtle composition bug that none of the unit tests touched.
+
+Unit tests pass; production breaks. Classic.
+
+## Decision
+
+**Every inverter or charger brand listed in `README.md`'s supported
+list MUST have a corresponding pipeline scenario in
+`tests/test_split_grid_integration.py`.**
+
+A pipeline test exercises the _complete_ chain end-to-end for that
+brand's specific sensor shape (combined grid vs split L1/L2/L3,
+positive-import vs positive-export, battery sign, etc.). It feeds in
+realistic Energy Dashboard config and asserts the final flow sensors
+are correct.
+
+Adding a new brand to the supported list without adding a pipeline
+test is a review-blocker — flagged by CodeRabbit per
+`.coderabbit.yaml`'s path instructions and caught at review time.
+
+## Consequences
+
+**Good.** The class of bug from #129 is closed structurally — any new
+brand contributes a deterministic CI scenario that future refactors
+must keep green.
+
+**Cost.** ~30 min per new brand to write the scenario. Acceptable
+overhead for a new platform that's going to live in the codebase
+forever.
+
+Reference inverter patterns (grid sign × battery sign):
+
+- Pattern A: grid += export, battery += charge (Huawei, SMA, Victron, Sungrow)
+- Pattern B: grid += import, battery += discharge (Fronius, Enphase, Powerwall, Kostal, SolarEdge)
+- Pattern C: grid += export, battery += discharge (GoodWe, Sonnen)
+- Pattern D: grid += import, battery += charge (SolaX)
+- Pattern E: split grid, no combined sensor (Growatt)
+- Pattern F: solar-only, no grid sensor
+
+Reference charger patterns (control method):
+
+- Service-based: KEBA (`keba.set_current`), Easee, Zaptec
+- Number entity: Wallbox, go-eCharger, ChargePoint, Heidelberg, OpenWB, OCPP, Ohme, Peblar, V2C, Blue Current, OpenEVSE, Alfen
+- Power unit: W vs kW auto-conversion
+
+See `tests/test_split_grid_integration.py` for the existing scenarios
+and [`CLAUDE.md`](../../CLAUDE.md#mandatory-pipeline-tests-for-every-supported-device)
+for the operator-level summary.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,29 @@
+# Architecture Decision Records
+
+ADRs document _why_ SEM is built the way it is — for decisions that aren't
+obvious from reading the code, and that we'd lose if context goes cold.
+
+We use the [lightweight Nygard format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+**Context → Decision → Status → Consequences**, one page max.
+
+## When to write an ADR
+
+Write one when crossing a real complexity threshold:
+
+- A new device class or platform pattern
+- A new sign-convention or data-flow invariant
+- A protocol / API surface change with backward-compat implications
+- A new architectural fitness function (AST lint, import-linter rule)
+- A significant refactor that reshapes a subsystem
+
+**Don't** write one for routine bugfixes, dependency bumps, or feature
+work that fits the existing patterns. ADRs are for _decisions_, not
+_changes_.
+
+## Index
+
+- [0001 — PerChargerContext per-charger swap surface](0001-per-charger-context.md)
+- [0002 — EVBudget unified across publish path, state machine, actuator](0002-ev-budget-unified.md)
+- [0003 — Sign convention boundary at sensor_reader](0003-sign-convention-boundary.md)
+- [0004 — home_consumption_power is clamped to zero](0004-home-consumption-clamp.md)
+- [0005 — Pipeline test per supported brand is mandatory](0005-pipeline-test-per-brand.md)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,3 +3,39 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 # Prevent pytest from collecting __init__.py in repo root
 collect_ignore = ["__init__.py", "setup.py"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+exclude = [
+  "dashboard/card/dist",
+  "dashboard/card/node_modules",
+  ".gstack",
+]
+
+[tool.ruff.lint]
+# Curated set — enough to catch real bugs, not enough to drown the
+# diff in style noise. Expand once the baseline is clean.
+select = [
+  "E",    # pycodestyle errors
+  "F",    # pyflakes (undefined names, unused imports)
+  "W",    # pycodestyle warnings
+  "I",    # isort
+  "UP",   # pyupgrade — use modern syntax
+  "B",    # flake8-bugbear — likely-bug patterns
+  "SIM",  # flake8-simplify
+  "RUF",  # ruff-native rules
+]
+ignore = [
+  "E501",   # line-too-long — let formatter handle it
+  "B008",   # function call in arg defaults — HA selectors do this all over
+  "SIM108", # ternary suggestion — often less readable for HA code
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Tests can use star-imports and assert without restriction
+"tests/**/*.py" = ["F401", "F403", "F405", "B011"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/scripts/hassfest_lite.py
+++ b/scripts/hassfest_lite.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+"""Sanity-check that ``manifest.json`` has the bare minimum HA expects.
+
+Runs as a pre-commit hook before the 15-minute CI Hassfest job. Catches
+the one-character mistakes that would otherwise burn a CI cycle.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+REQUIRED_KEYS = ("domain", "version", "name", "documentation", "issue_tracker")
+
+
+def main() -> int:
+    manifest_path = Path(__file__).resolve().parent.parent / "manifest.json"
+    try:
+        with manifest_path.open() as fh:
+            manifest = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"hassfest-lite: cannot read {manifest_path}: {exc}", file=sys.stderr)
+        return 1
+
+    missing = [k for k in REQUIRED_KEYS if k not in manifest]
+    if missing:
+        print(
+            f"hassfest-lite: manifest.json missing required keys: {missing}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"hassfest-lite OK: {manifest['domain']} {manifest['version']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Implements the must-haves from the review-process research: solo-maintainer, fast beta cadence, AI as the always-on second reviewer, ADRs only for decisions worth keeping. Net effect: every future PR gets a free second-opinion review, every commit catches style locally in <5 s, and architecture rationale lives in version-controlled markdown instead of gitignored CLAUDE.md.

## What's in this PR

### \`.coderabbit.yaml\` — always-on AI reviewer
Comments on every PR against \`develop\` / \`main\`. Project-specific instructions for the rules that matter:

- FLEET-READ pattern in \`coordinator/ev_control.py\` (mirrors the AST lint at \`tests/test_ev_control_fleet_reads.py\`)
- Sign-convention boundary at \`coordinator/sensor_reader.py\` (the commit-00e449c hazard)
- \`home_consumption_power\` clamp invariant
- \`PerChargerContext\` as the single per-charger swap surface
- \`WRITE_HEARTBEAT_INTERVAL_S\` in \`devices/base.py\` (#392)
- Mandatory pipeline-test-per-brand

Excludes the bundled card JS, generated \`sem-localize.js\`, and the 15 translation files from review noise.

### \`.pre-commit-config.yaml\` + \`pyproject.toml\` ruff config
Local hooks that catch ~80% of what CI would catch, in <5 s, before the 15-min CI cycle starts. Ruff in curated mode (E/F/W/I/UP/B/SIM/RUF) — real-bug rules without style noise. Tests exempt from \`F401/F403/F405/B011\`. Plus YAML/JSON/TOML checks, trailing-whitespace, end-of-file-fixer, large-file guard, and a local \`hassfest-lite\` that validates \`manifest.json\` has the bare minimum keys.

**Baseline policy**: pre-commit only checks files staged for a commit, not the whole tree. Existing files keep their style; touched files get cleaned up incrementally. Avoids one massive Ruff-noise commit that would obscure real changes.

Install:
\`\`\`
pip install pre-commit
pre-commit install --hook-type pre-commit --hook-type pre-push
\`\`\`

### \`docs/adr/\` — first 5 ADRs (lightweight Nygard format)

| # | Title | What it ratifies |
|---|---|---|
| 0001 | PerChargerContext owns the per-charger swap surface | v1.6.7 multi-charger refactor + the AST-lint fitness function |
| 0002 | EVBudget is the single source of truth | v1.6.0 unification across publish, state machine, actuator, distributor |
| 0003 | Sign convention boundary lives at sensor_reader | Postmortem of commit 00e449c |
| 0004 | home_consumption_power is clamped to zero, never \`unknown\` | Explicit user-facing decision preserved |
| 0005 | Pipeline test per supported brand is mandatory | Postmortem of #129 unit-tests-pass-but-pipeline-breaks |

\`docs/adr/README.md\` explains when to write one (decisions, not changes).

### \`CONTRIBUTING.md\` — Review Flow section
Trigger → tool → cost table. Setup steps for pre-commit. ADR policy.

### \`scripts/hassfest_lite.py\`
Tiny pre-commit hook that catches manifest.json mistakes before the 20-second Hassfest job. Extracted from \`.pre-commit-config.yaml\` to keep the YAML clean.

## Net effect

| Before | After |
|---|---|
| Author = reviewer on every PR | CodeRabbit comments automatically; \`/codex review\` available for an independent second opinion on non-trivial PRs |
| ~15-min CI round-trip to catch style errors | Pre-commit catches style locally in <5 s |
| Architecture rationale gitignored in CLAUDE.md | Decisions worth keeping live in \`docs/adr/\`, searchable + version-controlled |
| No fitness functions beyond FLEET-READ | Same — adding more is the next layer of work, tracked separately |

## What this PR does NOT do (intentionally)

- **No bulk Ruff reformat** of the existing 30k LoC. \`pre-commit run --all-files\` would auto-fix ~1208 files; instead the policy is "clean as you go" on touched files only. Avoids a noisy commit that would obscure real diffs and create merge conflicts with the open PRs.
- **No CodeRabbit GitHub App installed yet** — needs your manual click. The config is here; the app install is at https://github.com/apps/coderabbitai
- **No new fitness functions yet** (sign-convention AST lint, home_consumption_power invariant) — that's a follow-up PR once this lands.

## Tests

2934 / 2934 pass. No code-path changes — purely config + docs.

## Release path

Lands on \`develop\`. No version bump needed (chore, not a release). Will be present in the next beta (\`v1.7.0-beta.15+\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development tooling and linting configurations.
  * Added pre-commit hooks for code quality checks.
  * Configured code review automation settings.

* **Documentation**
  * Enhanced contributing guidelines with review flow and setup instructions.
  * Added architecture decision records documenting key design decisions and system constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->