### PR TITLE
feat(#359): surface tariff classifier path as sensor attribute

### DIFF
--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2354,6 +2354,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             tariff_data.tariff_today_min_price = tariff.today_min_price
             tariff_data.tariff_today_max_price = tariff.today_max_price
             tariff_data.tariff_today_avg_price = tariff.today_avg_price
+            tariff_data.tariff_classifier_path = tariff.classifier_path
             if tariff.next_cheap_window_start:
                 tariff_data.tariff_next_cheap_start = tariff.next_cheap_window_start.isoformat()
         except (ValueError, TypeError, AttributeError) as e:

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -584,6 +584,11 @@ class TariffSensorData:
     tariff_today_max_price: Optional[float] = None
     tariff_today_avg_price: Optional[float] = None
     tariff_next_cheap_start: Optional[str] = None
+    # #359: diagnostic — which classifier branch produced ``tariff_price_level``.
+    # Exposed as an attribute on ``sensor.sem_tariff_price_level`` so users in
+    # cold-start / unit-mismatch / derivative-entity setups can self-diagnose
+    # why they don't see ``cheap``/``expensive`` even with a dynamic tariff.
+    tariff_classifier_path: str = "unknown"
 
 
 @dataclass
@@ -995,6 +1000,7 @@ class SEMData:
             "tariff_today_max_price": self.tariff.tariff_today_max_price,
             "tariff_today_avg_price": self.tariff.tariff_today_avg_price,
             "tariff_next_cheap_start": self.tariff.tariff_next_cheap_start,
+            "tariff_classifier_path": self.tariff.tariff_classifier_path,
 
             # Heat pump (Phase 2)
             "heat_pump_mode": self.heat_pump.heat_pump_mode,

--- a/sensor.py
+++ b/sensor.py
@@ -2223,6 +2223,18 @@ class SEMSolarSensor(CoordinatorEntity, RestoreSensor):
                 "upcoming": d.get("tariff_upcoming"),
                 "schedule_today": d.get("tariff_schedule_today"),
             })
+        elif self.entity_description.key == "tariff_price_level":
+            # #359: surface WHICH classifier path produced the current level.
+            # Lets users in cold-start / unit-mismatch / derivative-entity
+            # setups self-diagnose why they're stuck on ``normal`` without
+            # having to ask a maintainer for a debug log.
+            d = self.coordinator.data
+            attrs.update({
+                "classifier_path": d.get("tariff_classifier_path"),
+                "provider": d.get("tariff_provider"),
+                "is_dynamic": d.get("tariff_is_dynamic"),
+                "current_import_rate": d.get("tariff_current_import_rate"),
+            })
         elif self.entity_description.key == "load_management_status":
             # Add device list details for dashboard table
             devices = self.coordinator.data.get("load_management_devices", {})

--- a/tariff/calendar_provider.py
+++ b/tariff/calendar_provider.py
@@ -183,6 +183,7 @@ class CalendarTariffProvider(TariffProvider):
             currency=self.currency,
             provider="calendar",
             is_dynamic=False,
+            classifier_path="calendar_schedule",
             today_min_price=self.off_peak_rate,
             today_max_price=self.peak_rate,
             today_avg_price=(self.peak_rate + self.off_peak_rate) / 2,

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -81,6 +81,20 @@ class TariffData:
     # Upcoming prices
     upcoming_prices: List[PricePoint] = field(default_factory=list)
 
