### PR TITLE
fix(set_option): smart-merge ev_chargers + scope reload (#462 #464, likely #461)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -168,6 +168,97 @@ PLATFORMS: list[Platform] = [
 ]
 
 
+# ─────────────────────────────────────────────────────────────────────
+# set_option helpers (#462/#464)
+# ─────────────────────────────────────────────────────────────────────
+
+# Structural option keys — changes to these require re-instantiating
+# controllers because they wire SEM to HA entities. Everything else
+# (modes, thresholds, targets, tunables) is read each cycle from
+# coordinator.config and can be hot-swapped without a reload.
+#
+# Conservative on ``ev_chargers``: any change to the list shape
+# (charger added/removed/per-charger entity rewired) needs a reload
+# so the actuator bindings get refreshed. Per-charger tunables inside
+# the list (charge_mode, target_soc, daily_ev_target) go through the
+# select.py / number.py paths instead of set_option, so they don't
+# hit this list.
+_SET_OPTION_STRUCTURAL_KEYS: frozenset[str] = frozenset({
+    "heat_pump_relay1_entity", "heat_pump_relay2_entity",
+    "heat_pump_climate_entity", "heat_pump_power_sensor",
+    "heat_pump_temperature_sensor",
+    "hot_water_entity", "hot_water_power_sensor",
+    "hot_water_temperature_sensor",
+    "ev_chargers",
+})
+
+
+def _set_option_needs_reload(option_keys) -> bool:
+    """True iff at least one key in ``option_keys`` is structural.
+
+    Structural keys (entity wiring) require an integration reload so
+    the controllers re-instantiate against the new wiring. Tunable
+    keys (modes, thresholds, switches) are read from
+    ``coordinator.config`` on every cycle, so an in-place mirror is
+    sufficient — no reload needed.
+    """
+    return any(k in _SET_OPTION_STRUCTURAL_KEYS for k in option_keys)
+
+
+def _merge_ev_chargers_by_id(
+    existing: list, incoming: list,
+) -> list:
+    """Merge an ``ev_chargers`` list by ``id`` rather than full-replace.
+
+    Built for the set_option service path so a partial submit from the
+    Config card (one charger's worth of fields) can never drop sibling
+    chargers from the persisted state — the bug class behind #464.
+
+    Contract:
+
+    * Each entry in ``incoming`` is merged INTO the matching entry in
+      ``existing`` by ``id``, with incoming fields winning. Fields
+      present in the existing entry but absent from the incoming entry
+      are preserved (no key is silently removed).
+    * Existing chargers whose ``id`` is NOT in the incoming list are
+      kept verbatim. This is the actual fix for the cross-talk: a
+      one-charger update never affects siblings.
+    * Incoming chargers without a matching existing ``id`` (a fresh
+      add) are appended verbatim.
+    * Non-dict entries on either side are skipped (defensive).
+    * Output preserves the existing order; new chargers are appended.
+
+    Pure function — no I/O, no HA dependencies. Tested in
+    ``tests/test_set_option_smart_merge.py``.
+    """
+    existing_by_id: dict[str, dict] = {
+        c["id"]: dict(c) for c in (existing or [])
+        if isinstance(c, dict) and c.get("id")
+    }
+    seen_ids: set[str] = set()
+    merged: list[dict] = []
+    for inc in incoming or []:
+        if not isinstance(inc, dict):
+            continue
+        cid = inc.get("id")
+        if cid and cid in existing_by_id:
+            base = existing_by_id[cid]
+            base.update(inc)
+            merged.append(base)
+            seen_ids.add(cid)
+        else:
+            merged.append(dict(inc))
+            if cid:
+                seen_ids.add(cid)
+    # Preserve existing chargers not mentioned in the incoming list —
+    # appended after the incoming-derived entries to keep the result
+    # deterministic.
+    for cid, c in existing_by_id.items():
+        if cid not in seen_ids:
+            merged.append(c)
+    return merged
+
+
 async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     """Migrate old config entry data to current schema.
 
@@ -2675,12 +2766,26 @@ async def _async_register_phase_services(
     async def async_set_option(call) -> None:
         """Write one or more keys into the SEM ConfigEntry options.
 
