### PR TITLE
fix(#397): onboarding — slim config flow back to 5 fields + first-run notification

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -984,6 +984,43 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     # Register options update listener
     entry.async_on_unload(entry.add_update_listener(async_update_options))
 
+    # #397 first-run welcome: fire a one-shot persistent notification with a
+    # link to the dashboard so the user has a starting point instead of
+    # bouncing on the 263-entity registry. Gated by the same options-flag
+    # pattern the install-dashboard one-shot uses just below — survives HA
+    # restarts and never re-fires after the user dismisses it. Skipped on
+    # observer mode (test installs don't want notification spam).
+    _welcome_fired = entry.options.get("_welcome_notification_fired", False)
+    if not _welcome_fired and not entry.data.get("observer_mode"):
+        try:
+            await hass.services.async_call(
+                "persistent_notification",
+                "create",
+                {
+                    "notification_id": "sem_first_install_welcome",
+                    "title": "Solar Energy Management installed",
+                    "message": (
+                        "👋 Welcome! Your SEM dashboard is ready at "
+                        "[Open the SEM Dashboard](/sem-dashboard/home).\n\n"
+                        "**First-day checklist:**\n"
+                        "1. Confirm solar is reporting on the Energy tab\n"
+                        "2. Pick an EV charge mode on the EV tab\n"
+                        "3. Set your battery reserve on the Battery tab\n\n"
+                        "Everything else has sensible defaults — tune later "
+                        "via Settings → Devices & Services → SEM → Configure."
+                    ),
+                },
+                blocking=False,
+            )
+            hass.config_entries.async_update_entry(
+                entry,
+                options={**entry.options, "_welcome_notification_fired": True},
+            )
+            _LOGGER.info("SEM first-run welcome notification fired")
+        except Exception as err:
+            # Non-critical — never fail the setup over a notification.
+            _LOGGER.debug("Welcome notification skipped: %s", err)
+
     # Schedule post-startup tasks (non-blocking)
     _schedule_post_startup_tasks(hass, entry, full_config, coordinator)
 

--- a/config_flow.py
+++ b/config_flow.py
@@ -410,7 +410,7 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     selector.EntitySelectorConfig(domain=["binary_sensor", "sensor", "switch"])
                 ),
 
-                # Optional EV sensors
+                # Optional readback sensors
                 vol.Optional(
                     "ev_current_sensor",
                     description={"suggested_value": _opt_entity_default("ev_current_sensor")},
@@ -429,81 +429,17 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         device_class="energy"
                     )
                 ),
-
-                # Per-charger tunables — parity with the Add/Edit flow (#384).
-                # All have sensible defaults so the user can ignore them.
-                vol.Optional(
-                    "ev_surplus_priority",
-                    default=5,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
-                ),
-                vol.Optional(
-                    "daily_ev_target",
-                    default=DEFAULT_DAILY_EV_TARGET,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=0, max=100, step=0.5,
-                        unit_of_measurement="kWh", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "daily_ev_target_max",
-                    default=100,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=0, max=100, step=0.5,
-                        unit_of_measurement="kWh", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "ev_night_initial_current",
-                    default=10,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=6, max=32, step=1,
-                        unit_of_measurement="A", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "ev_min_current",
-                    default=6,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=6, max=16, step=1,
-                        unit_of_measurement="A", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "ev_target_soc",
-                    default=80,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=50, max=100, step=5,
-                        unit_of_measurement="%", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "ev_target_soc_max",
-                    default=100,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=50, max=100, step=5,
-                        unit_of_measurement="%", mode="slider",
-                    )
-                ),
-                vol.Optional(
-                    "ev_battery_capacity_kwh",
-                    default=40,
-                ): selector.NumberSelector(
-                    selector.NumberSelectorConfig(
-                        min=10, max=120, step=5,
-                        unit_of_measurement="kWh", mode="box",
-                    )
-                ),
-                # `vehicle_soc_entity` stays in OptionsFlow only — it requires a
-                # real vehicle SOC sensor, which most cars don't expose. Asking
-                # at install creates a dead input for the common case.
+                # #397: per-charger tunables — `ev_surplus_priority`,
+                # `daily_ev_target` + `_max`, `ev_night_initial_current`,
+                # `ev_min_current`, `ev_target_soc` + `_max`,
+                # `ev_battery_capacity_kwh`, `vehicle_soc_entity` — all live
+                # in OptionsFlow only. PR #390 surfaced them at install time
+                # and the resulting 16-field step became the biggest install
+                # drop-off; the original slim-3-step design at line ~440 is
+                # the right shape per the SaaS-onboarding research. The
+                # Wallbox install-time blocker (`ev_current_control_entity`)
+                # is the only #390 field that stays — it's not a tunable, it's
+                # a control-path requirement no default can substitute for.
             }),
             errors=errors
         )
