### PR TITLE
fix(#359): percentile mode returns NORMAL when breaks unavailable, not silent CHF fallback

### DIFF
--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -340,6 +340,31 @@ The options flow is organized into these pages:
 - **Calendar**: You define cheap/expensive periods via a HA calendar entity.
   Useful for fixed time-of-use tariffs without a dynamic price API.
 
+#### Price classification — how the dynamic-tariff "cheap" / "expensive" labels are computed
+
+When tariff mode is **Dynamic**, SEM bucketises every price reading into one of
+**very_cheap / cheap / normal / expensive / very_expensive / negative**. Two modes:
+
+- **Percentile** (default since v1.7.0-beta.3): buckets are computed from
+  today's 24-hour price array. Bottom 10% = `very_cheap`, bottom 25% = `cheap`,
+  25–75% = `normal`, top 25% = `expensive`, top 10% = `very_expensive`. Works
+  on any currency / any market — the breaks adapt to your tariff's actual range.
+- **Static**: bucketises against fixed cutoffs (`< 0.075 = very_cheap`,
+  `< 0.15 = cheap`, `> 0.35 = expensive`, `> 0.525 = very_expensive`).
+  Calibrated for CHF — change to your currency only if you've explicitly opted
+  in to this mode in Settings → Configure → Tariff settings.
+
+**Cold start / sparse data (#359)**: in percentile mode, if SEM has fewer than
+4 price points for today (cold start before your dynamic-tariff integration
+populates, or a perfectly flat day), the classifier returns `normal` as a safe
+default. **It will not silently apply the static cutoffs**, which would
+mis-classify any non-CHF tariff (RienduPre's Tibber NL install was reporting
+€0.30 as `normal` for hours after restart before this was fixed in
+v1.7.0-beta.16).
+
+Switch modes from **Settings → Devices & Services → Solar Energy Management
+→ Configure → Tariff settings → "Price classification mode"**.
+
 ### Notification settings
 
 | Setting | Default | What it does and when to change it |

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -494,6 +494,16 @@ class DynamicTariffProvider(TariffProvider):
 
         ``static`` preserves the legacy fixed-cutoff behaviour for
         users with flat tariffs or unpredictable spike markets.
+
+        #359 follow-up (beta.16): when the user picked ``percentile``
+        but the breaks can't be computed (cold start, < 4 points, flat
+        day), DO NOT silently fall through to the static cutoffs.
+        Those thresholds are calibrated for CHF (0.15 / 0.35) and
+        silently mis-classify any other currency — RienduPre's
+        Tibber NL install reported €0.30 as ``normal`` for this exact
+        reason. Return ``NORMAL`` instead: a neutral default that
+        doesn't trigger cheap-window or expensive-window automation
+        until we actually have data to classify against.
         """
         if price < 0:
             return PriceLevel.NEGATIVE
@@ -510,10 +520,22 @@ class DynamicTariffProvider(TariffProvider):
                 if price >= breaks["p75"]:
                     return PriceLevel.EXPENSIVE
                 return PriceLevel.NORMAL
-            # Fall through to static when we can't compute percentiles
-            # yet (cold start, single price point).
+            # #359: percentile requested but no breaks available.
+            # Return NORMAL as a safe default. NEVER apply the
+            # CHF-calibrated static cutoffs here — they're wrong for
+            # any non-CHF tariff and silently produce confusing
+            # classifications that look like a SEM bug.
+            _LOGGER.debug(
+                "tariff/#359: percentile mode but no breaks — returning "
+                "NORMAL (safe default). Static cutoffs are CHF-calibrated "
+                "and would mis-classify other currencies.",
+            )
+            return PriceLevel.NORMAL
 
-        # Static thresholds (legacy + fallback).
+        # Static thresholds (legacy + explicit opt-in).
+        # Only reached when classification_mode == "static" — the user
+        # has explicitly chosen fixed cutoffs because their tariff is
+        # flat or their CHF/EUR scale matches the defaults.
         if price < self.cheap_threshold * 0.5:
             return PriceLevel.VERY_CHEAP
         if price < self.cheap_threshold:

--- a/tests/test_tariff_percentile_359.py
+++ b/tests/test_tariff_percentile_359.py
@@ -101,47 +101,54 @@ class TestPercentileBucketing:
         # Negative price (spot-market overproduction).
         assert p._classify_price(-0.05) is PriceLevel.NEGATIVE
 
-    def test_cold_start_falls_back_to_static(self):
-        """Before _prices_cache is populated, percentile mode must
-        fall back to the legacy static thresholds — otherwise the
-        very first sensor read would be unclassified."""
+    def test_cold_start_returns_normal(self):
+        """#359 follow-up: before _prices_cache is populated, percentile
+        mode must return NORMAL — not fall through to the static
+        thresholds, which are CHF-calibrated (0.15 / 0.35) and silently
+        mis-classify any other currency. RienduPre's Tibber NL install
+        hit this and reported €0.30 as ``normal`` for hours before the
+        Tibber sensor populated."""
         p = _make_provider("percentile")
         # No cache yet.
         assert p._prices_cache == []
-        # Static says < 0.15 = CHEAP, > 0.35 = EXPENSIVE.
-        assert p._classify_price(0.10) is PriceLevel.CHEAP
-        assert p._classify_price(0.50) is PriceLevel.EXPENSIVE
+        # NORMAL is the safe default until we have data.
+        assert p._classify_price(0.10) is PriceLevel.NORMAL
+        assert p._classify_price(0.50) is PriceLevel.NORMAL
         assert p._classify_price(0.25) is PriceLevel.NORMAL
+        # Negative prices remain NEGATIVE even pre-data.
+        assert p._classify_price(-0.05) is PriceLevel.NEGATIVE
 
-    def test_insufficient_data_falls_back_to_static(self):
-        """3 prices isn't enough for meaningful percentiles — fall
-        back to static."""
+    def test_insufficient_data_returns_normal(self):
+        """#359 follow-up: 3 prices isn't enough for percentiles — return
+        NORMAL, not the CHF-calibrated static fallback."""
         p = _make_provider("percentile")
         p._prices_cache = _today_prices([0.10, 0.20, 0.30])
 
-        # Bucket using static thresholds.
-        assert p._classify_price(0.10) is PriceLevel.CHEAP
+        assert p._classify_price(0.10) is PriceLevel.NORMAL
+        assert p._classify_price(0.50) is PriceLevel.NORMAL
 
-    def test_flat_distribution_falls_back_to_static(self):
-        """M1 reviewer note: a flat day collapses p10 == p90 and would
-        silently classify every price as VERY_CHEAP, over-triggering
-        cheap-window logic. Spread < 1 ct/kWh must fall through."""
+    def test_flat_distribution_returns_normal(self):
+        """#359 follow-up: a flat day collapses p90-p10 < 1 ct/kWh; the
+        degenerate guard returns None. In percentile mode that now
+        means NORMAL, not the CHF-calibrated static fallback."""
         p = _make_provider("percentile")
         # 24-point flat day at 0.20 €/kWh.
         p._prices_cache = _today_prices([0.20] * 24)
 
-        # Static says 0.20 lies in 0.15..0.35 → NORMAL (not
-        # VERY_CHEAP which the degenerate percentile path would
-        # produce).
         assert p._classify_price(0.20) is PriceLevel.NORMAL
+        # Even values that would static-classify differently come back
+        # as NORMAL because we have no real distribution to compare to.
+        assert p._classify_price(0.05) is PriceLevel.NORMAL
+        assert p._classify_price(0.40) is PriceLevel.NORMAL
 
-    def test_near_flat_distribution_falls_back(self):
-        """Spread under the 1 ct threshold also falls back."""
+    def test_near_flat_distribution_returns_normal(self):
+        """Spread under the 1 ct threshold also returns NORMAL."""
         p = _make_provider("percentile")
         prices = [0.20 + i * 0.0001 for i in range(24)]  # ~0.20 → ~0.2023
         p._prices_cache = _today_prices(prices)
 
         assert p._classify_price(0.20) is PriceLevel.NORMAL
+        assert p._classify_price(0.40) is PriceLevel.NORMAL
 
 
 class TestStaticMode:
@@ -291,3 +298,69 @@ class TestTimezoneSkew359Followup:
                 assert naive_date < local_today  # would be lost pre-fix
         finally:
             dt_util.set_default_time_zone(original_tz)
+
+
+class TestRienduPreRegressionFromReproScript:
+    """#359 follow-up — regression tests that mirror the live reproduction
+    on HA-TEST against synthetic Tibber-NL data, validated 2026-06-04.
+    Each test reproduces one of the three scenarios that caused €0.30 to
+    render as ``normal`` for RienduPre's install before the fix."""
+
+    @pytest.mark.parametrize("hour, price, expected", [
+        # Cherry-picked from the 24h synthetic Tibber NL curve in
+        # /tmp/sem-359-repro.py (scenario A). Breaks compute to
+        # p10=0.140, p25=0.180, p75=0.300, p90=0.400.
+        (4, 0.13, PriceLevel.VERY_CHEAP),     # below p10
+        (2, 0.15, PriceLevel.CHEAP),          # at p25 boundary (0.180)
+        (10, 0.32, PriceLevel.EXPENSIVE),     # above p75
+        (18, 0.45, PriceLevel.VERY_EXPENSIVE),  # above p90
+        # RienduPre's exact symptom price — at p75 = 0.30 → EXPENSIVE,
+        # NOT NORMAL (which is what static-fallback was producing).
+        (8, 0.30, PriceLevel.EXPENSIVE),
+    ])
+    def test_a_realistic_tibber_nl_percentile(self, hour, price, expected):
+        """Scenario A from the repro script: realistic 24h Tibber NL curve,
+        percentile mode, breaks compute cleanly."""
+        p = _make_provider("percentile")
+        curve = [
+            0.18, 0.16, 0.15, 0.14, 0.13, 0.14, 0.18, 0.24,
+            0.30, 0.32, 0.28, 0.25, 0.22, 0.20, 0.22, 0.26,
+            0.32, 0.42, 0.45, 0.40, 0.34, 0.28, 0.22, 0.18,
+        ]
+        p._prices_cache = _today_prices(curve)
+        assert p._classify_price(price) is expected
+
+    def test_b_static_mode_user_choice(self):
+        """Scenario B: user explicitly chose static mode. Their choice is
+        respected — the CHF-calibrated cutoffs apply. This is the only
+        scenario where €0.30 → NORMAL is the correct outcome (because
+        the user opted in to those thresholds)."""
+        p = _make_provider("static")
+        p._prices_cache = _today_prices([0.18, 0.30, 0.45])
+        assert p._classify_price(0.30) is PriceLevel.NORMAL
+
+    def test_d_cold_start_no_silent_fallback(self):
+        """Scenario D: percentile mode but cache is empty (cold start
+        before Tibber populates). Pre-fix: silently used CHF cutoffs and
+        €0.30 → NORMAL. Post-fix: returns NORMAL as a safe default
+        rather than running through the wrong-currency thresholds."""
+        p = _make_provider("percentile")
+        p._prices_cache = []
+        # NORMAL because we have no data — NOT because a stray €0.15
+        # CHF threshold happened to put €0.30 in the middle.
+        assert p._classify_price(0.30) is PriceLevel.NORMAL
+        # The point: every value comes back as NORMAL during cold
+        # start, no matter the magnitude. That's the safe behaviour.
+        assert p._classify_price(0.05) is PriceLevel.NORMAL
+        assert p._classify_price(0.80) is PriceLevel.NORMAL
+
+    def test_e_flat_day_no_silent_fallback(self):
+        """Scenario E: 24h of perfectly-flat €0.30 pricing. The
+        degenerate-distribution guard returns None; percentile mode
+        should return NORMAL — NOT use the CHF cutoffs and pretend
+        anything below €0.15 is CHEAP."""
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.30] * 24)
+        assert p._classify_price(0.30) is PriceLevel.NORMAL
+        assert p._classify_price(0.10) is PriceLevel.NORMAL  # would have been CHEAP pre-fix
+        assert p._classify_price(0.50) is PriceLevel.NORMAL  # would have been EXPENSIVE pre-fix

