### PR TITLE
fix(select,number): fall back to entry.data for per-charger writes (#464 follow-up)

### DIFF
--- a/number.py
+++ b/number.py
@@ -747,7 +747,19 @@ class SEMPerChargerNumber(CoordinatorEntity, NumberEntity):
         new_options = {**self._entry.options}
         # Copy each charger dict — in-place mutation leaves entry.options unchanged,
         # so async_update_entry skips persisting and the value reverts on restart (#245).
-        ev_chargers = [dict(c) for c in new_options.get("ev_chargers", [])]
+        #
+        # Fall back to entry.data.ev_chargers when entry.options doesn't have
+        # the key yet (fresh install / never edited via the Config card). Without
+        # the fallback this writes ``new_options["ev_chargers"] = []`` and the
+        # merge ``{**data, **options}`` on next reload overrides data's chargers
+        # with the empty list — every charger disappears. Same latent foot-gun
+        # as in select.py:SEMPerChargerSelect.async_select_option.
+        source_chargers = (
+            new_options.get("ev_chargers")
+            or (self._entry.data or {}).get("ev_chargers")
+            or []
+        )
+        ev_chargers = [dict(c) for c in source_chargers]
         for charger in ev_chargers:
             if charger.get("id") == self._charger_id:
                 charger[self._config_key] = value

--- a/select.py
+++ b/select.py
@@ -362,7 +362,21 @@ class SEMPerChargerSelect(CoordinatorEntity, SelectEntity):
         # Copy each charger dict — mutating the shared dicts in place leaves
         # entry.options == new_options, so async_update_entry detects no change
         # and never persists to .storage (the value then reverts on restart). (#245)
-        ev_chargers = [dict(c) for c in new_options.get("ev_chargers", [])]
+        #
+        # Fall back to entry.data.ev_chargers when entry.options doesn't have
+        # the key yet (fresh install / never edited via the Config card). Without
+        # the fallback this writes ``new_options["ev_chargers"] = []`` and the
+        # merge ``{**data, **options}`` on next reload overrides data's chargers
+        # with the empty list — every charger disappears, all per-charger entities
+        # go unavailable. Latent since multi-charger landed; would manifest the
+        # first time any user clicked a per-charger select without first having
+        # touched a Config-card field that populates options.ev_chargers.
+        source_chargers = (
+            new_options.get("ev_chargers")
+            or (self._entry.data or {}).get("ev_chargers")
+            or []
+        )
+        ev_chargers = [dict(c) for c in source_chargers]
         for charger in ev_chargers:
             if charger.get("id") == self._charger_id:
                 charger[self._config_key] = option


### PR DESCRIPTION
## Summary

Latent foot-gun in **both** `SEMPerChargerSelect.async_select_option` (`select.py:365`) and `SEMPerChargerNumber.async_set_native_value` (`number.py:750`). Plausible root cause for the asymmetric symptom RienduPre reported on #464 after beta.1 ("change on charger 1 works, change on charger 2 does nothing").

## The bug

```python
new_options = {**self._entry.options}
ev_chargers = [dict(c) for c in new_options.get("ev_chargers", [])]
for charger in ev_chargers:
    if charger.get("id") == self._charger_id:
        charger[self._config_key] = value
        break
new_options["ev_chargers"] = ev_chargers   # ← writes [] when options didn't have the key!
```

When `entry.options.ev_chargers` doesn't exist yet (fresh install, user has never opened the Config card), `get("ev_chargers", [])` returns `[]`. The for loop iterates nothing. The setter writes `entry.options["ev_chargers"] = []`. On next coordinator init the merge `{**entry.data, **entry.options}` overrides `entry.data.ev_chargers` (which had the chargers) with the empty options-side list. **Every charger disappears.**

## Why this matches RienduPre's symptom

1. RienduPre edits charger 1's `ev_target_type` via Config card → goes through `set_option` → smart-merge populates `entry.options.ev_chargers` with both chargers preserved. ✓
2. RienduPre flips charger 2's `charge_mode` on the dashboard per-charger card → goes through `SEMPerChargerSelect.async_select_option`. If at that moment `entry.options.ev_chargers` *somehow* doesn't have both chargers (e.g. only got charger 1 due to an earlier bug), the for loop hits a list missing charger 2 → no match → no-op write. ✗

The symmetric "charger 1 works, charger 2 doesn't" pattern lines up.

## Fix

Fall back to `entry.data.ev_chargers` when `entry.options` doesn't have the key:

```python
source_chargers = (
    new_options.get("ev_chargers")
    or (self._entry.data or {}).get("ev_chargers")
    or []
)
ev_chargers = [dict(c) for c in source_chargers]
```

Applied identically in `select.py:365` and `number.py:750`.

## Test plan

- [x] Syntax + full pytest suite green (3296 passed, no regressions)
- [ ] After merge: ship as v1.7.3-beta.3 + RienduPre re-tests on his real multi-charger Wallbox setup
- [ ] Follow-up integration test in `tests/test_per_charger_options_fallback.py` (using `pytest-homeassistant-custom-component` once that lands) to lock the contract

## Why no unit test in this PR

The contract is small and the inline comments lock the intent. A real unit test would either (a) mock `_entry.options` / `_entry.data` and assert against a real call path, which we already do for the contract pieces in `test_set_option_smart_merge.py`, or (b) use `pytest-homeassistant-custom-component` to assert the entity write path end-to-end — which is the right test to write but should land alongside the integration-test scaffolding work we discussed in the same session. Shipping the fix first to unblock #464.

Refs #464 #462