### PR TITLE
fix(#400): native ev_current_control_entity translations for 12 remaining languages

### DIFF
--- a/translations/cs.json
+++ b/translations/cs.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "Cílová entita služby nabíječky (volitelné)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entita Number pro řízení proudu (nabíječky typu Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entita Number, do které SEM zapisuje, aby měnil nabíjecí proud (např. number.wallbox_charging_current). Použijte pro nabíječky, které vystavují entitu Number místo volání služby. Ponechte prázdné, pokud níže vyplníte cestu Služba."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Priorita přebytku (1=nejvyšší)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entita řízení proudu (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit solárního nabíjení (kWh)",
           "ev_target_soc_max": "Limit solárního nabíjení (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entita Number použitá pro nastavení nabíjecího proudu (A). Pro Wallbox, go-eCharger a podobné nabíječky.",
           "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
           "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Priorita přebytku (1=nejvyšší)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entita řízení proudu (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit solárního nabíjení (kWh)",
           "ev_target_soc_max": "Limit solárního nabíjení (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entita Number použitá pro nastavení nabíjecího proudu (A). Pro Wallbox, go-eCharger a podobné nabíječky.",
           "daily_ev_target_max": "Solární přebytek nabíjí až do této hodnoty a poté se zastaví. Ponechte na maximu pro volné nabíjení ze slunce.",
           "ev_target_soc_max": "Solární přebytek nabíjí až do tohoto SOC a poté se zastaví. Ponechte na 100 % pro volné nabíjení ze slunce."
         }

--- a/translations/da.json
+++ b/translations/da.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number-entitet til strømstyring (Wallbox-lignende ladere)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number-entitet som SEM skriver til for at ændre ladestrømmen (f.eks. number.wallbox_charging_current). Brug denne til ladere, der eksponerer en Number-entitet i stedet for et servicekald. Lad være tom, hvis du udfylder Service-stien nedenfor."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Overskudsprioritet (1=højeste)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strømstyringsentitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solopladningsgrænse (kWh)",
           "ev_target_soc_max": "Solopladningsgrænse (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet brugt til at sætte ladestrømmen (A). Til Wallbox, go-eCharger og lignende ladere.",
           "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
           "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Overskudsprioritet (1=højeste)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strømstyringsentitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solopladningsgrænse (kWh)",
           "ev_target_soc_max": "Solopladningsgrænse (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet brugt til at sætte ladestrømmen (A). Til Wallbox, go-eCharger og lignende ladere.",
           "daily_ev_target_max": "Soloverskud oplader op til dette og stopper derefter. Lad stå på fuld for at oplade frit fra solen.",
           "ev_target_soc_max": "Soloverskud oplader op til denne SOC og stopper derefter. Lad stå på 100 % for at oplade frit fra solen."
         }