--- a/tests/test_tariff_provider.py
+++ b/tests/test_tariff_provider.py
@@ -181,27 +181,33 @@ class TestDynamicTariffProvider:
         assert provider._classify_price(-0.05) == PriceLevel.NEGATIVE
 
     def test_classify_price_very_cheap(self, mock_hass):
-        provider = DynamicTariffProvider(mock_hass)
+        """#359 follow-up: these tests were exercising the static-cutoff
+        buckets but constructing a percentile-default provider, so they
+        only passed because of the silent CHF fallback that we just
+        removed. Pass ``classification_mode='static'`` to make the
+        original intent explicit — testing the fixed-cutoff bucketing.
+        """
+        provider = DynamicTariffProvider(mock_hass, classification_mode="static")
         # cheap_threshold default = 0.15, very_cheap < 0.075
         assert provider._classify_price(0.05) == PriceLevel.VERY_CHEAP
 
     def test_classify_price_cheap(self, mock_hass):
-        provider = DynamicTariffProvider(mock_hass)
+        provider = DynamicTariffProvider(mock_hass, classification_mode="static")
         # 0.075 <= price < 0.15
         assert provider._classify_price(0.10) == PriceLevel.CHEAP
 
     def test_classify_price_normal(self, mock_hass):
-        provider = DynamicTariffProvider(mock_hass)
+        provider = DynamicTariffProvider(mock_hass, classification_mode="static")
         # 0.15 <= price <= 0.35
         assert provider._classify_price(0.25) == PriceLevel.NORMAL
 
     def test_classify_price_expensive(self, mock_hass):
