### PR TITLE
feat(diagnostics): defensive instrumentation for #461/#462/#464

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1110,6 +1110,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
                 ev_charger_service or ev_current_entity,
             )
 
+            # Defensive: surface dead entity_ids at registration. Each of
+            # these configured entities is something SEM will try to write
+            # to or read from during the cycle. HA's service calls succeed
+            # silently against non-existent entity_ids, so a stale id (e.g.
+            # after a Wallbox/KEBA HA-integration upgrade renamed entities
+            # under the user) results in SEM commanding nothing and the
+            # charger continuing on its own last setpoint — the symptom of
+            # #315 / #357 / #462. Logging at WARNING here makes the gap
+            # visible in any diagnostics dump or log query.
+            _to_check = [
+                ("ev_charging_power_sensor", ev_power_entity),
+                ("ev_current_control_entity", ev_current_entity),
+                ("ev_charger_service_entity_id", ev_service_entity),
+                ("ev_start_stop_entity", _cfg("ev_start_stop_entity")),
+                ("ev_charge_mode_entity", _cfg("ev_charge_mode_entity")),
+            ]
+            _missing = []
+            for _attr, _eid in _to_check:
+                if not _eid:
+                    continue
+                if hass.states.get(_eid) is None:
+                    _missing.append((_attr, _eid))
+            if _missing:
+                _LOGGER.warning(
+                    "EV charger '%s' (%s): %d configured entity ID(s) "
+                    "missing from HA's state registry — SEM commands to "
+                    "these silently no-op. Likely cause: the upstream "
+                    "integration renamed entities after a version upgrade "
+                    "(common with Wallbox/KEBA/Easee on HA core upgrades). "
+                    "Affected: %s",
+                    charger_name, charger_id, len(_missing),
+                    ", ".join(f"{a}={e}" for a, e in _missing),
+                )
+
             # Also register in load management for peak shedding (#436:
             # pass per-charger id + name so each ev_chargers[i] gets its
             # own ``load_device_<id>`` entry in self._devices instead of

--- a/coordinator/charger_adapters/wallbox.py
+++ b/coordinator/charger_adapters/wallbox.py
@@ -128,6 +128,23 @@ class WallboxAdapter(GenericAdapter):
                 )
                 return entry.entity_id
 
+        # No pause switch found — command_disable falls back to generic
+        # set_current(0) + stop_session, which some Wallbox firmware
+        # latches at the last non-zero setpoint (#357). Silent failure
+        # pre-#462 makes the user think their off-mode setting is
+        # ignored. Logging at WARNING surfaces the gap in any
+        # diagnostics dump. Workaround: pass the pause switch id
+        # manually as ``ev_start_stop_entity``.
+        _LOGGER.warning(
+            "Wallbox %s: no pause_resume switch discovered on device %s "
+            "— SEM will fall back to generic set_current(0), which some "
+            "Wallbox firmware latches at the last setpoint. If off mode "
+            "does not actually stop charging, the Wallbox HA integration "
+            "may have renamed the switch in a recent version. Search HA "
+            "for switch.wallbox_*_pause_resume and set it as "
+            "ev_start_stop_entity in this charger's config. (#462)",
+            self._device.name, device_id,
+        )
         return None
 
     async def _toggle_pause_switch(self, turn_on: bool) -> None:

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -598,10 +598,33 @@ class SensorReader:
             self._uses_split_grid = True
             disc = self._split_grid_discovery
             if disc["confidence"] != "same-device":
+                # Capture the previous picks BEFORE re-discovery so we can
+                # detect mid-run switches. Any-device confidence re-runs
+                # every cycle so a flicker in HA's state list can flip the
+                # discovered sensor without warning — that's the candidate
+                # root cause for #461 (Growatt sign inversion that
+                # "sometimes works, sometimes inverted"). Logging at
+                # WARNING when the picks change makes the cause visible
+                # in any user-supplied log dump.
+                _prev_imp = disc["import"]
+                _prev_exp = disc["export"]
                 imp, exp, conf = self._discover_split_grid_power(ed)
                 disc["import"] = imp
                 disc["export"] = exp
                 disc["confidence"] = conf
