### PR TITLE
docs(adr): split 0002 into 0002+0009, sync CONTRIBUTING pyramid to ADR 0007

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,17 +80,18 @@ rsync -av --delete --exclude='__pycache__' --exclude='.git' \
   ./ your-ha:/config/custom_components/solar_energy_management/
 ```
 
-## The three-layer test pyramid
+## The four-layer test pyramid
 
-SEM tests live at three layers, each catching a different bug class. Use the one that matches what you're verifying:
+SEM tests live at four layers, each catching a different bug class. Use the one that matches what you're verifying. See [ADR 0007](docs/adr/0007-real-hass-test-framework.md) for the choice rule and rationale.
 
 | Layer | Where | Catches | Cost |
 |---|---|---|---|
-| **Unit tests** | `tests/test_*.py` | Pure logic / arithmetic bugs | Fast (seconds) |
+| **Unit tests** | `tests/test_*.py` (mock `hass`) | Pure logic / arithmetic bugs | Fast (seconds) |
 | **Scenario harness** | `tests/scenarios/*.yaml` + `tests/scenario_harness.py` | Decision-vs-enforcement drift, replay of real traces through the coordinator pipeline | Medium (sub-second per scenario) |
+| **Real-hass tests** | `tests/test_setup_entry_*.py`, `tests/test_unload_reload_cycle.py`, … (`hass` fixture from `pytest-homeassistant-custom-component`) | HA lifecycle — setup, unload, reload, `hass.data` slot lifecycle, frontend resource registration races | Medium (ms-to-seconds per test) |
 | **Live tests** | `tests/live/*.sh` | Time-boundary effects, entity reactivity, persistence across HA restart, real coordinator update path | Slow (minutes per test) |
 
-Each is necessary; none is sufficient. The Phase B EV-budget unification (#282) bug was invisible to unit tests because it required different code paths reading different formulas — only a scenario replay or live observation could surface the disagreement.
+Each is necessary; none is sufficient. The Phase B EV-budget unification (#282) bug was invisible to unit tests because it required different code paths reading different formulas — only a scenario replay or live observation could surface the disagreement. The real-hass layer was added in v1.7.0-beta.10 after entry-setup/unload bugs slipped past every mock-hass test in the suite.
 
 ### Live tests (`tests/live/`)
 
@@ -109,6 +110,15 @@ YAML-driven replays of timeline-of-readings. Reach for these when:
 - You want CI coverage of "what does SEM do given these inputs"
 
 A scenario YAML has a `config:` block (which becomes `coordinator.config`), an `ev_chargers:` block (use 2+ entries to exercise multi-charger distribution), a `timeline:` of sensor rows (sticky semantics — values carry forward unless overridden), and an `expect:` block with assertions. See `tests/scenarios/2026-05-28_surplus_leak.yaml` for a worked example.
+
+### Real-hass tests (`tests/test_setup_entry_*.py`, `tests/test_unload_reload_cycle.py`, …)
+
+In-process `HomeAssistant` instance via the `hass` fixture from `pytest-homeassistant-custom-component`. Reach for these when:
+- You're testing entry setup / unload / reload behaviour, `hass.data` slot lifecycle, or frontend resource registration
+- A mock-hass unit test would pass but the real HA call path is what you actually care about
+- You want CI coverage of an HA-lifecycle bug class without a deploy cycle
+
+Real-hass tests run against a real (but in-process) HA instance, so they're fast enough for CI on every PR. See ADR 0007 for the layer-choice rule.
 
 ## Branch Strategy
 

--- a/docs/adr/0002-ev-budget-unified.md
+++ b/docs/adr/0002-ev-budget-unified.md
@@ -1,4 +1,4 @@
-# ADR 0002 — EVBudget is the single source of truth across publish, state machine, actuator, and multi-charger distribution
+# ADR 0002 — EVBudget is the single source of truth across publish, state machine, and actuator
 
 **Status:** Accepted (v1.6.0)
 
@@ -10,18 +10,15 @@ Pre-v1.6, EV budgeting was computed independently in three places:
 2. The state machine that decided which mode to be in
 3. The actuator that translated mode → amps for the charger
 
-Plus a fourth, layered on top in multi-charger configs: a distribution
-step that split the global budget across chargers by priority. Each
-path had its own slightly different rounding, clamping, and minimum-
-amps handling. When the four diverged — as they always did — the
-sensor on the dashboard didn't match what the actuator commanded, the
-state machine flipped between modes the user didn't trigger, and
-multi-charger installs got unpredictable splits.
+Each path had its own slightly different rounding, clamping, and
+minimum-amps handling. When they diverged — as they always did — the
+sensor on the dashboard didn't match what the actuator commanded, and
+the state machine flipped between modes the user didn't trigger.
 
 ## Decision
 
 **Canonical `EVBudget` dataclass is the single source of truth across
-all four paths.**
+all three paths.**
 
 Defined in `coordinator/flow_calculator.py` (line 95). Computed once per coordinator
 cycle, consumed by:
@@ -30,15 +27,18 @@ cycle, consumed by:
 - the state machine (modes branch off `EVBudget.intent`, not their own
   recompute)
 - the actuator (amps come from `EVBudget.amps`, no second rounding)
-- the multi-charger distributor (operates on the same `EVBudget`,
-  produces per-charger `EVBudget` slices that follow the same shape)
+
+Multi-charger power allocation is a separate decision — see
+[ADR 0009](0009-ev-budget-multi-charger-distribution.md). Today the
+distributor operates on raw watts, not on `EVBudget` instances; a
+future unification could make it produce per-charger `EVBudget`
+slices, but that change is intentionally not in scope of this ADR.
 
 ## Consequences
 
 **Good.** The dashboard's `sensor.sem_ev_budget` is by construction
 what the actuator will command. Mode transitions are deterministic
-from the dataclass. Multi-charger splits compose cleanly because the
-per-charger budget is the same type as the global one.
+from the dataclass.
 
 **Open.** Phase D.2 cleanup (legacy `_calculate_ev_budget` method
 removal, demotion-guard removal) deferred to v1.7.0 after sustained
@@ -47,8 +47,3 @@ A + B + B.5 + C + D.1 shipped in v1.6.0.
 
 See `coordinator/flow_calculator.py` for the dataclass shape and helper
 predicates.
-
-**Open (TODO):** Consider splitting this ADR into (a) a unification ADR
-covering the single-source-of-truth decision and (b) a per-charger-
-distribution ADR covering the multi-charger split shape — under
-consideration, not yet authorised.

--- a/docs/adr/0009-ev-budget-multi-charger-distribution.md
+++ b/docs/adr/0009-ev-budget-multi-charger-distribution.md
@@ -1,0 +1,75 @@
+# ADR 0009 — Multi-charger EV power distribution is a priority cascade with 60-second reallocation hysteresis
+
+**Status:** Accepted (v1.4.0, refined v1.6.0+) · depends on [ADR 0002](0002-ev-budget-unified.md)
+
+## Context
+
+[ADR 0002](0002-ev-budget-unified.md) makes `EVBudget` the canonical
+single-cycle EV power decision. SEM has supported multiple EV
+chargers per install since v1.4.0; when more than one charger is
+configured, the fleet-level budget needs to be split across them.
+
+Three things the split has to get right:
+
+1. **Determinism** — the same fleet budget + the same charger config
+   must produce the same per-charger allocation. Otherwise the
+   per-charger dashboard sensors and the actuator commands drift
+   out of sync.
+2. **No oscillation** — a small budget jitter (a passing cloud, a
+   100 W sensor wobble) must not bounce the allocation across
+   chargers every cycle, because the chargers' own minimum-amps
+   floors mean reallocating costs charging time.
+3. **Mode-disabled chargers stay visible** — a charger in
+   `charge_mode=off` must NOT consume any of the budget cascade, but
+   it MUST still appear in the per-charger dashboard sensors with
+   `0 W` so the dashboard doesn't look broken.
+
+## Decision
+
+**A priority cascade allocates a fleet watts budget to per-charger
+watts, with 60-second hysteresis on reallocation.**
+
+Implemented in `coordinator/surplus_controller.py:distribute_ev_budget`
+(line 132). The shape:
+
+- Chargers are sorted by `priority` (lower number = higher priority,
+  from the config flow).
+- Highest priority gets up to its max; the remainder cascades to the
+  next charger if it can meet its minimum-amps threshold.
+- Reallocation is suppressed for 60 s after the last change UNLESS
+  the fleet budget moves by more than 500 W (the threshold that
+  signals a real demand change vs sensor noise).
+- Chargers in `excluded_charger_ids` (today: `charge_mode=off` per
+  #351 M5) receive `0` in the output dict but are skipped in the
+  cascade. The output keying every configured charger keeps the
+  dashboard sensors accurate.
+
+The distributor returns `Dict[charger_id, watts]`, NOT
+`Dict[charger_id, EVBudget]`. The per-charger `PerChargerContext`
+(see [ADR 0001](0001-per-charger-context.md)) wraps the watts value
+with the per-charger state at consumption time.
+
+## Consequences
+
+**Good.** Per-charger dashboard sensors match what each actuator
+commands. Multi-charger installs are deterministic for a given config
+order. Cloud-driven budget jitter doesn't oscillate the allocation.
+The mode-disabled gate (#351 M5) means a charger turned off in the
+options flow visibly stays off without breaking the dashboard.
+
+**Open.**
+
+- The distributor consumes raw watts, not `EVBudget`. A future change
+  could make it accept the canonical `EVBudget` and produce per-charger
+  `EVBudget` slices — which would let intent, amps, and watts flow
+  through the distribution layer in a single typed value instead of
+  three. Not in scope today; tracking for v1.8.
+- Priority is fixed at config-order. Alternative allocation policies
+  (round-robin, proportional-to-SOC, deadline-aware) would land as
+  new distributor implementations, not as schema changes.
+- 60 s hysteresis + 500 W threshold are constants. If a fleet ever
+  hits a regime where these are wrong, they become config.
+
+See `coordinator/surplus_controller.py:distribute_ev_budget` for the
+allocator and `coordinator/per_charger_context.py` for the per-charger
+view's lifecycle.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -32,3 +32,4 @@ _changes_.
 | [0006](0006-fleet-cycle-state.md) | FleetCycleState as single source of truth for fleet-level coordinator inputs | Accepted |
 | [0007](0007-real-hass-test-framework.md) | Real-hass test framework adoption and test-layer choice rule | Accepted |
 | [0008](0008-fleet-ev-power-newtype.md) | FleetEvPower newtype as type-system enforcement of fleet-vs-per-charger reads | Accepted |
+| [0009](0009-ev-budget-multi-charger-distribution.md) | Multi-charger EV power distribution is a priority cascade with 60 s hysteresis | Accepted |


### PR DESCRIPTION
## Summary

The two follow-ups parked at the end of #396.

## ADR 0002 split → 0002 + 0009

ADR 0002 conflated two decisions:

- **(a)** `EVBudget` unification across publish path, state machine, actuator — a **data-model** decision.
- **(b)** How the resulting fleet budget is allocated to multiple chargers — a **distribution** decision.

Splitting them lets each ADR be accurate about its scope and point at the right code anchor.

### Drift surfaced while drafting

ADR 0002 as written claimed the multi-charger distributor *"operates on the same `EVBudget`, produces per-charger `EVBudget` slices."* The actual signature at `coordinator/surplus_controller.py:132`:

```python
def distribute_ev_budget(
    self,
    budget_w: float,
    ev_devices: Dict[str, ControllableDevice],
    excluded_charger_ids: Optional[set[str]] = None,
) -> Dict[str, float]:
```

Raw watts in, raw watts out. The unification stops at the actuator boundary. ADR 0002 has been over-claiming this since it was written. The split corrects that — 0002 is now scope-accurate, 0009 documents what the distributor actually does.

### What's in each ADR now

**0002 (trimmed):** unification across publish / state machine / actuator. Drops the multi-charger sentences from Context, Decision, and Consequences. Drops the TODO note about the split (now resolved). Cross-links 0009.

**0009 (new):** multi-charger EV power distribution. Decision: priority cascade with 60-second reallocation hysteresis, 500 W significant-change threshold, mode-disabled chargers visible with 0 W (#351 M5). Anchors `coordinator/surplus_controller.py:distribute_ev_budget` (line 132) and `coordinator/per_charger_context.py`. Open items: distributor consumes raw watts (not `EVBudget`) — future unification could change that; alternative allocation policies (round-robin, proportional-to-SOC) would be new distributor implementations.

## CONTRIBUTING.md test pyramid: three-layer → four-layer

ADR 0007 ratifies a four-layer pyramid (unit / scenario / real-hass / live). CONTRIBUTING.md described three. This PR:

- Renames the section to "The four-layer test pyramid"
- Adds a Real-hass row to the layer table with the `hass` fixture + concrete test-file examples
- Adds a "Real-hass tests" subsection mirroring the existing Live and Scenario sections
- Cross-links ADR 0007 for the choice rule
- Notes that the layer was added in v1.7.0-beta.10 after entry-setup/unload bugs slipped past every mock-hass test

## Verification

- `coordinator/surplus_controller.py:132` confirmed signature `(budget_w: float, ev_devices: Dict, excluded: Optional[set])` returning `Dict[str, float]` — matches 0009's claim
- `PerChargerContext` class verified at `coordinator/per_charger_context.py:34` (caught and fixed a typo where I'd written `PowerControlContext`)
- All real-hass test files referenced in CONTRIBUTING.md confirmed present (`tests/test_setup_entry_smoke.py`, `tests/test_setup_entry_lifecycle.py`, `tests/test_unload_reload_cycle.py`)

## Test plan

- [ ] CI green (docs only — no code touched)
- [ ] After merge: 9 ADRs in `docs/adr/` index; CONTRIBUTING.md describes four layers; ADR 0002 no longer mentions the distributor; ADR 0009 exists

Refs #394 #396