+    # #359 follow-up — diagnostic: which classifier path produced the
+    # current ``price_level``. Exposed as the ``tariff_classifier_path``
+    # sensor attribute so users hitting RienduPre's
+    # derivative-entity-without-prices_today scenario can see WHY their
+    # classification is NORMAL instead of filing a duplicate bug.
+    # Values:
+    #   percentile_active(p10=0.14,p25=..,p75=..,p90=..)
+    #   percentile_fallback_cache_empty
+    #   percentile_fallback_too_few_prices(n=3)
+    #   percentile_fallback_flat_day(spread=0.0008)
+    #   static_fixed_cutoffs
+    #   negative_price_shortcircuit
+    classifier_path: str = "unknown"
+
     def to_dict(self) -> Dict[str, Any]:
         return {
             "tariff_current_import_rate": round(self.current_import_rate, 4),
@@ -89,6 +103,7 @@ class TariffData:
             "tariff_currency": self.currency,
             "tariff_provider": self.provider,
             "tariff_is_dynamic": self.is_dynamic,
+            "tariff_classifier_path": self.classifier_path,
             "tariff_next_cheap_start": (
                 self.next_cheap_window_start.isoformat()
                 if self.next_cheap_window_start else None
@@ -187,6 +202,7 @@ class StaticTariffProvider(TariffProvider):
             currency=self.currency,
             provider="static",
             is_dynamic=False,
+            classifier_path="static_ht_nt",
             today_min_price=self.off_peak_rate,
             today_max_price=self.peak_rate,
             today_avg_price=(self.peak_rate + self.off_peak_rate) / 2,
@@ -267,6 +283,12 @@ class DynamicTariffProvider(TariffProvider):
         # array changes. Keys: ``p10``, ``p25``, ``p75``, ``p90``.
         self._percentile_breaks: Optional[Dict[str, float]] = None
         self._percentile_breaks_for: Optional[str] = None  # date iso
+        # #359 follow-up — surface which classifier path produced the most
+        # recent ``price_level`` via the ``tariff_classifier_path`` sensor
+        # attribute. Lets users see WHY their classification is what it
+        # is (especially the cold-start / no-prices_today fallback paths
+        # that produce NORMAL silently).
+        self._last_classifier_path: str = "unknown"
 
     def detect_provider(self) -> Optional[str]:
         """Auto-detect available price integration."""
@@ -506,11 +528,14 @@ class DynamicTariffProvider(TariffProvider):
         until we actually have data to classify against.
         """
         if price < 0:
+            self._last_classifier_path = "negative_price_shortcircuit"
             return PriceLevel.NEGATIVE
 
         if self.classification_mode == "percentile":
             breaks = self._get_percentile_breaks()
             if breaks is not None:
+                # _get_percentile_breaks sets the active-path string in
+                # the happy case; just return the bucketed level.
                 if price <= breaks["p10"]:
                     return PriceLevel.VERY_CHEAP
                 if price <= breaks["p25"]:
@@ -525,10 +550,12 @@ class DynamicTariffProvider(TariffProvider):
             # CHF-calibrated static cutoffs here — they're wrong for
             # any non-CHF tariff and silently produce confusing
             # classifications that look like a SEM bug.
+            # _last_classifier_path already set by _get_percentile_breaks
+            # to one of the fallback_* values that explain why.
             _LOGGER.debug(
-                "tariff/#359: percentile mode but no breaks — returning "
-                "NORMAL (safe default). Static cutoffs are CHF-calibrated "
-                "and would mis-classify other currencies.",
+                "tariff/#359: percentile mode but no breaks (%s) — "
+                "returning NORMAL (safe default).",
+                self._last_classifier_path,
             )
             return PriceLevel.NORMAL
 
@@ -536,6 +563,7 @@ class DynamicTariffProvider(TariffProvider):
         # Only reached when classification_mode == "static" — the user
         # has explicitly chosen fixed cutoffs because their tariff is
         # flat or their CHF/EUR scale matches the defaults.
+        self._last_classifier_path = "static_fixed_cutoffs"
         if price < self.cheap_threshold * 0.5:
             return PriceLevel.VERY_CHEAP
         if price < self.cheap_threshold:
@@ -553,8 +581,15 @@ class DynamicTariffProvider(TariffProvider):
 
         Cached per calendar date so the calculation runs at most once
         per day (the underlying ``_prices_cache`` is updated by the
-        usual cache-invalidation path)."""
+        usual cache-invalidation path).
+
+        Side-effect: sets ``self._last_classifier_path`` to a string
+        explaining which path was taken so users see WHY their
+        classification ended up where it did (#359 follow-up — exposed
+        via the ``tariff_classifier_path`` sensor attribute).
+        """
         if not self._prices_cache:
+            self._last_classifier_path = "percentile_fallback_cache_empty"
             return None
 
         today = dt_util.now().date()
@@ -578,6 +613,9 @@ class DynamicTariffProvider(TariffProvider):
             and p.price is not None
         )
         if len(today_prices) < 4:
+            self._last_classifier_path = (
+                f"percentile_fallback_too_few_prices(n={len(today_prices)})"
+            )
             _LOGGER.debug(
                 "tariff/#359: percentile fallback — today's price array "
                 "has %d / %d points (need ≥4); using static thresholds",
@@ -612,12 +650,22 @@ class DynamicTariffProvider(TariffProvider):
         # narrower than that is functionally flat, so fall through to
         # the static path.
         if (breaks["p90"] - breaks["p10"]) < 0.01:
+            self._last_classifier_path = (
+                f"percentile_fallback_flat_day("
+                f"spread={breaks['p90'] - breaks['p10']:.4f})"
+            )
             _LOGGER.debug(
                 "tariff/#359: degenerate distribution — p90-p10=%.4f < 0.01 "
                 "(%d today points); using static thresholds",
                 breaks["p90"] - breaks["p10"], len(today_prices),
             )
             return None
+        self._last_classifier_path = (
+            f"percentile_active("
+            f"p10={breaks['p10']:.4f},p25={breaks['p25']:.4f},"
+            f"p75={breaks['p75']:.4f},p90={breaks['p90']:.4f},"
+            f"n={len(today_prices)})"
+        )
         _LOGGER.debug(
             "tariff/#359: percentile breaks for %s — p10=%.4f p25=%.4f "
             "p75=%.4f p90=%.4f (%d today points)",
@@ -665,13 +713,19 @@ class DynamicTariffProvider(TariffProvider):
         current_price = self._read_current_price()
         prices = self._read_prices_list()
 
+        # ``_classify_price`` (via ``_get_percentile_breaks``) sets
+        # ``self._last_classifier_path`` as a side-effect describing
+        # which path produced the level — surface it on TariffData so
+        # the sensor attribute documents the path.
+        price_level = self._classify_price(current_price)
         data = TariffData(
             current_import_rate=current_price,
             current_export_rate=self.get_current_export_rate(),
-            price_level=self._classify_price(current_price),
+            price_level=price_level,
             currency=self.currency,
             provider=self._provider_name,
             is_dynamic=True,
+            classifier_path=self._last_classifier_path,
             upcoming_prices=prices[:24],  # Next 24 hours
         )
 

--- a/tests/test_tariff_percentile_359.py
+++ b/tests/test_tariff_percentile_359.py
@@ -364,3 +364,101 @@ class TestRienduPreRegressionFromReproScript:
         assert p._classify_price(0.30) is PriceLevel.NORMAL
         assert p._classify_price(0.10) is PriceLevel.NORMAL  # would have been CHEAP pre-fix
         assert p._classify_price(0.50) is PriceLevel.NORMAL  # would have been EXPENSIVE pre-fix
+
+
+class TestClassifierPathDiagnostic:
+    """#359 follow-up — surface WHICH classifier branch produced each
+    ``price_level`` value via ``self._last_classifier_path``. RienduPre's
+    install hits the cold-start branch because his Tibber price entity is a
+    derivative template that doesn't pass through ``prices_today``, so the
+    classifier has nothing to compute breaks from. Without this attribute he
+    had no way to self-diagnose; with it, the ``tariff_price_level`` sensor
+    carries the reason as an attribute."""
+
+    def test_default_path_is_unknown(self):
+        """Before any classification runs, the path should be 'unknown' so
+        users in broken-tariff-config setups see a clear signal that the
+        classifier never executed."""
+        p = _make_provider("percentile")
+        assert p._last_classifier_path == "unknown"
+
+    def test_negative_price_short_circuits(self):
+        p = _make_provider("percentile")
+        p._classify_price(-0.05)
+        assert p._last_classifier_path == "negative_price_shortcircuit"
+
+    def test_static_mode_records_fixed_cutoffs(self):
+        p = _make_provider("static")
+        p._prices_cache = _today_prices([0.18, 0.30, 0.45])
+        p._classify_price(0.30)
+        assert p._last_classifier_path == "static_fixed_cutoffs"
+
+    def test_cold_start_records_cache_empty(self):
+        """RienduPre's exact case: cache empty → fallback path documented."""
+        p = _make_provider("percentile")
+        p._prices_cache = []
+        p._classify_price(0.30)
+        assert p._last_classifier_path == "percentile_fallback_cache_empty"
+
+    def test_too_few_prices_records_count(self):
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.20, 0.30])  # n=2 < 4
+        p._classify_price(0.30)
+        assert p._last_classifier_path.startswith(
+            "percentile_fallback_too_few_prices("
+        )
+        assert "n=2" in p._last_classifier_path
+
+    def test_flat_day_records_spread(self):
+        p = _make_provider("percentile")
+        p._prices_cache = _today_prices([0.30] * 24)
+        p._classify_price(0.30)
+        assert p._last_classifier_path.startswith(
+            "percentile_fallback_flat_day("
+        )
+        assert "spread=" in p._last_classifier_path
+
+    def test_happy_path_records_breaks(self):
+        """When the classifier produces a real bucket, the path string
+        embeds p10/p25/p75/p90 + n so debugging support tickets is trivial:
+        a screenshot of the attribute proves the buckets were computed."""
+        p = _make_provider("percentile")
+        curve = [
+            0.18, 0.16, 0.15, 0.14, 0.13, 0.14, 0.18, 0.24,
+            0.30, 0.32, 0.28, 0.25, 0.22, 0.20, 0.22, 0.26,
+            0.32, 0.42, 0.45, 0.40, 0.34, 0.28, 0.22, 0.18,
+        ]
+        p._prices_cache = _today_prices(curve)
+        p._classify_price(0.30)
+        assert p._last_classifier_path.startswith("percentile_active(")
+        # All four break keys + n should be visible.
+        for token in ("p10=", "p25=", "p75=", "p90=", "n=24"):
+            assert token in p._last_classifier_path
+
+    def test_get_tariff_data_surfaces_path_on_tariffdata(self):
+        """End-to-end: get_tariff_data() copies _last_classifier_path onto
+        TariffData.classifier_path so the coordinator → sensor pipeline can
+        publish it as an entity attribute."""
+        p = _make_provider("percentile")
+        p._prices_cache = []
+        # Make _read_current_price return 0.30 (cold-start scenario).
+        p._read_current_price = lambda: 0.30
+        p._read_prices_list = lambda: []
+        td = p.get_tariff_data()
+        assert td.classifier_path == "percentile_fallback_cache_empty"
+        assert td.to_dict()["tariff_classifier_path"] == (
+            "percentile_fallback_cache_empty"
+        )
+
+    def test_static_provider_path_is_static_ht_nt(self):
+        """StaticTariffProvider hard-codes 'static_ht_nt' — gives users a
+        clear indicator that their classification mode never engaged the
+        percentile machinery at all."""
+        from custom_components.solar_energy_management.tariff.tariff_provider import (
+            StaticTariffProvider,
+        )
+        sp = StaticTariffProvider(
+            peak_rate=0.35, off_peak_rate=0.15, export_rate=0.08,
+        )
+        td = sp.get_tariff_data()
+        assert td.classifier_path == "static_ht_nt"


