### PR TITLE
Release v1.7.1.1 — orphan-resource patch (#448)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [1.7.1.1] - 07.06.2026
+
+## 🩹 Patch Release
+
+_Single-fix patch on top of [1.7.1](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1)._
+
+### 🐛 Fix: raw `config_*` translation keys after upgrade to 1.7.1 (#448)
+
+Reported by @RienduPre + reproduced on the maintainer's install: after upgrading to 1.7.1 stable the Configuration tab + dashboard labels showed as raw translation keys (e.g. `config_section_overview`, `config_diagnose`, `heat_pump_title`) even though every key was present in the deployed `sem-localize.js`.
+
+**Root cause.** The Lovelace resources storage carried an orphan entry pinning `sem-localize.js?v=1.7.1-beta.11-fca70f78` from an older registration path. Nothing in the current code touched it (the file is correctly served via `add_extra_js_url` — the right channel for non-card helper JS that must be global before cards load). The browser's service worker happily kept serving the cached beta.11 file, missing every key added since.
+
+**Fix.** Added `sem-localize.js` to the existing `_legacy_bases` cleanup list in `__init__.py:_async_register_frontend_resources`. On first entry setup after the patch the existing delete-orphan loop removes the stale Lovelace resource; `add_extra_js_url` remains the single registration channel; the content-hash now bumps correctly on every deploy.
+
+Verified on HA-TEST + HA-PROD: after deploy the only SEM Lovelace resources are `sem-cards.js?v=1.7.2-beta.1-…` and `sem-system-diagram-card.js?v=1.7.2-beta.1-…`. The orphan `sem-localize.js` entry is gone.
+
+Users still need one hard refresh (or Companion app → App Configuration → Reset frontend cache) after upgrading to clear the service worker's cached copy. After that single refresh, every subsequent deploy busts the cache automatically via the content-hash.
+
 # [1.7.1] - 07.06.2026
 
 ## 🎉 Stable Release

--- a/__init__.py
+++ b/__init__.py
@@ -2217,8 +2217,19 @@ async def _async_register_frontend_resources(hass: HomeAssistant) -> None:
         # Load semLocalize via add_extra_js_url — must be available before cards
         add_extra_js_url(hass, localize_url)
 
-        # Legacy base URLs to clean up (migrated to single Lit bundle)
+        # Legacy base URLs to clean up (migrated to single Lit bundle, OR
+        # — for ``sem-localize.js`` — moved to the ``add_extra_js_url``
+        # channel which is the correct one for non-card helper JS that
+        # must be global before cards load). #448: PROD storage on
+        # 2026-06-07 still had an orphan Lovelace resource entry for
+        # ``sem-localize.js`` pinned at ``?v=1.7.1-beta.11-fca70f78`` — it
+        # was never bumped because nothing in the current registration
+        # code touched it, and the service worker happily served the
+        # stale beta.11 file. Result: every user saw raw ``config_*``
+        # translation keys for everything added in beta.12+. Listing the
+        # base URL here triggers the delete-orphan path at line ~2335.
         _legacy_bases = [
+            f"{static_path}/card/sem-localize.js",
             f"{static_path}/card/sem-shared.js",
             f"{static_path}/card/sem-reactive-base.js",
             f"{static_path}/card/sem-load-priority-card.js",

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.1"
+  "version": "1.7.1.1"
 }

--- a/tests/test_frontend_resource_cache_bust.py
+++ b/tests/test_frontend_resource_cache_bust.py
@@ -100,9 +100,13 @@ def test_manifest_version_present_for_url_prefix() -> None:
     assert "version" in data, "manifest.json missing 'version' key"
     version = data["version"]
     assert isinstance(version, str), "manifest version is not a string"
-    # Sanity — every version we've shipped matches one of these shapes.
+    # Sanity — every version we've shipped matches one of these shapes:
+    #   ``X.Y.Z``          regular release            (e.g. 1.7.1)
+    #   ``X.Y.Z.P``        out-of-band patch          (e.g. 1.7.1.1 #448)
+    #   ``X.Y.Z-beta.N``   beta                       (e.g. 1.7.2-beta.1)
+    #   ``X.Y.Z-rc.N``     release candidate
     assert (
-        version.count(".") == 2
+        version.count(".") in (2, 3)
         or "-beta" in version
         or "-rc" in version
-    ), f"manifest version {version!r} doesn't match expected v?.?.? or pre-release shape"
+    ), f"manifest version {version!r} doesn't match expected v?.?.? / v?.?.?.? / pre-release shape"


### PR DESCRIPTION
## Summary

Single-fix patch on top of v1.7.1. Targets the **orphan Lovelace resource** bug reported by @RienduPre on #448 + reproduced on the maintainer's install.

After upgrading to v1.7.1 from a beta < beta.12, users saw raw \`config_*\` translation keys on the Configuration tab + dashboard. Root cause was a stale Lovelace resource entry pinning \`sem-localize.js?v=1.7.1-beta.11-fca70f78\` from an older registration path that nothing in the current code touched. The browser's service worker served the cached beta.11 file → missing every key added since.

## Fix

Added \`sem-localize.js\` to the existing \`_legacy_bases\` cleanup list in \`__init__.py:_async_register_frontend_resources\`. The delete-orphan loop already in that path now drops the stale entry on next entry setup; \`add_extra_js_url\` remains the single (correct) registration channel for non-card helper JS.

## Verification

- ✅ HA-TEST: after deploy, only legitimate resources remain — \`sem-cards.js?v=1.7.2-beta.1-…\` + \`sem-system-diagram-card.js?v=1.7.2-beta.1-…\`. Orphan gone.
- ✅ HA-PROD: same. Hard-refreshed Companion app now shows translated labels (was raw \`config_*\` keys).
- Same fix is on \`develop\` as commit \`6ec8ba9\` (will land in 1.7.2 too).

Users still need one hard refresh (Companion app → App Configuration → Reset frontend cache) after upgrading. After that single refresh, future deploys bust the cache automatically via the content-hash.

Closes #448

## Test plan

- [x] Manual verification on HA-TEST: orphan removed from \`lovelace_resources\` storage
- [x] Manual verification on HA-PROD: orphan removed, translations render
- [x] CI Tests workflow (3 239 pass, 9 skipped) on parent commit \`fe36182\` (1.7.1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed dashboard labels showing raw translation keys after the 1.7.1 update.
  * Existing users must perform a one-time hard browser refresh to pick up the fix due to service worker caching.

* **Chores**
  * Released patch version 1.7.1.1.

* **Tests**
  * Updated version-format validation to accept the new patch version shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->