### PR TITLE
fix(#404): per-battery sign autodetect (supersedes #408)

### DIFF
--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -72,11 +72,28 @@ class SensorReader:
         self._grid_sign_votes: int = 0  # Consecutive same-sign detections needed
         self._grid_import_baseline: Optional[float] = None
         self._grid_export_baseline: Optional[float] = None
-        self._battery_sign_inverted = False
-        self._battery_sign_detected = False
-        self._battery_sign_votes: int = 0  # Consecutive same-sign detections needed
-        self._battery_charge_baseline: Optional[float] = None
-        self._battery_discharge_baseline: Optional[float] = None
+        # Battery sign autodetect — #404: per-battery state.
+        # Multi-battery installs (≥ 2 ``battery_power_list`` entries) run
+        # the detection independently per battery using each one's own
+        # ``battery_charge_energy_list[i]`` / ``discharge_energy_list[i]``
+        # counters, so a dual-brand fleet (e.g., Sessy + Huawei) with
+        # opposite sign conventions ends up canonical for both. Each
+        # dict is keyed by the stable per-battery slug (``b1``, ``b2`` …)
+        # assigned in the read-power loop below.
+        #
+        # Single-battery / combined-sensor installs fall back to the
+        # legacy fleet-level detection using the ``ed.battery_*_energy``
+        # (singular) counters. Both code paths share the same voting +
+        # threshold heuristic — only the input scope differs.
+        self._battery_sign_inverted: Dict[str, bool] = {}
+        self._battery_sign_detected: Dict[str, bool] = {}
+        self._battery_sign_votes: Dict[str, int] = {}
+        self._battery_charge_baseline: Dict[str, Optional[float]] = {}
+        self._battery_discharge_baseline: Dict[str, Optional[float]] = {}
+        # Sentinel key for the legacy single-battery / fleet-sensor path.
+        # Keeps the per-battery and fleet paths in one data model
+        # without spreading two parallel sets of state across the class.
+        self._FLEET_BID = "__fleet__"
         # Track sensor availability transitions (#5: robustness)
         self._sensor_unavailable: set[str] = set()
         # Cache last valid SOC to avoid 0% during sensor gaps
@@ -236,11 +253,54 @@ class SensorReader:
 
         # Auto-detect battery sign convention using Energy Dashboard counters.
         # SEM convention: positive = charge, negative = discharge.
-        battery_needs_negate = self._detect_battery_sign(readings)
+        #
+        # #404: when the install has ≥ 2 per-battery power sensors AND
+        # the matching per-battery energy counters, run the detection
+        # independently per battery and rebuild the fleet sum from the
+        # corrected per-battery values — this guarantees fleet ↔ per-
+        # battery consistency by construction AND handles dual-brand
+        # fleets (e.g., Sessy + Huawei) that need different per-battery
+        # flip decisions.
+        #
+        # Single-battery / combined-sensor installs fall back to the
+        # legacy fleet-level path.
+        ed = self._energy_dashboard_config
+        per_battery_mode = (
+            ed is not None
+            and len(ed.battery_power_list) >= 2
+            and len(readings.batteries) == len(ed.battery_power_list)
+        )
 
-        if battery_needs_negate:
-            readings.battery_power = -readings.battery_power
+        if per_battery_mode:
+            from dataclasses import replace
+            corrected_total = 0.0
+            for idx, entity in enumerate(ed.battery_power_list):
+                bid = f"b{idx + 1}"
+                bp = readings.batteries.get(bid)
+                if bp is None:
+                    continue
+                charge_entity = (
+                    ed.battery_charge_energy_list[idx]
+                    if idx < len(ed.battery_charge_energy_list) else None
+                )
+                discharge_entity = (
+                    ed.battery_discharge_energy_list[idx]
+                    if idx < len(ed.battery_discharge_energy_list) else None
+                )
+                needs_negate = self._detect_battery_sign_for(
+                    bid, bp.power_w, charge_entity, discharge_entity,
+                )
+                if needs_negate:
+                    bp = replace(bp, power_w=-bp.power_w)
+                    readings.batteries[bid] = bp
+                corrected_total += bp.power_w
+            readings.battery_power = corrected_total
             readings.calculate_derived()
+        else:
+            battery_needs_negate = self._detect_battery_sign(readings)
+            if battery_needs_negate:
+                readings.battery_power = -readings.battery_power
+                readings.calculate_derived()
 
         return readings
 
@@ -351,42 +411,73 @@ class SensorReader:
 
         charge_entity = ed.battery_charge_energy
         discharge_entity = ed.battery_discharge_energy
+        return self._detect_battery_sign_for(
+            self._FLEET_BID,
+            readings.battery_power,
+            charge_entity,
+            discharge_entity,
+        )
+
+    def _detect_battery_sign_for(
+        self,
+        bid: str,
+        power: float,
+        charge_entity: Optional[str],
+        discharge_entity: Optional[str],
+    ) -> bool:
+        """Run the sign-autodetect correlation against one (battery_id,
+        power, charge_counter, discharge_counter) tuple.
+
+        Used both by the legacy fleet path (``bid = _FLEET_BID``) and by
+        the per-battery loop introduced in #404. Each ``bid`` gets its
+        own voting deque + baselines, so dual-brand multi-battery installs
+        end up with each battery independently corrected.
+
+        Returns True if ``power`` should be negated for this ``bid``.
+        """
+        # ``setdefault`` keeps the existing per-bid state stable across
+        # cycles while letting new bids appear lazily (e.g., a second
+        # battery added mid-session).
+        self._battery_sign_inverted.setdefault(bid, False)
+        self._battery_sign_detected.setdefault(bid, False)
+        self._battery_sign_votes.setdefault(bid, 0)
+        self._battery_charge_baseline.setdefault(bid, None)
+        self._battery_discharge_baseline.setdefault(bid, None)
 
         if not charge_entity or not discharge_entity:
-            return False
+            return self._battery_sign_inverted[bid]
 
         # Need meaningful power to detect (ignore noise)
-        power = readings.battery_power
         if abs(power) < 100:
-            return self._battery_sign_inverted  # Keep last known state
+            return self._battery_sign_inverted[bid]  # Keep last known state
 
         # Read energy counter values
         charge_state = self.hass.states.get(charge_entity)
         discharge_state = self.hass.states.get(discharge_entity)
 
         if not charge_state or charge_state.state in ("unknown", "unavailable"):
-            return self._battery_sign_inverted
+            return self._battery_sign_inverted[bid]
         if not discharge_state or discharge_state.state in ("unknown", "unavailable"):
-            return self._battery_sign_inverted
+            return self._battery_sign_inverted[bid]
 
         try:
             charge_val = float(charge_state.state)
             discharge_val = float(discharge_state.state)
         except (ValueError, TypeError):
-            return self._battery_sign_inverted
+            return self._battery_sign_inverted[bid]
 
         # First call: store baselines, don't correct yet
-        if self._battery_charge_baseline is None:
-            self._battery_charge_baseline = charge_val
-            self._battery_discharge_baseline = discharge_val
+        if self._battery_charge_baseline[bid] is None:
+            self._battery_charge_baseline[bid] = charge_val
+            self._battery_discharge_baseline[bid] = discharge_val
             return False
 
-        charge_delta = charge_val - self._battery_charge_baseline
-        discharge_delta = discharge_val - self._battery_discharge_baseline
+        charge_delta = charge_val - self._battery_charge_baseline[bid]
+        discharge_delta = discharge_val - self._battery_discharge_baseline[bid]
 
         # Update baselines for next cycle
-        self._battery_charge_baseline = charge_val
-        self._battery_discharge_baseline = discharge_val
+        self._battery_charge_baseline[bid] = charge_val
+        self._battery_discharge_baseline[bid] = discharge_val
 
         # Determine convention from correlation:
         # power > 0 + charge growing → SEM convention (+ = charge) → no negate
@@ -402,31 +493,32 @@ class SensorReader:
             detected = power > 0  # If power positive during discharge → negate
 
         if detected is None:
-            return self._battery_sign_inverted
+            return self._battery_sign_inverted[bid]
 
         # Require 3 consecutive consistent detections before locking in.
         # This prevents false sign flips from transient energy counter
         # jitter after reboots (e.g. both counters ticking simultaneously
         # during HA recorder settling).
-        if not self._battery_sign_detected:
-            if detected == (self._battery_sign_votes > 0):
+        if not self._battery_sign_detected[bid]:
+            if detected == (self._battery_sign_votes[bid] > 0):
                 # Same direction as previous votes (True=negate votes positive)
-                self._battery_sign_votes += 1 if detected else -1
+                self._battery_sign_votes[bid] += 1 if detected else -1
             else:
                 # Direction changed — reset
-                self._battery_sign_votes = 1 if detected else -1
+                self._battery_sign_votes[bid] = 1 if detected else -1
 
-            if abs(self._battery_sign_votes) >= 3:
-                self._battery_sign_inverted = detected
-                self._battery_sign_detected = True
+            if abs(self._battery_sign_votes[bid]) >= 3:
+                self._battery_sign_inverted[bid] = detected
+                self._battery_sign_detected[bid] = True
                 _LOGGER.info(
-                    "Battery sign detected from Energy Dashboard counters: %s "
+                    "Battery sign detected for %s from Energy Dashboard counters: %s "
                     "(power=%.0fW, charge_delta=%.3f, discharge_delta=%.3f)",
+                    bid,
                     "negating (opposite convention)" if detected else "no correction (SEM convention)",
                     power, charge_delta, discharge_delta,
                 )
 
-        return self._battery_sign_inverted
+        return self._battery_sign_inverted[bid]
 
     def _read_sensors_sum(self, entity_ids: list, name: str) -> float:
         """Sum values from multiple sensors of the same type."""

--- a/tests/test_battery_sign_detect.py
+++ b/tests/test_battery_sign_detect.py
@@ -110,8 +110,15 @@ class TestBatterySignAutoDetect:
         readings = PowerReadings(battery_power=500.0)
         result = sensor_reader._detect_battery_sign(readings)
         assert result is False
-        assert sensor_reader._battery_charge_baseline == 100.0
-        assert sensor_reader._battery_discharge_baseline == 50.0
+        # #404: state is keyed by battery_id; the fleet path uses the
+        # ``_FLEET_BID`` sentinel so legacy single-battery / combined-
+        # sensor installs still funnel through one entry.
+        assert sensor_reader._battery_charge_baseline[
+            sensor_reader._FLEET_BID
+        ] == 100.0
+        assert sensor_reader._battery_discharge_baseline[
+            sensor_reader._FLEET_BID
+        ] == 50.0
 
     def test_huawei_sem_convention_no_negate(self, sensor_reader, mock_hass):
         """Huawei Solar: positive=charge matches SEM → no negation needed.
@@ -489,3 +496,240 @@ class TestSplitGridPowerDiscovery:
         imp, exp, _conf = reader._discover_split_grid_power(ed)
         assert imp == "sensor.growatt_import_from_grid"
         assert exp is None
+
+
+def _make_multi_battery_ed(
+    battery_power_list,
+    battery_charge_energy_list,
+    battery_discharge_energy_list,
+):
+    """Build a multi-battery EnergyDashboardConfig mock for #404 tests.
+
+    Mirrors the parallel-list shape ``ha_energy_reader.py`` populates
+    when the HA Energy Dashboard has multiple battery sources configured.
+    """
+    config = Mock()
+    config.battery_power = None  # No combined sensor in multi-battery mode
+    config.battery_charge_energy = None
+    config.battery_discharge_energy = None
+    config.battery_power_list = list(battery_power_list)
+    config.battery_charge_energy_list = list(battery_charge_energy_list)
+    config.battery_discharge_energy_list = list(battery_discharge_energy_list)
+    config.solar_power = "sensor.solar_power"
+    config.solar_power_list = []
+    config.grid_power = "sensor.grid_power"
+    config.grid_power_list = []
+    config.grid_import_power = "sensor.grid_power"
+    config.grid_import_energy = "sensor.grid_import_total"
+    config.grid_export_energy = "sensor.grid_export_total"
+    config.ev_power = None
+    config.has_battery = True
+    config.has_solar = True
+    config.has_grid = True
+    config.has_ev = False
+    return config
+
+
+class TestPerBatterySignAutoDetect404:
+    """#404 — per-battery sign autodetect.
+
+    Single boolean ``_battery_sign_inverted`` doesn't work for dual-brand
+    installs (Sessy + Huawei in one fleet). The autodetect now runs
+    independently per battery, keyed by the ``b1`` / ``b2`` … slugs
+    assigned in the read-power loop. Fleet ``battery_power`` is rebuilt
+    from the corrected per-battery values — fleet ↔ per-battery agreement
+    is guaranteed by construction.
+    """
+
+    @staticmethod
+    def _make_reader_with_multi_ed(charge_vals, discharge_vals):
+        """Build a SensorReader pre-loaded with multi-battery EnergyDashboardConfig.
+
+        ``charge_vals`` / ``discharge_vals`` are lists of cumulative
+        energy counter values (kWh) — one per battery, in the same
+        order as ``battery_power_list``.
+        """
+        hass = Mock()
+        hass.states = Mock()
+        reader = SensorReader(hass, {})
+        ed = _make_multi_battery_ed(
+            battery_power_list=[f"sensor.b{i+1}_power" for i in range(len(charge_vals))],
+            battery_charge_energy_list=[f"sensor.b{i+1}_charge" for i in range(len(charge_vals))],
+            battery_discharge_energy_list=[f"sensor.b{i+1}_discharge" for i in range(len(charge_vals))],
+        )
+        reader.set_energy_dashboard_config(ed)
+        # Populate hass.states with the per-battery counters
+        states_map = {}
+        for i, (c, d) in enumerate(zip(charge_vals, discharge_vals)):
+            states_map[f"sensor.b{i+1}_charge"] = _make_sensor_state(c, "kWh")
+            states_map[f"sensor.b{i+1}_discharge"] = _make_sensor_state(d, "kWh")
+        hass.states.get = lambda eid: states_map.get(eid)
+        return reader, ed
+
+    def test_independent_per_battery_state(self):
+        """Each battery_id has its own baseline + voting state.
+
+        Two batteries see different power values and different counter
+        deltas — neither should pollute the other's state.
+        """
+        reader, _ed = self._make_reader_with_multi_ed(
+            charge_vals=[100.0, 200.0], discharge_vals=[50.0, 75.0],
+        )
+
+        # Prime baselines for both
+        reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+        reader._detect_battery_sign_for("b2", -500.0, "sensor.b2_charge", "sensor.b2_discharge")
+
+        assert reader._battery_charge_baseline["b1"] == 100.0
+        assert reader._battery_charge_baseline["b2"] == 200.0
+        assert reader._battery_discharge_baseline["b1"] == 50.0
+        assert reader._battery_discharge_baseline["b2"] == 75.0
+        # Each starts fresh — neither flipped on the first call.
+        assert reader._battery_sign_inverted["b1"] is False
+        assert reader._battery_sign_inverted["b2"] is False
+
+    def test_dual_brand_one_flipped_one_not(self):
+        """Battery 1 reports opposite convention (Sessy-shape: positive
+        during discharge → needs flip). Battery 2 reports canonical
+        (Huawei-shape: positive during charge → no flip).
+
+        After 3 consecutive correlation votes per battery, only b1's
+        ``_battery_sign_inverted`` flag flips. b2 stays at False.
+        """
+        reader, _ed = self._make_reader_with_multi_ed(
+            charge_vals=[100.0, 200.0], discharge_vals=[50.0, 75.0],
+        )
+        hass = reader.hass
+
+        # 4 cycles: each cycle advances both batteries' counters in
+        # opposite directions relative to their reported power.
+        for cycle in range(4):
+            states_map = {
+                "sensor.b1_charge": _make_sensor_state(100.0 + cycle * 0.0000001, "kWh"),
+                # b1 discharge counter growing while power is POSITIVE → opposite convention → flip
+                "sensor.b1_discharge": _make_sensor_state(50.0 + (cycle + 1) * 0.5, "kWh"),
+                # b2 charge counter growing while power is POSITIVE → canonical → no flip
+                "sensor.b2_charge": _make_sensor_state(200.0 + (cycle + 1) * 0.5, "kWh"),
+                "sensor.b2_discharge": _make_sensor_state(75.0 + cycle * 0.0000001, "kWh"),
+            }
+            hass.states.get = lambda eid, _m=states_map: _m.get(eid)
+            reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+            reader._detect_battery_sign_for("b2", 500.0, "sensor.b2_charge", "sensor.b2_discharge")
+
+        assert reader._battery_sign_inverted["b1"] is True, (
+            "b1 (Sessy-shape: positive during discharge) should be flipped"
+        )
+        assert reader._battery_sign_inverted["b2"] is False, (
+            "b2 (Huawei-shape: positive during charge) should NOT be flipped"
+        )
+
+    def test_both_invert_both_canonical_after_correction(self):
+        """RienduPre's actual install: both batteries Sessy-shape, both
+        need flipping. After autodetect locks in, both per-battery
+        entries report the canonical SEM sign for the user-visible direction.
+        """
+        reader, _ed = self._make_reader_with_multi_ed(
+            charge_vals=[100.0, 200.0], discharge_vals=[50.0, 75.0],
+        )
+        hass = reader.hass
+
+        for cycle in range(4):
+            states_map = {
+                "sensor.b1_charge": _make_sensor_state(100.0 + cycle * 0.0000001, "kWh"),
+                "sensor.b1_discharge": _make_sensor_state(50.0 + (cycle + 1) * 0.4, "kWh"),
+                "sensor.b2_charge": _make_sensor_state(200.0 + cycle * 0.0000001, "kWh"),
+                "sensor.b2_discharge": _make_sensor_state(75.0 + (cycle + 1) * 0.3, "kWh"),
+            }
+            hass.states.get = lambda eid, _m=states_map: _m.get(eid)
+            # Both report POSITIVE power while their discharge counter
+            # is growing → Sessy-shape → autodetect votes "flip".
+            reader._detect_battery_sign_for("b1", 712.0, "sensor.b1_charge", "sensor.b1_discharge")
+            reader._detect_battery_sign_for("b2", 300.0, "sensor.b2_charge", "sensor.b2_discharge")
+
+        assert reader._battery_sign_inverted["b1"] is True
+        assert reader._battery_sign_inverted["b2"] is True
+
+    def test_neither_inverts_canonical_baseline(self):
+        """Two canonical batteries (Huawei-shape): neither flips."""
+        reader, _ed = self._make_reader_with_multi_ed(
+            charge_vals=[100.0, 200.0], discharge_vals=[50.0, 75.0],
+        )
+        hass = reader.hass
+
+        for cycle in range(4):
+            states_map = {
+                "sensor.b1_charge": _make_sensor_state(100.0 + (cycle + 1) * 0.5, "kWh"),
+                "sensor.b1_discharge": _make_sensor_state(50.0 + cycle * 0.0000001, "kWh"),
+                "sensor.b2_charge": _make_sensor_state(200.0 + (cycle + 1) * 0.4, "kWh"),
+                "sensor.b2_discharge": _make_sensor_state(75.0 + cycle * 0.0000001, "kWh"),
+            }
+            hass.states.get = lambda eid, _m=states_map: _m.get(eid)
+            reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+            reader._detect_battery_sign_for("b2", 400.0, "sensor.b2_charge", "sensor.b2_discharge")
+
+        assert reader._battery_sign_inverted["b1"] is False
+        assert reader._battery_sign_inverted["b2"] is False
+
+    def test_fallback_when_per_battery_counters_missing(self):
+        """If a battery is missing its energy counters (user didn't
+        configure them in the Energy Dashboard), per-battery autodetect
+        returns the stored default (False) for that battery — no crash.
+        """
+        reader = SensorReader(Mock(states=Mock()), {})
+        # No charge/discharge entities provided
+        result = reader._detect_battery_sign_for("b1", 500.0, None, None)
+        assert result is False
+        # State entry created lazily so subsequent calls work
+        assert reader._battery_sign_inverted["b1"] is False
+
+    def test_voting_threshold_prevents_premature_flip(self):
+        """One-off readings don't flip a battery's sign — need 3
+        consecutive votes per battery (heuristic carried over from the
+        fleet-level autodetect).
+        """
+        reader, _ed = self._make_reader_with_multi_ed(
+            charge_vals=[100.0], discharge_vals=[50.0],
+        )
+        hass = reader.hass
+
+        # Cycle 1: prime baseline.
+        reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+
+        # Cycle 2: one Sessy-shape vote. NOT enough.
+        states = {
+            "sensor.b1_charge": _make_sensor_state(100.0000001, "kWh"),
+            "sensor.b1_discharge": _make_sensor_state(50.5, "kWh"),
+        }
+        hass.states.get = lambda eid, _m=states: _m.get(eid)
+        reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+        assert reader._battery_sign_inverted["b1"] is False, (
+            "single vote should not flip"
+        )
+
+        # Cycles 3-4: two more Sessy-shape votes → 3 total → locks in.
+        for cycle in range(2):
+            states = {
+                "sensor.b1_charge": _make_sensor_state(100.0000001 + cycle * 0.0000001, "kWh"),
+                "sensor.b1_discharge": _make_sensor_state(50.5 + (cycle + 1) * 0.5, "kWh"),
+            }
+            hass.states.get = lambda eid, _m=states: _m.get(eid)
+            reader._detect_battery_sign_for("b1", 500.0, "sensor.b1_charge", "sensor.b1_discharge")
+
+        assert reader._battery_sign_inverted["b1"] is True
+        assert reader._battery_sign_detected["b1"] is True
+
+    def test_fleet_sentinel_separate_from_per_battery_state(self):
+        """Legacy single-battery installs use ``_FLEET_BID`` as the key
+        and stay isolated from per-battery state — switching modes
+        doesn't cross-contaminate.
+        """
+        reader = SensorReader(Mock(states=Mock()), {})
+        # Prime fleet path
+        reader._detect_battery_sign_for("b1", 500.0, None, None)
+        reader._detect_battery_sign_for(reader._FLEET_BID, 500.0, None, None)
+        assert reader._battery_sign_inverted["b1"] == reader._battery_sign_inverted[
+            reader._FLEET_BID
+        ] == False
+        # The dicts have separate entries
+        assert "b1" in reader._battery_sign_inverted
+        assert reader._FLEET_BID in reader._battery_sign_inverted

--- a/tests/test_split_grid_integration.py
+++ b/tests/test_split_grid_integration.py
@@ -560,8 +560,10 @@ class TestAlphaESSCombined:
 
         reader = _make_reader_with_states(hass, states, ed)
         # Pattern C: grid +=export (same as SEM), battery +=discharge (opposite of SEM)
-        reader._battery_sign_inverted = True
-        reader._battery_sign_detected = True
+        # #404: state is per-battery-id keyed. Fleet/single-battery
+        # path uses the ``_FLEET_BID`` sentinel.
+        reader._battery_sign_inverted = {reader._FLEET_BID: True}
+        reader._battery_sign_detected = {reader._FLEET_BID: True}
         power = reader.read_power()
         power.calculate_derived()
 
@@ -653,9 +655,10 @@ class TestRCTPowerCombined:
         reader = _make_reader_with_states(hass, states, ed)
         # Pattern B: grid +=import, battery +=discharge — both opposite of SEM
         reader._grid_sign_inverted = True
-        reader._battery_sign_inverted = True
+        # #404: state is per-battery-id keyed. Fleet path uses ``_FLEET_BID``.
+        reader._battery_sign_inverted = {reader._FLEET_BID: True}
         reader._grid_sign_detected = True
-        reader._battery_sign_detected = True
+        reader._battery_sign_detected = {reader._FLEET_BID: True}
         power = reader.read_power()
         power.calculate_derived()
 
@@ -979,9 +982,10 @@ class TestCombinedGridSensor:
         reader = _make_reader_with_states(hass, states, ed)
         # Simulate sign correction (normally done by auto-detect over multiple cycles)
         reader._grid_sign_inverted = True
-        reader._battery_sign_inverted = True
+        # #404: state is per-battery-id keyed. Fleet path uses ``_FLEET_BID``.
+        reader._battery_sign_inverted = {reader._FLEET_BID: True}
         reader._grid_sign_detected = True
-        reader._battery_sign_detected = True
+        reader._battery_sign_detected = {reader._FLEET_BID: True}
         power = reader.read_power()
         power.calculate_derived()
 
@@ -1006,8 +1010,10 @@ class TestCombinedGridSensor:
             "sensor.battery_power": _state(800),    # +800W discharge (opposite)
         }
         reader = _make_reader_with_states(hass, states, ed)
-        reader._battery_sign_inverted = True
-        reader._battery_sign_detected = True
+        # #404: state is per-battery-id keyed. Fleet/single-battery
+        # path uses the ``_FLEET_BID`` sentinel.
+        reader._battery_sign_inverted = {reader._FLEET_BID: True}
+        reader._battery_sign_detected = {reader._FLEET_BID: True}
         power = reader.read_power()
         power.calculate_derived()
 


### PR DESCRIPTION
## Why

PR #408 (which we shipped briefly in beta.17, then reverted in beta.18) widened the **fleet-level** sign-autodetect decision to every per-battery dict entry under a single boolean. That works for the common case (one brand, one convention) but **breaks the dual-brand case**: one boolean can only represent one flip direction, so flipping it correctly for battery 1 wrongly flips battery 2.

User pushback nailed it: *"will this even work if a user has two different batteries — or just give a button to switch the direction on each battery?"*

## What this PR does

Replaces the single fleet correlation with N per-battery correlations. Reuses the existing voting/threshold heuristic — just keys everything by `battery_id`.

**When ≥ 2 per-battery power sensors are configured** (`ed.battery_power_list` has > 1 entry):
- Each battery autodetects independently using its own `battery_charge_energy_list[i]` / `discharge_energy_list[i]` counters — data `ha_energy_reader.py` already populates but `sensor_reader.py` was ignoring.
- Fleet `readings.battery_power` is rebuilt as `Σ(corrected per-battery)`.
- Fleet ↔ per-battery agreement is guaranteed by construction.

**When ≤ 1 per-battery sensor** (legacy / combined-sensor installs):
- Falls back to fleet-level autodetect via the `_FLEET_BID` sentinel key.
- Behaviour identical to today's single-battery path.

The fleet is **never** autodetected separately when per-battery data exists — it's *computed* from the corrected per-battery values, not *detected* on its own. Avoids the double-counting concern raised during planning.

## State model

Replaces single scalars with `Dict[str, ...]` keyed by battery_id:

| Before | After |
|---|---|
| `self._battery_sign_inverted: bool` | `Dict[str, bool]` |
| `self._battery_sign_detected: bool` | `Dict[str, bool]` |
| `self._battery_sign_votes: int` | `Dict[str, int]` |
| `self._battery_charge_baseline: Optional[float]` | `Dict[str, Optional[float]]` |
| `self._battery_discharge_baseline: Optional[float]` | `Dict[str, Optional[float]]` |

Single-battery / fleet-sensor installs use the `_FLEET_BID = "__fleet__"` sentinel — one entry in each dict, equivalent to today's scalar behavior.

## Tests

`TestPerBatterySignAutoDetect404` adds 7 tests:

1. **Independent per-battery state** — baselines/votes don't cross-pollute
2. **Dual-brand asymmetric flip** — b1 (Sessy-shape) flips, b2 (Huawei-shape) doesn't
3. **Both invert** — RienduPre's actual case
4. **Neither inverts** — canonical baseline
5. **Fallback** — missing per-battery counters returns False, no crash
6. **Voting threshold** — 3 consecutive votes still required per battery
7. **Fleet/per-battery isolation** — `_FLEET_BID` entry is separate from `b1` entry

Plus updates to 4 monkeypatches in `test_split_grid_integration.py` to use the dict shape.

Full suite: **2966 passing locally** (15 skipped unrelated).

## Plan

- Merge this
- Tag v1.7.0-beta.19
- Deploy to HA-TEST + validate
- Deploy to HA-PROD
- Ping @RienduPre on #404 with the beta.19 link

## What this PR does NOT do

- Does not add a per-battery user override toggle (autodetect handles the dual-brand case on its own when per-battery energy counters are configured; a UI toggle stays as a future option if autodetect false-positives ever surface).
- Does not touch PR #409 (temperature-hide) or PR #410 (#359 classifier_path) — both unaffected.

Closes #404