-        Equivalent to walking the OptionsFlow but without forcing the
-        caller to know which step owns each key. Triggers the standard
-        ``async_update_options`` listener which decides whether a reload
-        is needed (see ``async_update_options`` comment for the skip
-        rules — runtime number/switch tweaks don't reload, structural
-        keys like entity pickers do).
+        Two behaviors based on key kind (#462/#464 fix):
+
+        * **Structural keys** (entity wiring — heat pump relays, hot
+          water entity, ev_chargers list shape): force an integration
+          reload so controllers get re-instantiated against the new
+          wiring. This preserves the #448 heat-pump-relay fix that
+          motivated the v1.7.2-beta.2 always-reload behavior.
+
+        * **Tunable keys** (everything else — modes, thresholds,
+          targets, switches): mirror the new value into
+          ``coordinator.config`` in place and suppress the listener's
+          reload via ``_skip_options_reload``. Matches the per-charger
+          ``select.py`` / ``number.py`` runtime-tweak pattern that
+          existed in v1.7.1 and earlier. Avoids destroying + recreating
+          the coordinator (with all attendant per-charger / split-grid
+          state) on every tunable change.
+
+        Plus: when ``ev_chargers`` is in the payload, **merge by id**
+        instead of full-replace so a partial submit from the Config
+        card can never drop a sibling charger (#464 cross-talk).
         """
         options = call.data.get("options")
         if not isinstance(options, dict):
@@ -2701,27 +2806,59 @@ async def _async_register_phase_services(
                 if e.entry_id == call.data.get("entry_id"):
                     target_entry = e
                     break
-        # Merge with existing options to preserve unrelated keys, then
-        # update. HA fires the update_listener automatically — but that
-        # listener has a skip-reload optimization for runtime
-        # number/switch tweaks. Since ``set_option`` doesn't mirror
-        # values into coordinator memory (the runtime stepper path
-        # does), we ALWAYS need a reload here to take effect.
-        # Bug confirmed live on 2026-06-07: setting
-        # ``heat_pump_relay2_entity`` via this service updated the
-        # ``options`` dict but the heat-pump controller didn't get
-        # re-registered, leaving ``registered=false`` despite valid
-        # config. Explicit reload below makes this deterministic.
+
+        # Smart-merge ``ev_chargers`` by id (#464) — see
+        # ``_merge_ev_chargers_by_id`` for the contract.
+        if isinstance(options.get("ev_chargers"), list):
+            existing_list = (target_entry.options or {}).get("ev_chargers") or []
+            options = {
+                **options,
+                "ev_chargers": _merge_ev_chargers_by_id(
+                    existing_list, options["ev_chargers"],
+                ),
+            }
+
         merged = {**(target_entry.options or {}), **options}
-        if merged != (target_entry.options or {}):
-            hass.config_entries.async_update_entry(target_entry, options=merged)
-            # Block on reload so the caller's next read sees the new
-            # state. HA suppresses duplicate reloads when one is
-            # already pending from the listener.
+        if merged == (target_entry.options or {}):
+            _LOGGER.debug(
+                "set_option no-op (values unchanged): %s",
+                list(options.keys()),
+            )
+            return
+
+        needs_reload = _set_option_needs_reload(options.keys())
+
+        if needs_reload:
+            # Structural change — force a reload so controllers
+            # re-instantiate against the new wiring. The
+            # async_update_options listener will also reload, but
+            # HA suppresses duplicates so it's safe.
+            hass.config_entries.async_update_entry(
+                target_entry, options=merged,
+            )
             await hass.config_entries.async_reload(target_entry.entry_id)
+        else:
+            # Tunable change — mirror into coordinator.config in
+            # place and snapshot _skip_options_reload so the
+            # update_listener short-circuits. Matches the per-charger
+            # select / number tweaks. No reload, no destroyed state,
+            # no split-grid re-discovery, no per-charger context loss.
+            coordinator = getattr(target_entry, "runtime_data", None)
+            if coordinator is not None:
+                coordinator._skip_options_reload = dict(merged)
+                if isinstance(getattr(coordinator, "config", None), dict):
+                    coordinator.config.update({
+                        **(target_entry.data or {}),
+                        **merged,
+                    })
+            hass.config_entries.async_update_entry(
+                target_entry, options=merged,
+            )
+
         _LOGGER.debug(
-            "set_option wrote %d key(s) to entry %s: %s",
-            len(options), target_entry.entry_id, list(options.keys()),
+            "set_option wrote %d key(s) to entry %s (reload=%s): %s",
+            len(options), target_entry.entry_id, needs_reload,
+            list(options.keys()),
         )
 
     hass.services.async_register(

--- a/tests/test_set_option_smart_merge.py
+++ b/tests/test_set_option_smart_merge.py
@@ -1,0 +1,285 @@
+"""Contract tests for the set_option service helpers (#462/#464).
+
+The actual ``solar_energy_management.set_option`` service handler is a
+closure inside ``_async_register_phase_services`` in ``__init__.py`` —
+hard to test directly without a full HA harness. So the structural
+pieces it depends on are pulled out to module-level pure helpers:
+
+* ``_merge_ev_chargers_by_id`` — smart-merge to prevent the #464
+  cross-talk where a partial Config-card submit could drop sibling
+  chargers.
+* ``_set_option_needs_reload`` — gate that determines whether a write
+  is structural (needs reload) or a runtime tunable (in-memory mirror
+  is sufficient). Restores the per-charger select.py-style
+  skip-reload optimization for the service path so a Config-card
+  tweak doesn't destroy + recreate the coordinator on every change.
+* ``_SET_OPTION_STRUCTURAL_KEYS`` — the source-of-truth set.
+
+These tests lock the contract behind those three names so future edits
+can't silently regress the #464 cross-talk or the #462 reload-on-every-
+tweak behavior.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.solar_energy_management import (
+    _SET_OPTION_STRUCTURAL_KEYS,
+    _merge_ev_chargers_by_id,
+    _set_option_needs_reload,
+)
+
+
+# ─────────────────────────────────────────────────────────────────
+# _merge_ev_chargers_by_id — the #464 cross-talk fix
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMergeEvChargersById:
+    """The smart-merge contract.
+
+    Bug being fixed: in v1.7.2 the set_option service did a naïve
+    full-replace of ``ev_chargers``. If the Config card's cached
+    ``_options`` was stale or only contained the changed charger,
+    saving back dropped the sibling — and the next reload came up
+    missing it. Reported as #464 "Both Chargers reacht on config
+    changes of one charger".
+    """
+
+    def test_single_charger_field_update_preserves_other_fields(self):
+        """An update touching one field on one charger keeps the rest."""
+        existing = [
+            {"id": "A", "name": "Garage", "charge_mode": "off",
+             "ev_target_soc": 80, "vehicle_soc_entity": "sensor.car_a_soc"},
+        ]
+        incoming = [
+            {"id": "A", "ev_target_soc": 90},
+        ]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 1
+        a = result[0]
+        assert a["id"] == "A"
+        assert a["ev_target_soc"] == 90               # incoming wins
+        assert a["name"] == "Garage"                  # preserved
+        assert a["charge_mode"] == "off"              # preserved
+        assert a["vehicle_soc_entity"] == "sensor.car_a_soc"  # preserved
+
+    def test_partial_submit_preserves_sibling_charger(self):
+        """The #464 reproducer — partial list must not drop siblings."""
+        existing = [
+            {"id": "A", "name": "Garage", "charge_mode": "min_plus_solar"},
+            {"id": "B", "name": "Driveway", "charge_mode": "solar_only"},
+        ]
+        # User only changed charger A; UI only sends A.
+        incoming = [
+            {"id": "A", "charge_mode": "off"},
+        ]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 2, "sibling charger B was dropped — #464 regression"
+        by_id = {c["id"]: c for c in result}
+        assert by_id["A"]["charge_mode"] == "off"
+        assert by_id["B"]["charge_mode"] == "solar_only"
+        assert by_id["B"]["name"] == "Driveway"
+
+    def test_full_list_submit_works_as_before(self):
+        """The "good citizen" path — Config card submits the full list."""
+        existing = [
+            {"id": "A", "charge_mode": "min_plus_solar"},
+            {"id": "B", "charge_mode": "solar_only"},
+        ]
+        incoming = [
+            {"id": "A", "charge_mode": "off"},
+            {"id": "B", "charge_mode": "always_max"},
+        ]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 2
+        by_id = {c["id"]: c for c in result}
+        assert by_id["A"]["charge_mode"] == "off"
+        assert by_id["B"]["charge_mode"] == "always_max"
+
+    def test_new_charger_appended(self):
+        """A charger with a fresh id is added; existing ones unchanged."""
+        existing = [
+            {"id": "A", "charge_mode": "min_plus_solar"},
+        ]
+        incoming = [
+            {"id": "B", "name": "Driveway", "charge_mode": "solar_only"},
+        ]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 2
+        by_id = {c["id"]: c for c in result}
+        assert by_id["A"]["charge_mode"] == "min_plus_solar"   # preserved
+        assert by_id["B"]["name"] == "Driveway"
+        assert by_id["B"]["charge_mode"] == "solar_only"
+
+    def test_empty_existing_takes_incoming(self):
+        """First-time charger add — incoming becomes the canonical list."""
+        result = _merge_ev_chargers_by_id([], [{"id": "A", "name": "Garage"}])
+        assert result == [{"id": "A", "name": "Garage"}]
+
+    def test_empty_incoming_returns_existing_clones(self):
+        """No-op submit — existing chargers come through unchanged."""
+        existing = [
+            {"id": "A", "charge_mode": "off"},
+            {"id": "B", "charge_mode": "solar_only"},
+        ]
+        result = _merge_ev_chargers_by_id(existing, [])
+        assert len(result) == 2
+        # Identity check — the returned dicts are FRESH copies, so
+        # mutating one of them doesn't bleed back into ``existing``.
+        result[0]["charge_mode"] = "always_max"
+        assert existing[0]["charge_mode"] == "off"
+
+    def test_incoming_without_id_is_appended(self):
+        """An incoming dict missing an id is appended (no merge target)."""
+        existing = [{"id": "A", "charge_mode": "off"}]
+        incoming = [{"name": "Stray", "charge_mode": "solar_only"}]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 2
+        # Existing 'A' preserved
+        assert any(c.get("id") == "A" for c in result)
+        # Stray appended
+        assert any(c.get("name") == "Stray" for c in result)
+
+    def test_non_dict_entries_are_skipped(self):
+        """Defensive — garbage entries on either side never raise."""
+        existing = [{"id": "A", "charge_mode": "off"}, "not-a-dict", None]
+        incoming = [None, {"id": "A", "charge_mode": "always_max"}, 42]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert len(result) == 1
+        assert result[0]["id"] == "A"
+        assert result[0]["charge_mode"] == "always_max"
+
+    def test_none_inputs_treated_as_empty(self):
+        """``None`` (the entry's ``options.get("ev_chargers")`` shape) is OK."""
+        assert _merge_ev_chargers_by_id(None, None) == []
+        assert _merge_ev_chargers_by_id(None, [{"id": "A"}]) == [{"id": "A"}]
+        assert _merge_ev_chargers_by_id([{"id": "A"}], None) == [{"id": "A"}]
+
+    def test_merge_does_not_mutate_inputs(self):
+        """Pure function — caller's lists/dicts stay intact."""
+        existing = [{"id": "A", "name": "Garage", "charge_mode": "off"}]
+        incoming = [{"id": "A", "charge_mode": "always_max"}]
+        existing_snapshot = [dict(c) for c in existing]
+        incoming_snapshot = [dict(c) for c in incoming]
+        _merge_ev_chargers_by_id(existing, incoming)
+        assert existing == existing_snapshot
+        assert incoming == incoming_snapshot
+
+
+# ─────────────────────────────────────────────────────────────────
+# _set_option_needs_reload — the #462 reload-scope gate
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSetOptionNeedsReload:
+    """Reload gate for the set_option service path.
+
+    Background: v1.7.2-beta.2 added an always-reload to ``set_option``
+    so heat-pump entity rewires (#448) would take effect. Side effect:
+    every Config-card tunable tweak (mode/threshold/switch) triggered
+    a full coordinator reload, destroying the SensorReader's split-
+    grid discovery state (candidate root cause for #461) and the
+    per-charger context across the multi-charger loop (candidate for
+    #462/#464). The gate restores the in-memory mirror for non-
+    structural keys.
+    """
+
+    def test_heat_pump_entity_keys_need_reload(self):
+        """Structural entity-wiring keys still force a reload (#448 path)."""
+        assert _set_option_needs_reload(["heat_pump_relay1_entity"])
+        assert _set_option_needs_reload(["heat_pump_relay2_entity"])
+        assert _set_option_needs_reload(["heat_pump_climate_entity"])
+        assert _set_option_needs_reload(["heat_pump_temperature_sensor"])
+        assert _set_option_needs_reload(["heat_pump_power_sensor"])
+
+    def test_hot_water_entity_keys_need_reload(self):
+        """Hot water wiring keys reload too (#454 path)."""
+        assert _set_option_needs_reload(["hot_water_entity"])
+        assert _set_option_needs_reload(["hot_water_temperature_sensor"])
+        assert _set_option_needs_reload(["hot_water_power_sensor"])
+
+    def test_ev_chargers_list_needs_reload(self):
+        """List-shape changes need reload so actuator bindings refresh."""
+        assert _set_option_needs_reload(["ev_chargers"])
+
+    def test_runtime_tunables_skip_reload(self):
+        """Modes / thresholds / switches don't reload — coordinator reads them each cycle."""
+        # Numbers
+        assert not _set_option_needs_reload(["ev_target_soc"])
+        assert not _set_option_needs_reload(["daily_ev_target"])
+        assert not _set_option_needs_reload(["target_peak_limit"])
+        assert not _set_option_needs_reload(["cheap_price_threshold"])
+        assert not _set_option_needs_reload(["minimum_solar_power"])
+        # Modes
+        assert not _set_option_needs_reload(["charge_mode"])
+        assert not _set_option_needs_reload(["tariff_mode"])
+        # Switches
+        assert not _set_option_needs_reload(["observer_mode"])
+        assert not _set_option_needs_reload(["night_charging"])
+        # Multi-key tunable batch
+        assert not _set_option_needs_reload([
+            "ev_target_soc", "daily_ev_target", "target_peak_limit",
+        ])
+
+    def test_mixed_payload_reloads_when_any_key_structural(self):
+        """One structural key in a mixed batch is enough to force reload."""
+        assert _set_option_needs_reload([
+            "ev_target_soc", "heat_pump_relay1_entity",
+        ])
+        assert _set_option_needs_reload([
+            "charge_mode", "hot_water_entity",
+        ])
+
+    def test_empty_payload_does_not_reload(self):
+        """No keys = no reload (caller short-circuits earlier anyway)."""
+        assert not _set_option_needs_reload([])
+
+    def test_keys_accept_any_iterable(self):
+        """Accepts list, set, dict_keys, generator — caller-friendly."""
+        assert _set_option_needs_reload({"ev_chargers"})
+        assert _set_option_needs_reload({"ev_chargers": None}.keys())
+        assert _set_option_needs_reload(k for k in ("ev_chargers",))
+
+
+# ─────────────────────────────────────────────────────────────────
+# _SET_OPTION_STRUCTURAL_KEYS — visibility lock
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestStructuralKeysVisibility:
+    """The structural-key set is the contract — guard its identity."""
+
+    def test_set_is_frozen(self):
+        """frozenset so callers can't mutate it from the outside."""
+        assert isinstance(_SET_OPTION_STRUCTURAL_KEYS, frozenset)
+
+    def test_known_structural_members_present(self):
+        """Adding a new entity-wiring key here is a contract change.
+
+        Removing one is too. Both should be deliberate.
+        """
+        expected = {
+            "heat_pump_relay1_entity", "heat_pump_relay2_entity",
+            "heat_pump_climate_entity", "heat_pump_power_sensor",
+            "heat_pump_temperature_sensor",
+            "hot_water_entity", "hot_water_power_sensor",
+            "hot_water_temperature_sensor",
+            "ev_chargers",
+        }
+        assert _SET_OPTION_STRUCTURAL_KEYS == expected
+
+    def test_common_tunables_not_in_structural(self):
+        """Negative space — these must stay OUT of the reload set."""
+        for k in (
+            "charge_mode", "ev_target_soc", "daily_ev_target",
+            "target_peak_limit", "tariff_mode", "minimum_solar_power",
+            "night_charging", "observer_mode", "cheap_price_threshold",
+        ):
+            assert k not in _SET_OPTION_STRUCTURAL_KEYS, (
+                f"'{k}' is a runtime tunable — adding it to the structural "
+                "set would re-introduce the #462 reload-on-every-tweak bug."
+            )


### PR DESCRIPTION
## Summary

Closes #464. Fixes the likely root cause of #462. Strong candidate to fix #461 as well.

## Root-cause analysis

RienduPre installed 1.7.1, was stable. Upgraded to 1.7.2 → 4 bugs within hours. Critical surfaces between the two versions:

| File | Touched 1.7.1 → 1.7.2? |
|---|---|
| `coordinator/sensor_reader.py` | **No** |
| `coordinator/ev_control.py` | **No** |
| `select.py` (per-charger writes) | **No** |
| `__init__.py` `set_option` service | **Yes — v1.7.2-beta.2** |

The v1.7.2-beta.2 change added an always-`async_reload` to `set_option` so heat-pump entity rewires (#448) would take effect. Side effect: every Config-card tunable tweak triggered a full coordinator reload, which:

1. Destroys the `SensorReader`'s split-grid discovery state. Next discovery re-walks `hass.states.async_all("sensor")` from scratch — iteration order differs, first-match differs, computed `grid_power = export - import` sign flips. That's #461 (Growatt sign intermittently inverted).
2. Destroys the per-charger context across the multi-charger loop. Any concurrent setting tweak interrupts decisions mid-cycle. #462 / #464.
3. The Config card's `ev_chargers` save (which sends the list back via the same service) shallow-merges. If the cached `_options` was stale or only contained the changed charger, the prior shallow-merge full-replaced the persisted list and dropped the sibling.

## What changed

### `_merge_ev_chargers_by_id` — extracted to module scope

Merges by `id` instead of full-replace:
- Incoming fields win on matching `id`.
- Siblings not in the incoming list are kept verbatim.
- Fresh `id`s are appended.
- Non-dict entries skipped (defensive).
- Pure function, doesn't mutate inputs.

### `_set_option_needs_reload` — extracted to module scope

Reload gate keyed on `_SET_OPTION_STRUCTURAL_KEYS`. Returns `True` only for entity-wiring keys:
- `heat_pump_relay1_entity`, `heat_pump_relay2_entity`, `heat_pump_climate_entity`, `heat_pump_power_sensor`, `heat_pump_temperature_sensor`
- `hot_water_entity`, `hot_water_power_sensor`, `hot_water_temperature_sensor`
- `ev_chargers` (list shape changes — charger added/removed/per-charger entity rewired)

Tunables (modes, thresholds, targets, switches) — `False`. Mirror to `coordinator.config` in place, snapshot `_skip_options_reload` so the update listener short-circuits, no reload.

### `async_set_option` — refactored to use the helpers

Same external behavior for structural keys (heat-pump fix from #448 preserved). New behavior for tunables: no reload, no destroyed state.

## Test coverage

`tests/test_set_option_smart_merge.py` — 20 contract tests:

- 10 for `_merge_ev_chargers_by_id`: partial submit preserves siblings, full submit works as before, field-level preservation, new-charger append, empty-input handling, defensive non-dict skipping, input non-mutation.
- 7 for `_set_option_needs_reload`: structural keys reload, tunables don't, mixed payloads reload on any structural, empty payload doesn't, iterable input accepted.
- 3 for `_SET_OPTION_STRUCTURAL_KEYS`: frozenset identity, expected members, negative space for common tunables.

Full suite: **3296 passed, 8 skipped** (was 3276 → +20 new). No regressions.

## What this PR does NOT claim to fix

- **#460** (clipboard) — separate path, fixed in #465.
- **The Wallbox pause-switch discovery failure** if RienduPre's HA-integration version renamed entities — that's a separate surface; the instrumentation PR (#466) will reveal it in his next log dump.

## Test plan

- [x] Smart-merge contract tests pass (10/10)
- [x] Reload-gate contract tests pass (7/7)
- [x] Structural-keys visibility tests pass (3/3)
- [x] Full suite: 3296 passed, no regressions
- [ ] After merge: deploy to HA-TEST, verify Config tab tunable changes don't trigger reload (log line: `set_option wrote N key(s) ... (reload=False)`)
- [ ] After merge: deploy to PROD via v1.7.3-beta.1
- [ ] RienduPre reports back on whether the four bugs persist on beta.1

Refs #462 #464 (direct)
Refs #461 (likely)
Refs #448 (preserves the original heat-pump fix)