+                if (_prev_imp is not None or _prev_exp is not None) and (
+                    _prev_imp != imp or _prev_exp != exp
+                ):
+                    _LOGGER.warning(
+                        "Split-grid sensor picks changed mid-run "
+                        "(confidence=%s) — import: %s → %s, export: %s → %s. "
+                        "This flips the computed grid_power sign if the new "
+                        "picks identify the meters in the opposite role. "
+                        "Candidate root cause for #461. Set "
+                        "grid_import_power_entity / grid_export_power_entity "
+                        "explicitly in the config to lock the picks.",
+                        conf, _prev_imp, imp, _prev_exp, exp,
+                    )
             if disc["import"]:
                 import_w = self._read_sensor(disc["import"], "grid_import")
                 export_w = self._read_sensor(disc["export"], "grid_export") if disc["export"] else 0.0


### PR DESCRIPTION
## Summary

Three WARNING-level log surfaces that expose root-cause evidence for the recurring **"settings ignored / off doesn't stop / import-export inverted"** bug class RienduPre keeps hitting. No behavior change — these make silent failures visible.

Stacked on top of `develop` (no dependency on #465 — they can land in either order).

## What's added

### #462 / #464 — Charger entity-id staleness check (`__init__.py`)

At charger registration, walks every configured entity id (`ev_charging_power_sensor`, `ev_current_control_entity`, `ev_charger_service_entity_id`, `ev_start_stop_entity`, `ev_charge_mode_entity`) and logs WARNING with a complete list when any are missing from `hass.states`.

**Why this matters**: HA's `number.set_value` / `switch.turn_off` service calls succeed silently against non-existent entity_ids. After a HA core upgrade or a charger HA-integration version bump, the entities can be renamed under the user. SEM continues writing to dead ids and "everything ignores my settings" reads exactly like #462.

### #462 — Wallbox pause-switch discovery surfacing (`wallbox.py`)

When `_discover_pause_switch` finds no `switch.*pause_resume` on the Wallbox device, now logs WARNING explaining the exact consequence (generic `set_current(0)` fallback, which Wallbox firmware latches per #357) and the workaround (find the switch in HA, set `ev_start_stop_entity`).

**Why this matters**: pause-switch discovery silently returning `None` is the most likely cause of RienduPre's "off mode doesn't stop charging" symptom. This makes the gap visible in any log query — both at startup and when discovery first runs.

### #461 — Split-grid discovery change-detection (`sensor_reader.py`)

When `any-device`-confidence split-grid discovery picks DIFFERENT sensor ids than the previous cycle, logs WARNING with before→after ids and the recommended workaround (`grid_import_power_entity` / `grid_export_power_entity` to lock).

**Why this matters**: discovery re-runs every cycle for any-device matches (line 596). HA's `states.async_all('sensor')` iteration order can change after a HA restart or when a new sensor registers. If the iteration picks a Growatt sensor with `import_power` in its name that isn't actually the meter (e.g. a PV string's "import"), the computed `grid_power = export - import` flips. That matches RienduPre's "sometimes works, sometimes inverted".

## Test plan

- [x] Syntax check (Python 3.12)
- [x] Full pytest suite: 3276 passed, 8 skipped (no regressions)
- [x] Split-grid integration tests: 54 passed (the path I instrumented)
- [ ] Deploy to HA-TEST + PROD — at next deploy these warnings will appear in RienduPre's logs (and our own) when conditions are hit
- [ ] After deploy: ask RienduPre to share the resulting log lines — the warnings include the exact entity_ids and recommendations, so the next round of triage starts with evidence instead of hypothesis

## Why this isn't "the fix"

I deliberately did NOT change behavior here. Without RienduPre's actual entity_id config dump, any "fix" would be a guess. These warnings are designed to make the next bug report self-diagnostic — when he hits #462 again, the log will say exactly which entity_id is dead and exactly what to do.

If after this deploy his logs confirm a specific hypothesis (e.g. "pause switch not found" or "split-grid picks flipped between cycles"), the next PR will be a targeted fix on that confirmed root cause.

Refs #461 #462 #464
Related: #285 #315 #357 (prior fixes in this bug class)