-        provider = DynamicTariffProvider(mock_hass)
+        provider = DynamicTariffProvider(mock_hass, classification_mode="static")
         # > 0.35 and <= 0.525
         assert provider._classify_price(0.40) == PriceLevel.EXPENSIVE
 
     def test_classify_price_very_expensive(self, mock_hass):
-        provider = DynamicTariffProvider(mock_hass)
+        provider = DynamicTariffProvider(mock_hass, classification_mode="static")
         # > 0.525 (1.5 * 0.35)
         assert provider._classify_price(0.60) == PriceLevel.VERY_EXPENSIVE
 
@@ -515,7 +521,14 @@ class TestAmberElectricProvider:
         assert prices[0].level == PriceLevel.NEGATIVE
 
     def test_amber_forecast_spike_detection(self, mock_hass):
-        """Classify spike prices as very_expensive."""
+        """Classify spike prices as very_expensive.
+
+        #359 follow-up: tests the static-cutoff branch explicitly (the
+        2-point forecast is too small for percentile mode, so under the
+        post-fix default the spike would be classified as NORMAL too).
+        Static mode is the correct shape for testing the literal 'a
+        price > 0.525 is very_expensive' assertion.
+        """
         now = datetime(2026, 5, 3, 14, 0, 0)
         forecasts = [
             {"start_time": now.isoformat(), "per_kwh": 0.25},
@@ -524,7 +537,11 @@ class TestAmberElectricProvider:
         state = _make_price_state(0.25, attributes={"forecasts": forecasts})
         mock_hass.states.get = MagicMock(return_value=state)
 
-        provider = DynamicTariffProvider(mock_hass, price_entity="sensor.amber_general_price")
+        provider = DynamicTariffProvider(
+            mock_hass,
+            price_entity="sensor.amber_general_price",
+            classification_mode="static",
+        )
         prices = provider._read_prices_list()
 
         assert prices[0].level == PriceLevel.NORMAL
@@ -949,7 +966,14 @@ class TestDynamicTariffSchedule:
         assert schedule[1]["tariff"] == "HT"
 
     def test_schedule_all_cheap(self, mock_hass):
-        """All prices cheap → single NT block."""
+        """All prices cheap → single NT block.
+
+        #359 follow-up: flat days (24 × €0.05) trip the degenerate-
+        distribution guard, so percentile mode returns NORMAL = HT
+        for every hour. Use static mode here — the test's semantics
+        are about schedule generation from a flat-cheap day, which is
+        exactly what static cutoffs were designed to encode.
+        """
         now = datetime(2026, 5, 3, 0, 0, 0)
         prices = [
             {"start": now.replace(hour=h).isoformat(), "total": 0.05}
@@ -960,7 +984,11 @@ class TestDynamicTariffSchedule:
 
         with patch(DT_UTIL_PATH) as mock_dt:
             mock_dt.now.return_value = now
-            provider = DynamicTariffProvider(mock_hass, price_entity="sensor.price")
+            provider = DynamicTariffProvider(
+                mock_hass,
+                price_entity="sensor.price",
+                classification_mode="static",
+            )
             schedule = provider.get_schedule_for_day(now)
 
         assert len(schedule) == 1
@@ -981,7 +1009,13 @@ class TestDynamicTariffSchedule:
         assert schedule == []
 
     def test_schedule_with_spikes(self, mock_hass):
-        """Spike prices map to HT."""
+        """Spike prices map to HT.
+
+        #359 follow-up: 3 prices is below the 4-point percentile
+        minimum, so percentile mode returns NORMAL for every hour and
+        the spike doesn't get singled out. Use static mode — the test
+        is about absolute-magnitude spike detection.
+        """
         now = datetime(2026, 5, 3, 14, 0, 0)
         prices = [
             {"start": now.isoformat(), "total": 0.10},           # Cheap
@@ -993,7 +1027,11 @@ class TestDynamicTariffSchedule:
 
         with patch(DT_UTIL_PATH) as mock_dt:
             mock_dt.now.return_value = now
-            provider = DynamicTariffProvider(mock_hass, price_entity="sensor.price")
+            provider = DynamicTariffProvider(
+                mock_hass,
+                price_entity="sensor.price",
+                classification_mode="static",
+            )
             schedule = provider.get_schedule_for_day(now)
 
         assert len(schedule) == 3


### PR DESCRIPTION
Closes #359 — the real fix this time, validated by live reproduction on synthetic Tibber-NL data.

## TL;DR

The percentile classifier was silently falling through to hardcoded CHF cutoffs (`< €0.15 = cheap, > €0.35 = expensive`) whenever it couldn't compute today's percentile breaks. Those defaults are wrong for any non-CHF tariff — RienduPre's Tibber NL install saw €0.30 as `normal` because €0.30 < €0.35. The fix: in percentile mode, return `NORMAL` as the safe default when breaks aren't available. Static cutoffs are now only reachable when the user explicitly opts in.

## Reproduction (validated 2026-06-04)

I built `/tmp/sem-359-repro.py` running the classifier against five hand-crafted scenarios. Three produce RienduPre's exact symptom:

| Scenario | Mode | Cache | €0.30 → | Fix scope |
|---|---|---|---|---|
| A. Realistic Tibber NL | percentile | 24 entries | **expensive** (correct) | n/a |
| B. User chose `static` mode | static | 24 entries | **normal** | config issue, not a code bug |
| C. Unit mismatch (incl/excl VAT) | percentile | 24 halved | very_expensive | not RienduPre's symptom |
| **D. Cold start, empty cache** | percentile | 0 | **normal** (was via CHF fallback) | **THIS COMMIT FIXES** |
| **E. Flat day, degenerate guard** | percentile | 24 flat | **normal** (was via CHF fallback) | **THIS COMMIT FIXES** |

D + E both fall through the same code path (`_get_percentile_breaks` returns `None` → silent static fallback). On post-fix code, both correctly return `NORMAL` as the explicit safe default and never touch the CHF cutoffs.

## What changed

### `tariff/tariff_provider.py`

`_classify_price`: when `classification_mode == "percentile"` AND `_get_percentile_breaks()` returns `None`, return `PriceLevel.NORMAL` instead of falling through to static cutoffs. Comment block explains why. DEBUG log line under the `tariff/#359` tag for diagnosability.

Static cutoffs (`cheap_threshold = 0.15`, `expensive_threshold = 0.35`) remain reachable when `classification_mode == "static"` — explicit user opt-in to CHF-calibrated fixed bucketing.

### `tests/test_tariff_percentile_359.py`

- Updated 4 tests that asserted the buggy fallback as correct: they now expect `NORMAL` (`test_cold_start_returns_normal`, `test_insufficient_data_returns_normal`, `test_flat_distribution_returns_normal`, `test_near_flat_distribution_returns_normal`).
- Added `TestRienduPreRegressionFromReproScript` with 4 new tests that mirror the live repro scenarios.

### `tests/test_tariff_provider.py`

Updated 7 tests that constructed a percentile-default provider but tested static-cutoff bucketing. Pass `classification_mode="static"` explicitly so they test the intended behaviour.

### `docs/SETUP_GUIDE.md`

New "Price classification" subsection under Tariff and Pricing settings. Explains percentile vs static modes + the cold-start NORMAL behaviour, so users hitting the cold-start window on non-CHF tariffs see the documented behaviour first instead of filing #359 again.

## Tests

**2942 / 2942 pass** (was 2934, +8 from #359 regression scenarios).

## Notes for @RienduPre

Once this ships in v1.7.0-beta.16, your Tibber NL install will:

1. During the first 30-60 seconds after HA restart (before Tibber populates `prices_today`), show **`normal`** instead of an arbitrary classification based on CHF cutoffs.
2. Once Tibber has populated and we have 4+ price points, switch to **proper percentile bucketing** — €0.30 should now correctly classify as `expensive` against a typical 24h €0.13-€0.45 range.

If you ever see `normal` for a steady stretch even hours after restart, please re-open with debug logging — that'd indicate scenario B (your config has `classification_mode = static`), which is a config setting at Settings → Configure → Tariff settings → "Price classification mode".

## Release path

Lands on develop. Bundles into v1.7.0-beta.16 with PR #402 (de + nl translations).