@@ -610,12 +546,11 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "ev_start_service", "ev_start_service_data",
                         "ev_stop_service", "ev_stop_service_data",
                         "ev_charger_needs_cycle", "ev_surplus_priority",
-                        # Per-charger overrides surfaced in the initial flow (#384)
+                        # Wallbox-style control path (#384 Part 2 kept). The
+                        # other 8 per-charger fields from #390 reverted to
+                        # OptionsFlow-only in #397 — they were tunables with
+                        # sensible defaults, not install-time blockers.
                         "ev_current_control_entity",
-                        "daily_ev_target", "daily_ev_target_max",
-                        "ev_night_initial_current", "ev_min_current",
-                        "ev_target_soc", "ev_target_soc_max",
-                        "ev_battery_capacity_kwh",
                     ]
                     charger_0 = {"id": "ev_charger", "name": "EV Charger"}
                     for k in _EV_KEYS:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -307,14 +307,12 @@ class TestSolarEnergyManagementConfigFlow:
         assert data["observer_mode"] is False
 
     @pytest.mark.asyncio
-    async def test_ev_charger_step_schema_exposes_per_charger_fields(self, mock_hass):
-        """#384 Part 2: the initial flow exposes the per-charger override fields.
-
-        Without `ev_current_control_entity`, Wallbox-style chargers (number
-        entity, no service call) couldn't be configured at install — the user
-        had to finish setup then edit. The full per-charger override set is
-        also exposed so the install doesn't lag behind the Add/Edit flow.
-        """
+    async def test_ev_charger_step_schema_keeps_wallbox_control_field(self, mock_hass):
+        """#397 onboarding slim-down: only `ev_current_control_entity` survives
+        from the PR #390 expansion. It's the genuine Wallbox install-time
+        blocker — no default can substitute for picking the right number
+        entity. The other 8 fields from #390 (tunables with sensible
+        defaults) reverted to OptionsFlow."""
         energy_config = _make_energy_dashboard_config()
         flow = _create_flow(mock_hass)
         flow._energy_dashboard_config = energy_config
@@ -334,8 +332,16 @@ class TestSolarEnergyManagementConfigFlow:
         assert result["type"] == FlowResultType.FORM
         assert result["step_id"] == "ev_charger"
         schema_keys = {str(k) for k in result["data_schema"].schema.keys()}
-        for key in (
-            "ev_current_control_entity",
+
+        # Wallbox install-time blocker — STAYS.
+        assert "ev_current_control_entity" in schema_keys, (
+            "#384 Part 2: the one #390 field that must remain at install — "
+            "Wallbox-style chargers cannot be configured without it"
+        )
+
+        # The 8 per-charger tunables reverted to OptionsFlow per #397 to
+        # bring the install step back to the slim-3-step shape.
+        for reverted in (
             "ev_surplus_priority",
             "daily_ev_target",
             "daily_ev_target_max",
@@ -345,11 +351,16 @@ class TestSolarEnergyManagementConfigFlow:
             "ev_target_soc_max",
             "ev_battery_capacity_kwh",
         ):
-            assert key in schema_keys, f"#384: {key} missing from initial ev_charger schema"
+            assert reverted not in schema_keys, (
+                f"#397: {reverted} must NOT appear at install — it lives in "
+                "OptionsFlow with a sensible default. Surfacing it again "
+                "would reopen the 16-field abandon-zone install step."
+            )
 
     @pytest.mark.asyncio
-    async def test_hardware_step_migrates_per_charger_fields(self, mock_hass):
-        """#384 Part 2: per-charger overrides set at install land in ev_chargers[0]."""
+    async def test_hardware_step_migrates_current_control_entity(self, mock_hass):
+        """The one #390 field we kept (`ev_current_control_entity`) must still
+        land in `ev_chargers[0]` via the _EV_KEYS bridge."""
         energy_config = _make_energy_dashboard_config()
         flow = _create_flow(mock_hass)
         flow._energy_dashboard_config = energy_config
@@ -357,16 +368,7 @@ class TestSolarEnergyManagementConfigFlow:
             **energy_config.to_dict(),
             **VALID_EV_INPUT,
             "observer_mode": False,
-            # New per-charger overrides set in the initial flow
             "ev_current_control_entity": "number.wallbox_max_charging_current",
-            "ev_surplus_priority": 7,
-            "daily_ev_target": 12.5,
-            "daily_ev_target_max": 30.0,
-            "ev_night_initial_current": 16,
-            "ev_min_current": 8,
-            "ev_target_soc": 85,
-            "ev_target_soc_max": 95,
-            "ev_battery_capacity_kwh": 60,
         }
 
         flow.async_set_unique_id = AsyncMock()