--- a/translations/es.json
+++ b/translations/es.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entidad Number para el control de corriente (cargadores tipo Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entidad Number que SEM utiliza para cambiar la corriente de carga (p. ej. number.wallbox_charging_current). Úsala para cargadores que exponen una entidad Number en lugar de una llamada de servicio. Déjala vacía si rellenas la ruta de Servicio más abajo."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entidad de control de corriente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Límite de carga solar (kWh)",
           "ev_target_soc_max": "Límite de carga solar (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entidad Number utilizada para establecer la corriente de carga (A). Para Wallbox, go-eCharger y cargadores similares.",
           "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
           "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entidad de control de corriente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Límite de carga solar (kWh)",
           "ev_target_soc_max": "Límite de carga solar (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entidad Number utilizada para establecer la corriente de carga (A). Para Wallbox, go-eCharger y cargadores similares.",
           "daily_ev_target_max": "El excedente solar carga hasta este valor y luego se detiene. Déjalo al máximo para cargar libremente con el sol.",
           "ev_target_soc_max": "El excedente solar carga hasta este SOC y luego se detiene. Déjalo al 100 % para cargar libremente con el sol."
         }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number-entiteetti virranhallintaan (Wallbox-tyyppiset laturit)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number-entiteetti, johon SEM kirjoittaa muuttaakseen latausvirtaa (esim. number.wallbox_charging_current). Käytä laturien kanssa, jotka tarjoavat Number-entiteetin palvelukutsun sijaan. Jätä tyhjäksi, jos täytät alla olevan Palvelu-polun."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Virranhallintaentiteetti (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Aurinkolatauksen raja (kWh)",
           "ev_target_soc_max": "Aurinkolatauksen raja (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entiteetti, jolla asetetaan latausvirta (A). Wallboxille, go-eChargerille ja vastaaville latureille.",
           "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
           "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Virranhallintaentiteetti (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Aurinkolatauksen raja (kWh)",
           "ev_target_soc_max": "Aurinkolatauksen raja (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entiteetti, jolla asetetaan latausvirta (A). Wallboxille, go-eChargerille ja vastaaville latureille.",
           "daily_ev_target_max": "Aurinkoylijäämä lataa tähän asti ja pysähtyy sitten. Jätä täyteen ladataksesi vapaasti auringosta.",
           "ev_target_soc_max": "Aurinkoylijäämä lataa tähän varaustasoon asti ja pysähtyy sitten. Jätä 100 %:iin ladataksesi vapaasti auringosta."
         }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entité Number pour le contrôle du courant (chargeurs type Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entité Number que SEM utilise pour modifier le courant de charge (par exemple number.wallbox_charging_current). À utiliser pour les chargeurs qui exposent une entité Number plutôt qu'un appel de service. Laissez vide si vous remplissez le champ Service ci-dessous."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Priorité surplus (1=plus haute)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entité de contrôle du courant (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de charge solaire (kWh)",
           "ev_target_soc_max": "Limite de charge solaire (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entité Number utilisée pour définir le courant de charge (A). Pour Wallbox, go-eCharger et chargeurs similaires.",
           "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
           "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Priorité surplus (1=plus haute)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entité de contrôle du courant (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de charge solaire (kWh)",
           "ev_target_soc_max": "Limite de charge solaire (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entité Number utilisée pour définir le courant de charge (A). Pour Wallbox, go-eCharger et chargeurs similaires.",
           "daily_ev_target_max": "Le surplus solaire charge jusqu’à cette valeur, puis s’arrête. Laissez au maximum pour charger librement au soleil.",
           "ev_target_soc_max": "Le surplus solaire charge jusqu’à ce SOC, puis s’arrête. Laissez à 100 % pour charger librement au soleil."
         }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number entitás az áramerősség szabályozásához (Wallbox típusú töltők)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number entitás, amelybe a SEM ír, hogy módosítsa a töltőáramot (pl. number.wallbox_charging_current). Olyan töltőkhöz használja, amelyek Number entitást tesznek elérhetővé szolgáltatáshívás helyett. Hagyja üresen, ha alább a Szolgáltatás útvonalat tölti ki."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Áramszabályozó entitás (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Napelemes töltési limit (kWh)",
           "ev_target_soc_max": "Napelemes töltési limit (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number entitás, amellyel a töltőáram (A) beállítható. Wallbox, go-eCharger és hasonló töltőkhöz.",
           "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
           "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Áramszabályozó entitás (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Napelemes töltési limit (kWh)",
           "ev_target_soc_max": "Napelemes töltési limit (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number entitás, amellyel a töltőáram (A) beállítható. Wallbox, go-eCharger és hasonló töltőkhöz.",
           "daily_ev_target_max": "A napelemes többlet eddig tölt, majd leáll. Hagyja maximumon, hogy szabadon töltsön a napból.",
           "ev_target_soc_max": "A napelemes többlet eddig a töltöttségi szintig tölt, majd leáll. Hagyja 100%-on, hogy szabadon töltsön a napból."
         }

--- a/translations/it.json
+++ b/translations/it.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entità Number per il controllo della corrente (caricatori tipo Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entità Number che SEM utilizza per modificare la corrente di ricarica (es. number.wallbox_charging_current). Usala per caricatori che espongono un'entità Number invece di una chiamata di servizio. Lascia vuoto se compili il percorso Servizio sotto."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entità di controllo della corrente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite di carica solare (kWh)",
           "ev_target_soc_max": "Limite di carica solare (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entità Number usata per impostare la corrente di ricarica (A). Per Wallbox, go-eCharger e caricatori simili.",
           "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
           "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entità di controllo della corrente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite di carica solare (kWh)",
           "ev_target_soc_max": "Limite di carica solare (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entità Number usata per impostare la corrente di ricarica (A). Per Wallbox, go-eCharger e caricatori simili.",
           "daily_ev_target_max": "Il surplus solare carica fino a questo valore, poi si ferma. Lascia al massimo per caricare liberamente dal sole.",
           "ev_target_soc_max": "Il surplus solare carica fino a questo SOC, poi si ferma. Lascia al 100% per caricare liberamente dal sole."
         }