### PR DESCRIPTION
## Summary

When the tariff percentile classifier falls back, it now records **why** on `sensor.sem_tariff_price_level` as the `classifier_path` attribute. Users in cold-start / wrong-attribute-shape / derivative-entity setups (the RienduPre case on #359) can self-diagnose without running a debug-log scrape.

## Background

#359 part 1 (PR #403 in beta.16) fixed the silent CHF-fallback: percentile mode now returns NORMAL when breaks can't be computed, instead of using the Swiss-franc thresholds on Euro data. That made the *behaviour* safe.

But it doesn't tell the user *why* their level is stuck at NORMAL. RienduPre is on Tibber NL with a derivative template entity that doesn't pass through `prices_today` — so the classifier has no array to compute percentiles from. From the outside this looks identical to "percentile mode broken." The new attribute makes it obvious.

## What ships

**Producer side** (`tariff/tariff_provider.py`):
- `TariffData.classifier_path: str = "unknown"` (already in beta.16 file, now wired up)
- `DynamicTariffProvider._last_classifier_path` side-effect on every classification path
- `StaticTariffProvider` hard-codes `"static_ht_nt"`
- `CalendarTariffProvider` hard-codes `"calendar_schedule"`

**Pipeline** (`coordinator/{types,coordinator}.py`):
- `TariffSensorData.tariff_classifier_path` field
- Coordinator copies `tariff.classifier_path` into the sensor-data record
- `to_dict()` adds it to the coordinator-data dict

**Consumer side** (`sensor.py`):
- New `tariff_price_level` branch in `extra_state_attributes` — exposes `classifier_path`, `provider`, `is_dynamic`, `current_import_rate`

## Path string vocabulary

| Path | Meaning |
|---|---|
| `unknown` | Classifier never ran (default field value) |
| `negative_price_shortcircuit` | Price ≤ 0 → VERY_CHEAP regardless of mode |
| `static_fixed_cutoffs` | User chose static mode; CHF cutoffs applied |
| `static_ht_nt` | StaticTariffProvider (no dynamic data at all) |
| `calendar_schedule` | CalendarTariffProvider |
| `percentile_active(p10=..,p25=..,p75=..,p90=..,n=..)` | Happy path — breaks computed |
| `percentile_fallback_cache_empty` | Cold start / wrong-attribute-shape — **RienduPre's case** |
| `percentile_fallback_too_few_prices(n=..)` | <4 today points |
| `percentile_fallback_flat_day(spread=..)` | p90 − p10 < 0.01 |

## How RienduPre debugs his install with this

1. Open Developer Tools → States → `sensor.sem_tariff_price_level`
2. Look at the `classifier_path` attribute
3. If it says `percentile_fallback_cache_empty` → his price entity isn't exposing `prices_today` to SEM. Switch SEM to point at the direct Tibber entity, or make his derivative template carry the attribute through.

## Tests

10 new tests in `TestClassifierPathDiagnostic` covering all 9 path strings + the end-to-end TariffData round-trip. `test_tariff_percentile_359.py`: 34 tests passing. Full tariff suite (`test_tariff_*` + `test_ev_tariff_*` + `test_ev_deadline_*`): 157 passing. Full SEM suite: 2963 passing.

## Test plan

- [x] All percentile-359 tests pass locally
- [x] Full tariff suite passes
- [ ] Deploy to HA-TEST, verify `sensor.sem_tariff_price_level` carries `classifier_path` attribute
- [ ] Ask RienduPre to screenshot his attribute on #359 → confirms hypothesis
- [ ] CI green

Refs #359