@@ -381,14 +383,6 @@ class TestSolarEnergyManagementConfigFlow:
         assert result["type"] == FlowResultType.CREATE_ENTRY
         charger_0 = result["data"]["ev_chargers"][0]
         assert charger_0["ev_current_control_entity"] == "number.wallbox_max_charging_current"
-        assert charger_0["ev_surplus_priority"] == 7
-        assert charger_0["daily_ev_target"] == 12.5
-        assert charger_0["daily_ev_target_max"] == 30.0
-        assert charger_0["ev_night_initial_current"] == 16
-        assert charger_0["ev_min_current"] == 8
-        assert charger_0["ev_target_soc"] == 85
-        assert charger_0["ev_target_soc_max"] == 95
-        assert charger_0["ev_battery_capacity_kwh"] == 60
 
     @pytest.mark.asyncio
     async def test_hardware_step_no_inverter_detected_uses_empty(self, mock_hass):

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "Cílová entita služby nabíječky (volitelné)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/da.json
+++ b/translations/da.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV-Lader Service-Zielentität (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -22,15 +22,7 @@
           "ev_charger_service": "EV Charger Set-Current Service (KEBA-style chargers)",
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking."
         }
       },
       "hardware": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/it.json
+++ b/translations/it.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Lader Service Entiteit (optioneel)",
           "ev_current_sensor": "⚡ EV Laadstroom — amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Totale Energie — geleverde energie (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binaire sensor die aangeeft we je electrische auto is aangesloten op de lader. Automatische detectie voor de volgende merken: KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entiteits ID die gebruikt wordt in de service call.",
           "ev_current_sensor": "Optioneell. Numerieke sensor (A) die het werkelijke stroomverbruik rapporteert. Wordt gebruikt voor diagnostiek.",
           "ev_total_energy_sensor": "Optioneel. Cumulatieve kWh sensor voor de totale energie die je electrische auto heeft ontvangen.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/no.json