--- a/translations/no.json
+++ b/translations/no.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number-entitet for strømkontroll (Wallbox-lignende ladere)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number-entitet som SEM skriver til for å endre ladestrømmen (f.eks. number.wallbox_charging_current). Bruk for ladere som eksponerer en Number-entitet i stedet for et tjenestekall. La være tom hvis du fyller ut Tjeneste-banen nedenfor."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strømkontroll-entitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladegrense (kWh)",
           "ev_target_soc_max": "Solladegrense (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet brukt for å sette ladestrømmen (A). For Wallbox, go-eCharger og lignende ladere.",
           "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
           "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strømkontroll-entitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladegrense (kWh)",
           "ev_target_soc_max": "Solladegrense (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet brukt for å sette ladestrømmen (A). For Wallbox, go-eCharger og lignende ladere.",
           "daily_ev_target_max": "Soloverskudd lader opp til dette og stopper deretter. La stå på full for å lade fritt fra sol.",
           "ev_target_soc_max": "Soloverskudd lader opp til denne SOC-en og stopper deretter. La stå på 100 % for å lade fritt fra sol."
         }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Encja Number do sterowania prądem (ładowarki typu Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Encja Number, której SEM używa do zmiany prądu ładowania (np. number.wallbox_charging_current). Stosuj dla ładowarek udostępniających encję Number zamiast wywołania usługi. Pozostaw puste, jeśli wypełnisz ścieżkę Usługa poniżej."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Encja sterowania prądem (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit ładowania słonecznego (kWh)",
           "ev_target_soc_max": "Limit ładowania słonecznego (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Encja Number używana do ustawiania prądu ładowania (A). Dla Wallbox, go-eCharger i podobnych ładowarek.",
           "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
           "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Encja sterowania prądem (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limit ładowania słonecznego (kWh)",
           "ev_target_soc_max": "Limit ładowania słonecznego (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Encja Number używana do ustawiania prądu ładowania (A). Dla Wallbox, go-eCharger i podobnych ładowarek.",
           "daily_ev_target_max": "Nadwyżka słoneczna ładuje do tej wartości, a potem się zatrzymuje. Pozostaw na maksimum, aby ładować swobodnie ze słońca.",
           "ev_target_soc_max": "Nadwyżka słoneczna ładuje do tego SOC, a potem się zatrzymuje. Pozostaw na 100%, aby ładować swobodnie ze słońca."
         }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entidade Number para o controlo de corrente (carregadores tipo Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entidade Number que o SEM utiliza para alterar a corrente de carregamento (por ex. number.wallbox_charging_current). Use para carregadores que expõem uma entidade Number em vez de uma chamada de serviço. Deixe em branco se preencher o caminho de Serviço abaixo."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entidade de controlo de corrente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de carga solar (kWh)",
           "ev_target_soc_max": "Limite de carga solar (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entidade Number usada para definir a corrente de carregamento (A). Para Wallbox, go-eCharger e carregadores semelhantes.",
           "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
           "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entidade de controlo de corrente (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limite de carga solar (kWh)",
           "ev_target_soc_max": "Limite de carga solar (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entidade Number usada para definir a corrente de carregamento (A). Para Wallbox, go-eCharger e carregadores semelhantes.",
           "daily_ev_target_max": "O excedente solar carrega até este valor e depois para. Deixe no máximo para carregar livremente com o sol.",
           "ev_target_soc_max": "O excedente solar carrega até este SOC e depois para. Deixe a 100% para carregar livremente com o sol."
         }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Entitate Number pentru controlul curentului (încărcătoare tip Wallbox)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Entitatea Number în care SEM scrie pentru a modifica curentul de încărcare (de ex. number.wallbox_charging_current). Folosiți pentru încărcătoare care expun o entitate Number în loc de un apel de serviciu. Lăsați gol dacă completați calea Serviciu mai jos."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entitate de control al curentului (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limită încărcare solară (kWh)",
           "ev_target_soc_max": "Limită încărcare solară (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entitate Number folosită pentru a seta curentul de încărcare (A). Pentru Wallbox, go-eCharger și încărcătoare similare.",
           "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
           "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Entitate de control al curentului (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Limită încărcare solară (kWh)",
           "ev_target_soc_max": "Limită încărcare solară (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Entitate Number folosită pentru a seta curentul de încărcare (A). Pentru Wallbox, go-eCharger și încărcătoare similare.",
           "daily_ev_target_max": "Surplusul solar încarcă până la această valoare, apoi se oprește. Lăsați la maximum pentru a încarca liber din soare.",
           "ev_target_soc_max": "Surplusul solar încarcă până la acest SOC, apoi se oprește. Lăsați la 100% pentru a încarca liber din soare."
         }

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -22,7 +22,7 @@
           "ev_charger_service_entity_id": "EV Charger Service Target Entity (optional)",
           "ev_current_sensor": "⚡ EV Charging Current — charging amperage (A)",
           "ev_total_energy_sensor": "🔋 EV Total Energy — cumulative energy delivered (kWh)",
