### PR TITLE
docs(adr): fix code-link drift in 0002+0004, add ADRs 0006-0008

### DIFF
--- a/docs/adr/0002-ev-budget-unified.md
+++ b/docs/adr/0002-ev-budget-unified.md
@@ -23,7 +23,7 @@ multi-charger installs got unpredictable splits.
 **Canonical `EVBudget` dataclass is the single source of truth across
 all four paths.**
 
-Defined in `coordinator/ev_budget.py`. Computed once per coordinator
+Defined in `coordinator/flow_calculator.py` (line 95). Computed once per coordinator
 cycle, consumed by:
 
 - the publish path (sensor reports exactly what's in the dataclass)
@@ -45,5 +45,10 @@ removal, demotion-guard removal) deferred to v1.7.0 after sustained
 soak — completed in v1.6.2 (PR #282). The unification phases
 A + B + B.5 + C + D.1 shipped in v1.6.0.
 
-See `coordinator/ev_budget.py` for the dataclass shape and helper
+See `coordinator/flow_calculator.py` for the dataclass shape and helper
 predicates.
+
+**Open (TODO):** Consider splitting this ADR into (a) a unification ADR
+covering the single-source-of-truth decision and (b) a per-charger-
+distribution ADR covering the multi-charger split shape — under
+consideration, not yet authorised.

--- a/docs/adr/0004-home-consumption-clamp.md
+++ b/docs/adr/0004-home-consumption-clamp.md
@@ -47,6 +47,6 @@ value at DEBUG when it goes negative, and the sign-convention
 boundary (ADR 0003) keeps the class small enough that audits catch
 real bugs upstream.
 
-Code path: `coordinator/sensor_reader.py:_compute_home_consumption`.
+Code path: `coordinator/types.py:PowerReadings.calculate_derived` (line 206).
 Do **not** add a `if balance < 0: return None` branch — that
 explicitly inverts this decision.

--- a/docs/adr/0006-fleet-cycle-state.md
+++ b/docs/adr/0006-fleet-cycle-state.md
@@ -1,0 +1,51 @@
+# ADR 0006 — FleetCycleState is the single source of truth for fleet-level coordinator inputs
+
+**Status:** Accepted (v1.7.0-beta.7) · ratifies `coordinator/charger_types.py:FleetCycleState`
+
+## Context
+
+Post-v1.6.7 the per-charger swap surface was closed by `PerChargerContext` (ADR
+0001). A symmetric plumbing problem remained on the fleet side: call sites for
+`build_charger_view` each passed fleet-level inputs as direct kwargs — `tariff_level`,
+`forecast_remaining_kwh`, night-plan signals, and similar. There was no structural
+guarantee that every call site passed the same fleet inputs, so a caller could
+silently omit a kwarg that a later `decide()` relied on. Issue `#358` surfaced the
+resulting asymmetry: some chargers in a multi-charger cycle saw a tariff level;
+others saw `None` from a call site that predated the tariff feature.
+
+## Decision
+
+**Fleet-level cycle inputs are collected once per cycle into a `FleetCycleState`
+object and passed as a single positional argument to every `build_charger_view`
+call.**
+
+- `FleetCycleState` is a frozen dataclass — immutable for the cycle's lifetime.
+- Both the primary view (constructed inside `coordinator._build_charging_context`)
+  and the multi-charger loop's per-charger views derive from the SAME
+  `FleetCycleState` object.
+- Per-charger overrides (`target_kwh`, `deadline_amps`, `tariff_wait`,
+  `solar_committed_w`) stay as direct kwargs — they legitimately differ across
+  chargers within the same cycle and are not fleet state.
+- When a new fleet input is needed, it lands as a field on `FleetCycleState`.
+- The AST lint at `tests/test_fleet_state_completeness.py` fails CI if any
+  `build_charger_view` call site bypasses `FleetCycleState` and passes a
+  fleet-level field as a direct kwarg. This is the fleet-side mirror of the
+  `FLEET-READ` annotation lint from ADR 0001.
+
+Shipped in v1.7.0-beta.7 (commit `44d28a8`).
+
+## Consequences
+
+**Good.** The plumbing-asymmetry class is closed structurally: every charger in
+the cycle is guaranteed to receive identical fleet state. Adding a new fleet
+input requires one field on `FleetCycleState`; the AST lint enforces it
+everywhere without manual audit. The per-charger and fleet sides of the loop now
+have symmetric structural guards (ADR 0001 for per-charger, this ADR for fleet).
+
+**Open.** The test at `tests/test_fleet_state_completeness.py` identifies
+forbidden kwargs by a static allowlist; if a kwarg is misclassified as
+per-charger when it should be fleet state, the lint won't catch it. Review the
+allowlist when adding a new kwarg to `build_charger_view`.
+
+See `coordinator/charger_types.py:FleetCycleState` (line 541) and
+`coordinator/_build_fleet_cycle_state` for construction.

--- a/docs/adr/0007-real-hass-test-framework.md
+++ b/docs/adr/0007-real-hass-test-framework.md
@@ -1,0 +1,55 @@
+# ADR 0007 — Real-hass test framework adoption and test-layer choice rule
+
+**Status:** Accepted (v1.7.0-beta.10) · ratifies `tests/requirements_test.txt` pin
+
+## Context
+
+SEM's test suite started as pure unit tests (mock `HomeAssistant` objects via
+`MagicMock`). By v1.6 a scenario harness (`tests/scenarios/*.yaml` + `scenario_harness.py`)
+was added to replay real coordinator traces in CI. Both layers proved insufficient
+for a third class of bug: lifecycle interactions with the actual HA process —
+entry setup/unload ordering, `hass.data` slot lifecycle, frontend resource
+registration races, and coordinator teardown. These bugs were only visible by
+running real HA startup, not by mocking it.
+
+`pytest-homeassistant-custom-component` provides a real `HomeAssistant` instance
+in-process via the `hass` fixture. Phase 1 of the adoption shipped in commit
+`8e34727` (smoke tests + framework wiring). Phase 2 shipped with
+v1.7.0-beta.10 (commit `91b0663`): unload/reload cycle tests,
+config-entry lifecycle tests, and frontend cache-bust regression guards — all
+using the real `hass` fixture against real HA internals.
+
+## Decision
+
+**`pytest-homeassistant-custom-component==0.13.205` (pinned in
+`tests/requirements_test.txt`) is first-class in SEM's test suite.**
+
+Pick the test layer that matches the bug class you are guarding:
+
+| Bug class | Layer |
+|---|---|
+| Pure arithmetic / data-structure logic | Unit test (mock `hass`) |
+| Coordinator decision vs enforcement drift across a timeline | Scenario harness (`tests/scenarios/`) |
+| HA lifecycle — setup, unload, reload, `hass.data`, frontend resource registration | Real-hass (`hass` fixture from `pytest-homeassistant-custom-component`) |
+| Time-boundary effects, entity reactivity, persistence across restart | Live tests (`tests/live/*.sh` against HA-TEST) |
+
+All four layers are necessary; none is sufficient. Do not substitute a mock-hass
+test for a bug class that requires real-hass lifecycle, and do not reach for
+live tests when a real-hass in-process test is faster and fully deterministic.
+
+## Consequences
+
+**Good.** HA-lifecycle bugs are now caught in CI without a deploy cycle. The
+`hass` fixture spins up a real `HomeAssistant` in milliseconds, so the cost
+is comparable to mock-hass tests while testing the actual integration path.
+
+**Open.** Both mock-hass and real-hass tests currently coexist for some code
+paths (no policy yet for when to retire the mock-hass equivalent once a
+real-hass test exists). Track for v1.8: a rule such as "retire the mock-hass
+test if the real-hass test covers the same assertion and is not significantly
+slower".
+
+See `tests/test_setup_entry_smoke.py`, `tests/test_setup_entry_lifecycle.py`,
+and `tests/test_unload_reload_cycle.py` for the real-hass test suite.
+See [`CONTRIBUTING.md`](../../CONTRIBUTING.md#the-three-layer-test-pyramid)
+for the full pyramid description.

--- a/docs/adr/0008-fleet-ev-power-newtype.md
+++ b/docs/adr/0008-fleet-ev-power-newtype.md
@@ -1,0 +1,59 @@
+# ADR 0008 — FleetEvPower newtype as type-system enforcement of fleet-vs-per-charger reads
+
+**Status:** Accepted (v1.6.16) · ratifies `coordinator/types.py:FleetEvPower`
+
+## Context
+
+ADR 0001 closed the per-charger context swap surface structurally
+(`PerChargerContext`) and added an AST lint scoped to `ev_control.py`. That lint
+caught unannotated `power.ev_power` reads in the per-charger loop body but had
+two gaps: it was scoped to one file, and it was comment-based (`# FLEET-READ:`),
+so the annotation was invisible to type checkers, IDEs, and `ast.dump`.
+
+Issues `#284`, `#289`, `#315`, and `#318` were each a different file repeating
+the same shape — code inside a per-charger context reading the fleet-summed
+`PowerReadings.ev_power` without acknowledging it. The v1.6.8 lint was
+file-scoped; the rest of `coordinator/` was unguarded.
+
+## Decision
+
+**`FleetEvPower` is a `float` subclass (not a `typing.NewType`, not a `TypeVar`)
+that wraps `PowerReadings.ev_power`.**
+
+- Subclassing `float` means every existing arithmetic and comparison expression
+  that reads `ev_power` continues to work without migration — the type is a
+  transparent wrapper at runtime.
+- The `.as_fleet_total(reason: str)` accessor returns the underlying watts and
+  takes a mandatory `reason` argument. The argument has no runtime effect but
+  documents intent at the call site in a form that appears in code review,
+  `git blame`, `ast.dump`, and IDE hover — stronger than a comment.
+- The expanded AST lint (`tests/test_fleet_ev_power_reads_global.py`) treats
+  `.as_fleet_total(...)` as equivalent to the `# FLEET-READ:` comment and
+  accepts either. Unannotated bare reads of `ev_power` in any module under
+  `coordinator/` fail CI.
+
+`typing.NewType` was rejected: it aliases at the type-checker level but is
+transparent at runtime, so arithmetic on a `NewType` alias produces a plain
+`float` — meaning the next assignment would silently lose the newtype. Subclassing
+preserves the type through arithmetic because Python's `float.__add__` returns a
+`float`, not the subclass, but the wrapper is re-applied at the one construction
+site (`sensor_reader`), which is where enforcement is needed.
+
+Shipped in v1.6.16 (commit `30317b6`, PR `#332`).
+
+## Consequences
+
+**Good.** The fleet-vs-per-charger read bug class is now statically enforceable
+across all of `coordinator/`, not just `ev_control.py`. New files automatically
+inherit the coverage without opt-in. The `.as_fleet_total()` method appears in
+any language-server hover, making the intent explicit to future contributors.
+
+**Open.** As noted in `coordinator/charger_types.py:FleetView`, the `FleetView`
+aggregate type (introduced post-v1.6.16) now centralises fleet reads for the
+actuator, reducing the number of legitimate `as_fleet_total()` call sites.
+When the actuator migration is complete, the newtype's primary remaining role
+is the energy-balance equation in `PowerReadings.calculate_derived`. Track for
+v1.8: whether the lint and newtype can be simplified once call-site count drops.
+
+See `coordinator/types.py:34` for the class definition and
+`tests/test_fleet_ev_power_reads_global.py` for the fitness function.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -22,8 +22,13 @@ _changes_.
 
 ## Index
 
-- [0001 — PerChargerContext per-charger swap surface](0001-per-charger-context.md)
-- [0002 — EVBudget unified across publish path, state machine, actuator](0002-ev-budget-unified.md)
-- [0003 — Sign convention boundary at sensor_reader](0003-sign-convention-boundary.md)
-- [0004 — home_consumption_power is clamped to zero](0004-home-consumption-clamp.md)
-- [0005 — Pipeline test per supported brand is mandatory](0005-pipeline-test-per-brand.md)
+| # | Title | Status |
+|---|---|---|
+| [0001](0001-per-charger-context.md) | PerChargerContext per-charger swap surface | Accepted |
+| [0002](0002-ev-budget-unified.md) | EVBudget unified across publish path, state machine, actuator | Accepted |
+| [0003](0003-sign-convention-boundary.md) | Sign convention boundary at sensor_reader | Accepted |
+| [0004](0004-home-consumption-clamp.md) | home_consumption_power is clamped to zero | Accepted |
+| [0005](0005-pipeline-test-per-brand.md) | Pipeline test per supported brand is mandatory | Accepted |
+| [0006](0006-fleet-cycle-state.md) | FleetCycleState as single source of truth for fleet-level coordinator inputs | Accepted |
+| [0007](0007-real-hass-test-framework.md) | Real-hass test framework adoption and test-layer choice rule | Accepted |
+| [0008](0008-fleet-ev-power-newtype.md) | FleetEvPower newtype as type-system enforcement of fleet-vs-per-charger reads | Accepted |


### PR DESCRIPTION
## Summary

First pass through `ruflo-adr:adr-architect` on the SEM ADR collection. Audits the 5 ADRs added in #394, fixes code-link drift, ratifies three already-shipped decisions that weren't yet captured.

## Mechanical fixes

- **ADR 0002 (EVBudget)** — code link pointed at `coordinator/ev_budget.py`. That file doesn't exist. `EVBudget` lives at `coordinator/flow_calculator.py:95`.
- **ADR 0004 (home_consumption_power clamp)** — code link pointed at `coordinator/sensor_reader.py:_compute_home_consumption`. That function doesn't exist by that name. The clamp is at `coordinator/types.py:206` inside `PowerReadings.calculate_derived()`.

Both were rename/refactor drift between when the decisions were made and when the ADRs were written. Exactly the class of bug `/adr verify` is meant to catch pre-merge.

## New ADRs (ratify already-shipped decisions)

- **0006 FleetCycleState** — single source of truth for fleet-level coordinator inputs + AST lint at `tests/test_fleet_state_completeness.py`. Symmetric to ADR 0001 but for the fleet side of the multi-charger loop. Shipped v1.7.0-beta.7 (commit `44d28a8`).
- **0007 Real-hass test framework adoption** — `pytest-homeassistant-custom-component==0.13.205` is first-class; four-layer test pyramid (unit / scenario harness / real-hass / live) with a bug-class → layer choice rule. Shipped v1.7.0-beta.10 (commits `8e34727` Phase 1, `91b0663` Phase 2).
- **0008 FleetEvPower newtype** — `float` subclass with `.as_fleet_total(reason: str)` accessor + global AST lint at `tests/test_fleet_ev_power_reads_global.py`. Expands the per-charger enforcement that ADR 0001 scoped to `ev_control.py` to all of `coordinator/`. Shipped v1.6.16 (commit `30317b6`, PR #332).

## README index

Flat link list → `# | Title | Status` table. ADRs 0001-0005 backfilled as `Accepted`, 0006-0008 added.

## Verification

Every code anchor in every new/edited ADR was grepped against the working tree before commit:
- `EVBudget` at `flow_calculator.py:95` ✓
- Clamp at `types.py:206` in `PowerReadings.calculate_derived()` ✓
- `FleetCycleState` at `charger_types.py:541` ✓ + `_build_fleet_cycle_state` at `coordinator.py:3024` ✓
- `FleetEvPower` at `types.py:34` ✓ + `.as_fleet_total()` at `types.py:72` ✓ + `FleetView` at `charger_types.py:623` ✓
- Real-hass test files (`test_setup_entry_smoke.py`, `test_setup_entry_lifecycle.py`, `test_unload_reload_cycle.py`) all present ✓
- `pytest-homeassistant-custom-component==0.13.205` pinned in `tests/requirements_test.txt:6` ✓

## Out of scope / follow-ups

- **Split of ADR 0002** into unification (stays as 0002) + per-charger distribution (would be 0009) — flagged as `TODO` in 0002's Open section. Not authorised yet.
- **CONTRIBUTING.md "three-layer test pyramid"** is now stale — ADR 0007 ratifies a four-layer pyramid. Update CONTRIBUTING.md in a follow-up.

## Test plan

- [ ] CI green (no Python or test code touched; pure docs change, should pass trivially)
- [ ] After merge: `docs/adr/` contains 8 ADRs + README index with Status column

Refs #394