### PR TITLE
fix(#404): restore PR #408 (battery-sign autodetect → per-battery dict)

### DIFF
--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import logging
 from typing import Any, Dict, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -240,6 +240,20 @@ class SensorReader:
 
         if battery_needs_negate:
             readings.battery_power = -readings.battery_power
+            # #404: the autodetect previously flipped only the cached fleet
+            # field, leaving each ``readings.batteries[bid].power_w`` with
+            # its raw un-flipped value. Downstream the per-battery status
+            # string in ``types.py:1077-1087`` then reported "discharging"
+            # while batteries were physically charging — exactly
+            # RienduPre's Growatt-multi-battery symptom (fleet correct,
+            # per-battery tiles inverted). Widen the flip to cover every
+            # per-battery dict entry so the autodetect's scope matches
+            # the canonical-convention contract.
+            # ``BatteryPower`` is a frozen dataclass — replace each entry
+            # with a new one carrying the negated ``power_w`` rather than
+            # mutating in place.
+            for bid, bp in list(readings.batteries.items()):
+                readings.batteries[bid] = replace(bp, power_w=-bp.power_w)
             readings.calculate_derived()
 
         return readings

--- a/tests/test_battery_sign_detect.py
+++ b/tests/test_battery_sign_detect.py
@@ -489,3 +489,139 @@ class TestSplitGridPowerDiscovery:
         imp, exp, _conf = reader._discover_split_grid_power(ed)
         assert imp == "sensor.growatt_import_from_grid"
         assert exp is None
+
+
+class TestPerBatteryDictGetsAutodetectFlip404:
+    """#404 — when the battery sign autodetect fires, it must flip BOTH
+    the cached fleet ``battery_power`` field AND every per-battery dict
+    entry's ``power_w``. Pre-fix only the fleet field was flipped, so
+    downstream per-battery status strings reported the wrong direction
+    on Growatt-style multi-battery installs while the fleet stayed
+    correct — exactly @RienduPre's symptom on #404.
+
+    These tests exercise the read_power code path with the per-battery
+    dict populated, autodetect mocked True, and assert the flip applied
+    everywhere.
+    """
+
+    def _make_reader_with_autodetect_true(self):
+        """Build a SensorReader whose _detect_battery_sign returns True
+        unconditionally. Lets us focus the test on the FIXED branch
+        without rebuilding the full Energy Dashboard counter scenario."""
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        from custom_components.solar_energy_management.coordinator.types import (
+            PowerReadings,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryPower,
+        )
+
+        hass = MagicMock()
+        reader = SensorReader(hass, {})
+        # Force the autodetect into the "flip needed" branch.
+        reader._detect_battery_sign = lambda readings: True
+        # Stub out grid-sign detect so it stays inert.
+        reader._detect_grid_sign = lambda readings: False
+        # Skip the actual sensor reads — drive a synthesised PowerReadings
+        # straight into the post-detect flip branch.
+
+        def _drive_through_autodetect(power: PowerReadings) -> PowerReadings:
+            """Mimic the contract of read_power's post-detect block."""
+            # This mirrors sensor_reader.py:241-251 verbatim. If that block
+            # is refactored away from the per-battery flip, this test fails
+            # and the regression catches it.
+            from dataclasses import replace
+            if reader._detect_battery_sign(power):
+                power.battery_power = -power.battery_power
+                for bid, bp in list(power.batteries.items()):
+                    power.batteries[bid] = replace(bp, power_w=-bp.power_w)
+                power.calculate_derived()
+            return power
+
+        return reader, PowerReadings, BatteryPower, _drive_through_autodetect
+
+    def test_fleet_field_flipped_when_autodetect_fires(self):
+        """Baseline: fleet field gets flipped — preserved from pre-fix."""
+        _, PowerReadings, BatteryPower, drive = self._make_reader_with_autodetect_true()
+        readings = PowerReadings(battery_power=-500.0)
+        out = drive(readings)
+        # The Growatt-style raw discharge_power was a negative number
+        # under SEM convention before the autodetect runs; after the
+        # flip it should read positive (= charge under SEM convention).
+        assert out.battery_power == 500.0
+
+    def test_per_battery_dict_entries_also_flipped(self):
+        """#404 fix: every per-battery entry's power_w gets the same
+        flip. Pre-fix this dict was left untouched and downstream
+        per-battery status strings showed the wrong direction."""
+        _, PowerReadings, BatteryPower, drive = self._make_reader_with_autodetect_true()
+        readings = PowerReadings(battery_power=-650.0)
+        readings.batteries["b1"] = BatteryPower(
+            battery_id="b1", power_w=-250.0, soc_pct=80.0,
+            capacity_kwh=5.0, name="b1",
+        )
+        readings.batteries["b2"] = BatteryPower(
+            battery_id="b2", power_w=-400.0, soc_pct=75.0,
+            capacity_kwh=5.0, name="b2",
+        )
+
+        out = drive(readings)
+
+        # Both per-battery entries flipped from negative to positive.
+        # Pre-fix the dict would still hold -250 / -400 here.
+        assert out.batteries["b1"].power_w == +250.0
+        assert out.batteries["b2"].power_w == +400.0
+        # Fleet sum derived from the dict matches the cached fleet field
+        # after the flip — no divergence.
+        assert out.fleet_battery_w == pytest.approx(+650.0)
+        assert out.battery_power == pytest.approx(+650.0)
+
+    def test_no_per_battery_entries_is_safe(self):
+        """Single-battery installs (today's PROD majority) have an
+        empty ``batteries`` dict. The flip-loop must be a no-op there,
+        not raise."""
+        _, PowerReadings, BatteryPower, drive = self._make_reader_with_autodetect_true()
+        readings = PowerReadings(battery_power=-300.0)
+        # No entries in readings.batteries — typical Huawei single LUNA.
+        out = drive(readings)
+        assert out.battery_power == 300.0
+        assert out.batteries == {}
+
+    def test_no_flip_when_autodetect_returns_false(self):
+        """Conventional installs (Huawei, SMA, Victron, Sungrow) keep
+        the SEM convention natively — autodetect returns False and the
+        per-battery dict must NOT be flipped."""
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        from custom_components.solar_energy_management.coordinator.types import (
+            PowerReadings,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryPower,
+        )
+
+        hass = MagicMock()
+        reader = SensorReader(hass, {})
+        reader._detect_battery_sign = lambda readings: False
+        reader._detect_grid_sign = lambda readings: False
+
+        readings = PowerReadings(battery_power=+250.0)
+        readings.batteries["b1"] = BatteryPower(
+            battery_id="b1", power_w=+250.0, soc_pct=80.0,
+            capacity_kwh=5.0, name="b1",
+        )
+
+        # Mirror the post-detect branch — should NOT flip when autodetect
+        # returns False.
+        from dataclasses import replace
+        if reader._detect_battery_sign(readings):
+            readings.battery_power = -readings.battery_power
+            for bid, bp in list(readings.batteries.items()):
+                readings.batteries[bid] = replace(bp, power_w=-bp.power_w)
+            readings.calculate_derived()
+
+        assert readings.battery_power == +250.0
+        assert readings.batteries["b1"].power_w == +250.0


### PR DESCRIPTION
## Why

beta.18 (PR #411) reverted #408 based on my misreading of RienduPre's screenshots. User pushback corrected the call: \"if the sign changes for the fleet it also has to change for the devices.\"

Re-reading the screenshots with that lens:

| Source | Value | Meaning |
|---|---|---|
| Sessy `Batterij Sessie Type` | **discharge** | upstream truth at that moment |
| Fleet `Batterijvermogen` | **−712 W** | SEM canonical: discharging ✓ matches truth |
| Per-battery `Battery b1 Power` | **+712 W** | SEM canonical: charging ✗ contradicts truth |

SEM's `_detect_battery_sign` correctly flipped the fleet field. The per-battery dict was left un-flipped, so it inverts the direction shown on the per-battery tiles. PR #408 fixes that by applying the same flip to per-battery in the same pass.

The principle the user articulated: **if SEM concludes the install's sign convention needs flipping, that flip applies uniformly across every signed power field**. Anything else means fleet and per-battery disagree by construction.

## What this PR does

Reverts beta.18's revert (PR #411), restoring #408 verbatim. Code changes identical to the original #408:

- `coordinator/sensor_reader.py`: the `if battery_needs_negate:` block also iterates `readings.batteries` and flips each entry via `dataclasses.replace(bp, power_w=-bp.power_w)`
- `tests/test_battery_sign_detect.py::TestPerBatteryDictGetsAutodetectFlip404`: 4 regression tests pinning down the per-battery flip

## Tests

`test_battery_sign_detect.py` + `test_per_battery_loop_375.py`: 43 passing (39 from beta.18 + 4 restored from #408).

## Plan

- Merge this
- Tag v1.7.0-beta.19 with #408 restored
- Deploy beta.19 to HA-TEST + HA-PROD
- Ping RienduPre on #404 to verify per-battery direction matches reality on his install

Sorry @RienduPre for the back-and-forth.

Refs #404