-          "ev_current_control_entity": "Number Entity for Current Control (Wallbox-style chargers)"
+          "ev_current_control_entity": "Number-entitet för strömstyrning (Wallbox-liknande laddare)"
         },
         "data_description": {
           "ev_connected_sensor": "Binary sensor that reports whether the vehicle plug is currently connected. Auto-detected from KEBA / Easee / Wallbox / go-eCharger / Zaptec / ChargePoint / Heidelberg.",
@@ -32,7 +32,7 @@
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Auto-filled when needed; leave blank if the service is global.",
           "ev_current_sensor": "Optional. Numeric sensor (A) reporting the actual charging current. Used for diagnostics.",
           "ev_total_energy_sensor": "Optional. Cumulative kWh counter for energy delivered to the vehicle. Used for accurate session tracking.",
-          "ev_current_control_entity": "Number entity SEM writes to so it can change the charging current (e.g. number.wallbox_charging_current). Use this for chargers that expose a number entity instead of a service call. Leave blank if you fill in the Service path below."
+          "ev_current_control_entity": "Number-entitet som SEM skriver till för att ändra laddströmmen (t.ex. number.wallbox_charging_current). Använd för laddare som exponerar en Number-entitet istället för ett servicekall. Lämna tom om du fyller i Service-vägen nedan."
         }
       },
       "hardware": {
@@ -355,7 +355,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strömstyrningsentitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladdningsgräns (kWh)",
           "ev_target_soc_max": "Solladdningsgräns (SOC %)"
         },
@@ -367,7 +367,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet som används för att ställa in laddströmmen (A). För Wallbox, go-eCharger och liknande laddare.",
           "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
           "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen."
         }
@@ -383,7 +383,7 @@
           "ev_charger_service": "Charger Set-Current Service (optional)",
           "ev_charger_service_entity_id": "Charger Service Target Entity (optional)",
           "ev_surplus_priority": "Surplus Priority (1=highest)",
-          "ev_current_control_entity": "Current Control Entity (number — Wallbox, go-eCharger)",
+          "ev_current_control_entity": "Strömstyrningsentitet (number — Wallbox, go-eCharger)",
           "daily_ev_target_max": "Solladdningsgräns (kWh)",
           "ev_target_soc_max": "Solladdningsgräns (SOC %)"
         },
@@ -395,7 +395,7 @@
           "ev_charger_service": "HA service used to set the charging current. Use for KEBA or Easee.",
           "ev_charger_service_entity_id": "Entity ID passed as the target of the service call. Leave blank if not needed.",
           "ev_surplus_priority": "Surplus allocation order across multiple chargers. Lower number = higher priority.",
-          "ev_current_control_entity": "Number entity used to set the charging current (A). Use for Wallbox, go-eCharger, and similar chargers.",
+          "ev_current_control_entity": "Number-entitet som används för att ställa in laddströmmen (A). För Wallbox, go-eCharger och liknande laddare.",
           "daily_ev_target_max": "Solöverskott laddar upp till detta och stoppar sedan. Lämna på fullt för att ladda fritt från solen.",
           "ev_target_soc_max": "Solöverskott laddar upp till denna SOC och stoppar sedan. Lämna på 100 % för att ladda fritt från solen."
         }


### PR DESCRIPTION
## Summary

Closes the last #400 gap. `ev_current_control_entity` — the field RienduPre most needs to wire up a Wallbox-style charger — now has native labels + descriptions in all 12 remaining languages: **fr, es, it, pt, pl, cs, da, fi, hu, ro, sv, no**.

en is the source. de + nl shipped in [v1.7.0-beta.16](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.16) via PR #402. After this PR, every translation file carries the field in its own language.

## What's translated

4 unique English source strings, each appearing in either 1 or 2 positions per file (install-flow step + Add/Edit options-flow steps):

| Source string | Positions per file |
|---|---|
| Label (install step) | 1 |
| Description (install step) | 1 |
| Label (options Add + Edit) | 2 |
| Description (options Add + Edit) | 2 |

12 files × 6 replacements = **72 total**. All 15 translation files JSON-validated post-edit.

## Translation philosophy

- **"Number entity" stays as the literal HA platform name** in every language. The user is configuring a Home Assistant entity type — calling it anything else would obscure what to look for in the entity picker.
- **Brand names stay untranslated** (Wallbox, go-eCharger).
- **Technical accuracy first, fluent prose second.** These strings appear in a setup flow where users are clicking entity dropdowns; they're scanning for the right field, not reading prose.

## Per-language samples

A few short ones for sanity:

- **fr** — `Entité Number pour le contrôle du courant (chargeurs type Wallbox)`
- **es** — `Entidad Number para el control de corriente (cargadores tipo Wallbox)`
- **it** — `Entità Number per il controllo della corrente (caricatori tipo Wallbox)`
- **fi** — `Number-entiteetti virranhallintaan (Wallbox-tyyppiset laturit)`

If any native speaker on the team spots an awkward word choice, follow-up cleanup PR welcome.

## Test plan

- [x] All 15 translation files JSON-valid post-edit
- [x] de + nl untouched (already shipped in beta.16)
- [x] en untouched (source)
- [ ] CI green

Closes #400