### PR TITLE
fix(#400): translate ev_charger step into native German + Dutch ev_current_control_entity

### DIFF
--- a/translations/de.json
+++ b/translations/de.json
@@ -13,26 +13,26 @@
       },
       "ev_charger": {
         "title": "EV-Lader",
-        "description": "SEM auto-detected your EV charger from the Home Assistant entity registry. Review the entries below and click **Submit** — there is usually nothing to change. Optional fields can be left blank.\n\nPick ONE control path: either a Number Entity (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) OR a Service Call (KEBA, Easee, Zaptec, OCPP, …).",
+        "description": "SEM hat deinen EV-Lader aus dem Home-Assistant-Entitätsregister automatisch erkannt. Überprüfe die Einträge unten und klicke auf **Senden** — meistens muss nichts geändert werden. Optionale Felder können leer bleiben.\n\nWähle EINEN Steuerungspfad: entweder eine Number-Entität (Wallbox, go-eCharger, Heidelberg, OpenWB, Ohme, V2C, …) ODER einen Service-Aufruf (KEBA, Easee, Zaptec, OCPP, …).",
         "data": {
-          "ev_connected_sensor": "🔌 EV Connected Status — vehicle plug connection",
-          "ev_charging_sensor": "⚡ EV Charging Active — current charging state",
-          "ev_charging_power_sensor": "🚗 EV Charging Power — power delivered to vehicle (W)",
-          "ev_charger_service": "EV-Lader Strom-Service (optional)",
-          "ev_charger_service_entity_id": "EV-Lader Service-Zielentität (optional)",
-          "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
-          "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_connected_sensor": "🔌 EV-Stecker verbunden — Fahrzeugstecker-Status",
+          "ev_charging_sensor": "⚡ EV lädt aktiv — aktueller Ladezustand",
+          "ev_charging_power_sensor": "🚗 EV-Ladeleistung — abgegebene Leistung an das Fahrzeug (W)",
+          "ev_current_control_entity": "Number-Entität für Ladestrom-Steuerung (Wallbox-artige Lader)",
+          "ev_charger_service": "Service zum Setzen des Ladestroms (KEBA-artige Lader)",
+          "ev_charger_service_entity_id": "Ziel-Entität für Service-Aufruf (optional)",
+          "ev_current_sensor": "⚡ EV-Ladestrom — Ladestromstärke (A)",
+          "ev_total_energy_sensor": "🔋 EV-Gesamtenergie — kumulierte abgegebene Energie (kWh)"
         },
         "data_description": {
-          "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
-          "ev_charging_sensor": "Binary sensor that reports whether SEM should consider charging active. Auto-detected from your charger integration.",
-          "ev_charging_power_sensor": "Numeric sensor (W) reporting how much power is currently flowing into the vehicle. Auto-detected from your charger integration.",
-          "ev_charger_service": "Home Assistant service called to set the charging current (e.g. keba.set_current, easee.set_charger_max_limit). Auto-filled for KEBA. Leave blank if you fill in the Number Entity path above.",
-          "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
-          "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
-          "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_connected_sensor": "Binärsensor, der meldet, ob der Fahrzeugstecker aktuell verbunden ist. Automatisch erkannt aus KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
+          "ev_charging_sensor": "Binärsensor, der meldet, ob SEM das Laden als aktiv betrachten soll. Automatisch erkannt aus deiner Lader-Integration.",
+          "ev_charging_power_sensor": "Numerischer Sensor (W), der meldet, wie viel Leistung aktuell ins Fahrzeug fließt. Automatisch erkannt aus deiner Lader-Integration.",
+          "ev_current_control_entity": "Number-Entität, in die SEM schreibt, um den Ladestrom zu ändern (z. B. number.wallbox_charging_current). Nutze diese Option für Lader, die eine Number-Entität statt eines Service-Aufrufs anbieten. Leer lassen, wenn du den Service-Pfad unten ausfüllst.",
+          "ev_charger_service": "Home-Assistant-Service zum Setzen des Ladestroms (z. B. keba.set_current, easee.set_charger_max_limit). Für KEBA automatisch ausgefüllt. Leer lassen, wenn du oben die Number-Entität verwendest.",
+          "ev_charger_service_entity_id": "Entity-ID, die als Ziel des Service-Aufrufs übergeben wird. Wird bei Bedarf automatisch ausgefüllt; leer lassen, wenn der Service global ist.",
+          "ev_current_sensor": "Optional. Numerischer Sensor (A), der den tatsächlichen Ladestrom meldet. Wird für Diagnosen verwendet.",
+          "ev_total_energy_sensor": "Optional. Kumulierter kWh-Zähler für die an das Fahrzeug abgegebene Energie. Wird für eine genaue Sitzungserfassung verwendet."
         }
       },
       "hardware": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Lader Service Entiteit (optioneel)",
           "ev_current_sensor": "⚡ EV Laadstroom — amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Totale Energie — geleverde energie (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number-entiteit voor laadstroom-besturing (Wallbox-achtige laders)"
         },
         "data_description": {
           "ev_connected_sensor": "Binaire sensor die aangeeft we je electrische auto is aangesloten op de lader. Automatische detectie voor de volgende merken: KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entiteits ID die gebruikt wordt in de service call.",
           "ev_current_sensor": "Optioneell. Numerieke sensor (A) die het werkelijke stroomverbruik rapporteert. Wordt gebruikt voor diagnostiek.",
           "ev_total_energy_sensor": "Optioneel. Cumulatieve kWh sensor voor de totale energie die je electrische auto heeft ontvangen.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number-entiteit waarnaar SEM schrijft om de laadstroom aan te passen (bv. number.wallbox_charging_current). Gebruik dit voor laders die een Number-entiteit aanbieden in plaats van een service-aanroep. Leeg laten als je hieronder het Service-pad invult."
         }
       },
       "hardware": {


### PR DESCRIPTION
Closes the highest-impact part of #400.

## Why this exists

Two real user-facing problems sat unfixed in the translation files:

1. **`de.json` ev_charger step was mostly English** — the step description and 5 of 8 field labels carried English copy, despite \`de.json\` being maintained for years. PR #388 noted this as out-of-scope (the \"separate sweep\") and the sweep never happened.
2. **\`nl.json\` had English copy for \`ev_current_control_entity\`** — the Wallbox-style control field PR #390 added with an English placeholder. RienduPre runs two Wallbox Pulsars and his install language is Dutch — he hits this exact field on every Edit-charger pass.

Both are docs-level UX bugs that don't need a code change.

## What changed

### \`de.json\` — full native German for the \`ev_charger\` config-flow step

- **title** — kept \"EV-Lader\" (already correct).
- **description** — full 3-sentence translation: auto-detection summary + the dual-control-path explainer (Number-Entität vs Service-Aufruf), preserving the line break before the picker note.
- **8 field labels** — native German, emoji prefixes preserved (\"🔌 EV-Stecker verbunden — Fahrzeugstecker-Status\", etc.).
- **8 field descriptions** — native German. Technical identifiers (\`keba.set_current\`, \`number.wallbox_charging_current\`) kept literal because they're HA service names users will see in their dashboards regardless of locale.

Style: Standard German that reads naturally in DE/AT/CH. Uses HA's own terminology where it exists (Entität, Service-Aufruf). Maintainer is German-speaking and can review my German directly.

### \`nl.json\` — \`ev_current_control_entity\` to native Dutch

Only the one field that was English. Label: \"Number-entiteit voor laadstroom-besturing (Wallbox-achtige laders)\". Description matches the pattern the other 7 fields already used. The rest of the Dutch \`ev_charger\` step was already native Dutch (good prior work).

## Out of scope, still tracked under #400

13 other languages still carry English placeholders for \`ev_current_control_entity\` and the dual-control-path note in the step header: fr, es, it, pt, pl, cs, da, fi, hu, no, ro, sv. These need native speakers — follow-up PRs on a per-language basis. The structural problem (English placeholder for PR #390's new field) is closed for the two languages most active in SEM's issue tracker.

## Tests

No code change — purely content updates. JSON validates: I ran the audit script and all 15 files still have 8 \`data\` + 8 \`data_description\` keys with no missing or orphan entries.

## Release path

Lands on develop. Ships with the next beta tag (\*not\* creating beta.16 here per the standing rule — when you say go).