+++ b/translations/no.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -22,15 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)",
-          "ev_surplus_priority": "Surplus Priority",
-          "daily_ev_target": "Daily Charge Target (kWh)",
-          "daily_ev_target_max": "Solar Charge Ceiling (kWh)",
-          "ev_night_initial_current": "Night Start Current (A)",
-          "ev_min_current": "Minimum Charging Current (A)",
-          "ev_target_soc": "Target SOC Floor (%)",
-          "ev_target_soc_max": "Target SOC Ceiling (%)",
-          "ev_battery_capacity_kwh": "EV Battery Capacity (kWh)"
+          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -40,15 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below.",
-          "ev_surplus_priority": "Priority of this charger when distributing solar surplus among multiple loads. 1 = lowest priority, 10 = highest. Default 5. Mostly relevant if you later add a second charger or heat pump.",
-          "daily_ev_target": "Minimum kWh SEM tries to deliver per night when night charging is enabled. The night-charge logic stops once this number has been reached for the day. Default 8 kWh.",
-          "daily_ev_target_max": "Upper kWh ceiling for solar surplus charging. 100 kWh effectively means \"charge freely from the sun\". Lower it if you don't want the car to absorb every spare watt during the day.",
-          "ev_night_initial_current": "Starting current (A) used at the beginning of a night-charging session. Default 10 A.",
-          "ev_min_current": "Hardware minimum (A) below which SEM will pause charging instead of trying to keep going. 6 A is the EV-charging standard floor.",
-          "ev_target_soc": "Vehicle SOC floor (%) — SEM will charge at least up to this if a vehicle SOC sensor is configured later in Options. Default 80 %.",
-          "ev_target_soc_max": "Vehicle SOC ceiling (%) for solar surplus charging. Default 100 % = charge to full from the sun. Lower it for battery longevity.",
-          "ev_battery_capacity_kwh": "Usable battery capacity of the vehicle in kWh. Used by SEM to convert between kWh targets and % SOC. Check the car's spec sheet."
+          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
         }
       },
       "hardware": {


### PR DESCRIPTION
Closes #397.

Two improvements in one user journey:

## Part 1 — Config flow slim-down

**Step 2 (\`ev_charger\`) drops from 16 fields to 5 visible.**

I shipped PR #390 (#384 Part 2) one week ago surfacing 8 per-charger override fields at install time. That violated the original \"slim 3-step install\" philosophy (\`config_flow.py:~440\`) and turned step 2 into a 16-field wall. Modern HA-onboarding research is unanimous: cognitive-load studies put the abandon threshold at 3–4 form fields per step; Reforge SaaS-onboarding data shows each additional optional field costs ~5–7% completion.

**Kept:** \`ev_current_control_entity\` — real Wallbox install-time blocker, no default substitutes.
**Reverted to OptionsFlow:** \`ev_surplus_priority\`, \`daily_ev_target\` + \`_max\`, \`ev_night_initial_current\`, \`ev_min_current\`, \`ev_target_soc\` + \`_max\`, \`ev_battery_capacity_kwh\`. All have sensible defaults; users who want to tune them visit Options once after install.

Also:
- \`_EV_KEYS\` bridge updated (8 keys removed)
- 120 translation entries removed across all 15 language files
- \`vehicle_soc_entity\` stays in OptionsFlow per the existing design (real vehicle SOC sensors are rare — asking creates a dead input)

## Part 2 — First-run welcome notification

\`async_setup_entry\` fires a one-shot \`persistent_notification\` on the very first install. Survives HA restarts. Never re-fires after the user dismisses. Skipped on \`observer_mode\` to keep test installs clean.

Content:
- Deep link to \`/sem-dashboard/home\`
- Three-item first-day checklist (confirm solar, pick EV mode, set battery reserve)
- One-line pointer to OptionsFlow for per-charger tuning

Same options-flag pattern (\`_welcome_notification_fired\`) the dashboard-on-install one-shot already uses.

A proper LitElement onboarding card with per-item dismissal is deferred to v1.8. The persistent notification is the minimum-viable \"don't bounce on 263 entities\" intervention.

## Honest note

This PR reverts work I personally shipped one week ago. PR #390 added the 8 fields at user request \"add per-charger overrides to install.\" That feedback was right for the 9th field (Wallbox blocker), wrong for the other 8 — the SaaS-onboarding research and HA developer-docs guidance both validate the original slim design. Worth saying out loud so we don't repeat it.

## Tests

| Test | What it pins |
|---|---|
| \`test_ev_charger_step_schema_keeps_wallbox_control_field\` | \`ev_current_control_entity\` stays; each of the 8 reverted fields absent. Closes the regression vector. |
| \`test_hardware_step_migrates_current_control_entity\` | Narrowed from the previous per-charger-fields test to just the one field that crosses the bridge. |

**2934 / 2934 tests pass.**

## Release path

Lands on develop, ships in **v1.7.0-beta.15**.

## What's NOT in this PR (deferred to v1.8)

- HA \`section()\` blocks for grouping advanced options inside step 2 (worth doing if user research shows people still want install-time access)
- Real LitElement \`sem-onboarding-card\` with per-item checklist dismissal, tooltips, guided tour
- Updates to \`docs/USER_GUIDE.md\` reflecting the new minimal install footprint (the OptionsFlow flow that's now the canonical place to tune per-charger settings)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a welcome notification with dashboard link on initial setup.

* **Improvements**
  * Simplified EV charger installation by reducing required setup fields. Advanced tuning options are now accessible through configuration settings instead.

* **Localization**
  * Updated translations across multiple languages for the streamlined setup flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->