### PR TITLE
test(framework): real-HA set_option tests + smart-merge fall-through fix

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2809,8 +2809,21 @@ async def _async_register_phase_services(
 
         # Smart-merge ``ev_chargers`` by id (#464) — see
         # ``_merge_ev_chargers_by_id`` for the contract.
+        #
+        # Fall back to ``entry.data.ev_chargers`` when entry.options
+        # doesn't have the key — same foot-gun as the per-charger
+        # select / number setters in #469. A fresh install has its
+        # chargers in entry.data only; the smart-merge needs to see
+        # them so a partial submit doesn't append a stray ghost entry
+        # and lose the existing chargers on next reload. Caught by
+        # ``test_set_option_ev_chargers_partial_submit_preserves_sibling``
+        # in the test_services_real.py framework tests.
         if isinstance(options.get("ev_chargers"), list):
-            existing_list = (target_entry.options or {}).get("ev_chargers") or []
+            existing_list = (
+                (target_entry.options or {}).get("ev_chargers")
+                or (target_entry.data or {}).get("ev_chargers")
+                or []
+            )
             options = {
                 **options,
                 "ev_chargers": _merge_ev_chargers_by_id(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -551,6 +551,35 @@ def charging_state_scenarios():
 
 
 @pytest.fixture
+def sem_real_hass(hass, enable_custom_integrations):
+    """Real-HA fixture for tests that drive the SEM integration end-to-end.
+
+    Composes pytest-homeassistant-custom-component's ``hass`` (real
+    HomeAssistant instance) and ``enable_custom_integrations`` (lets
+    HA's setup machinery find ``custom_components/solar_energy_management/``).
+    Without ``enable_custom_integrations`` an ``async_setup`` call
+    fails with *Integration not found*.
+
+    The reason this is NOT an autouse fixture: making
+    ``enable_custom_integrations`` autouse breaks the pre-existing
+    ``test_ev_daily_reset_boundary.py`` time-arithmetic tests because
+    of scope-wide side effects in HA's component discovery. Tests that
+    drive the SEM lifecycle should explicitly request ``sem_real_hass``;
+    everything else (pure-helper contract tests, mocked-coordinator
+    tests) keeps its current fixture set unchanged.
+
+    Usage::
+
+        async def test_set_option_does_something(sem_real_hass, sem_config_entry):
+            sem_config_entry.add_to_hass(sem_real_hass)
+            assert await sem_real_hass.config_entries.async_setup(sem_config_entry.entry_id)
+            await sem_real_hass.async_block_till_done()
+            # ... drive the integration and assert ...
+    """
+    return hass
+
+
+@pytest.fixture
 def expected_lingering_timers() -> bool:
     """Override pytest-HA's ``verify_cleanup`` strict timer check.
 
@@ -567,11 +596,25 @@ def expected_lingering_timers() -> bool:
 
 @pytest.fixture
 def sem_config_entry():
-    """A ``MockConfigEntry`` at SEM's current schema version (v7).
+    """A ``MockConfigEntry`` at SEM's current schema version (v12.1).
 
     Pre-seeded with a multi-charger-ready config (``ev_chargers`` list,
     not legacy flat keys). Test-specific tweaks can mutate ``.data`` /
     ``.options`` before calling ``entry.add_to_hass(hass)``.
+
+    Schema notes — version bumped from v7 to v12 on 2026-06-09:
+
+    * **v12.1 is current**: must match the migration target so tests
+      don't accidentally exercise the migration code path. Use the
+      ``sem_legacy_config_entry`` fixture (below) when migration IS
+      the thing under test.
+    * **No top-level ``ev_session_energy_sensor``** (v11→v12 drops it
+      when a per-charger value exists; #135).
+    * **Per-charger ``charge_mode``** is required post-#277 Phase A
+      (the named-mode consolidation that replaced
+      ``ev_charging_mode`` + ``night_charging`` + ``tariff_optimized``).
+    * **Per-charger ``min_current`` + ``vehicle_min_current``** are
+      v8→v9 additions (#440 ADR 0010 #3).
 
     Use with the real ``hass`` fixture::
 
@@ -586,7 +629,8 @@ def sem_config_entry():
 
     return MockConfigEntry(
         domain=DOMAIN,
-        version=7,
+        version=12,
+        minor_version=1,
         data={
             "grid_power_sensor": "sensor.test_grid_power",
             "battery_power_sensor": "sensor.test_battery_power",
@@ -618,14 +662,134 @@ def sem_config_entry():
                 "ev_charging_power_sensor": "sensor.test_ev_charging_power",
                 "ev_charger_service": "number.set_value",
                 "ev_charger_service_entity_id": "number.test_charger_current",
+                "ev_current_control_entity": "number.test_charger_current",
+                # v8 → v9 (#440 ADR 0010 #3) per-charger current bounds.
+                "min_current": 6,
+                "max_current": 16,
+                "vehicle_min_current": 6,
+                "phases": 3,
+                "voltage": 230,
+                # Post-#277 Phase A: charge_mode is the source of truth
+                # for the named-mode consolidation. Default is
+                # ``min_plus_solar`` (DEFAULT_EV_CHARGE_MODE).
+                "charge_mode": "min_plus_solar",
                 "daily_ev_target": 10,
                 "daily_ev_target_max": 50,
                 "ev_target_soc": 80,
                 "ev_target_soc_max": 100,
                 "ev_target_type": "kwh",
                 "ev_target_time": "07:00",
+                "ev_surplus_priority": 3,
             }],
         },
         options={},
-        title="SEM Test (real_hass)",
+        title="SEM Test (real_hass v12.1)",
+    )
+
+
+@pytest.fixture
+def sem_multi_wallbox_config_entry():
+    """A ``MockConfigEntry`` modelling RienduPre's real-world setup —
+    two Wallbox Pulsar chargers with different priorities + modes.
+
+    Seeded from his v1.7.3-beta.1 diagnostic dump on #462 / #464
+    (modulo entity-id sanitisation). Use this when a test needs to
+    exercise the multi-charger code paths against a realistic shape:
+    distinct priorities, distinct modes, distinct vehicles, distinct
+    entity bindings.
+
+    Specifically catches regressions in:
+
+    * the ``smart_merge_ev_chargers_by_id`` path (#467) — that one
+      charger's update doesn't drop the sibling.
+    * the per-charger ``async_select_option`` /
+      ``async_set_native_value`` fall-through (#469) — that
+      ``entry.options.ev_chargers`` missing the key falls back to
+      ``entry.data.ev_chargers`` instead of writing ``[]``.
+    * the per-charger select/number entity-id discovery scan
+      (``select.py:95`` loop) — that both chargers register their
+      own ``select.sem_charger_<id>_charge_mode`` entity.
+
+    Schema is v12.1 (matches ``sem_config_entry``).
+    """
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+    from custom_components.solar_energy_management.const import DOMAIN
+
+    return MockConfigEntry(
+        domain=DOMAIN,
+        version=12,
+        minor_version=1,
+        data={
+            "grid_power_sensor": "sensor.test_grid_power",
+            "battery_power_sensor": "sensor.test_battery_power",
+            "battery_soc_sensor": "sensor.test_battery_soc",
+            "solar_power_sensor": "sensor.test_solar_power",
+            "battery_priority_soc": 90,
+            "battery_minimum_soc": 30,
+            "battery_resume_soc": 50,
+            "min_solar_power": 1000,
+            "max_grid_import": 100,
+            "battery_capacity_kwh": 15.0,
+            "peak_load": 6000,
+            "update_interval": 30,
+            "ev_chargers": [
+                {
+                    "id": "ev_charger",
+                    "name": "Laadpaal Links",
+                    "ev_connected_sensor": "binary_sensor.test_wb_left_cable_connected",
+                    "ev_charging_sensor": "sensor.test_wb_left_status",
+                    "ev_charging_power_sensor": "sensor.test_wb_left_charging_power",
+                    "ev_charger_service": "number.set_value",
+                    "ev_charger_service_entity_id": "number.test_wb_left_max_current",
+                    "ev_current_control_entity": "number.test_wb_left_max_current",
+                    "ev_total_energy_sensor": "sensor.test_wb_left_charging_energy",
+                    "vehicle_soc_entity": "sensor.test_audi_etron_state_of_charge",
+                    "vehicle_range_entity": "sensor.test_audi_etron_range",
+                    "min_current": 6,
+                    "max_current": 16,
+                    "vehicle_min_current": 6,
+                    "phases": 3,
+                    "voltage": 230,
+                    "charge_mode": "always_max",
+                    "ev_battery_capacity_kwh": 95,
+                    "ev_kwh_per_100km": 25,
+                    "daily_ev_target": 10,
+                    "daily_ev_target_max": 95,
+                    "ev_target_soc": 50,
+                    "ev_target_soc_max": 100,
+                    "ev_target_type": "soc",
+                    "ev_surplus_priority": 5,
+                    "initial_current": 10,
+                },
+                {
+                    "id": "ev_charger_1",
+                    "name": "Laadpaal Rechts",
+                    "ev_connected_sensor": "binary_sensor.test_wb_right_cable_connected",
+                    "ev_charging_sensor": "sensor.test_wb_right_status",
+                    "ev_charging_power_sensor": "sensor.test_wb_right_charging_power",
+                    "ev_charger_service": "number.set_value",
+                    "ev_charger_service_entity_id": "number.test_wb_right_max_current",
+                    "ev_current_control_entity": "number.test_wb_right_max_current",
+                    "vehicle_soc_entity": "sensor.test_cooper_state_of_charge",
+                    "vehicle_range_entity": "sensor.test_cooper_range",
+                    "min_current": 6,
+                    "max_current": 16,
+                    "vehicle_min_current": None,
+                    "phases": 3,
+                    "voltage": 230,
+                    "charge_mode": "solar_plus_cheap",
+                    "ev_battery_capacity_kwh": 29,
+                    "ev_kwh_per_100km": 18,
+                    "daily_ev_target": 10,
+                    "daily_ev_target_max": 29,
+                    "ev_target_soc": 100,
+                    "ev_target_soc_max": 100,
+                    "ev_target_type": "soc",
+                    "ev_surplus_priority": 8,
+                    "initial_current": 10,
+                },
+            ],
+        },
+        options={},
+        title="SEM Test (multi-Wallbox v12.1)",
     )

--- a/tests/test_services_real.py
+++ b/tests/test_services_real.py
@@ -1,0 +1,287 @@
+"""Real-HA integration tests for SEM's ``set_option`` service.
+
+This is the test that would have caught v1.7.3-beta.1's number-entity
+staleness bug. The pure-helper contract tests in
+``test_set_option_smart_merge.py`` covered the smart-merge math and
+the structural-key gate in isolation; what they could NOT see was the
+entity lifecycle — that a number entity caches ``_attr_native_value``
+at ``__init__`` time and only refreshes on integration reload. Skipping
+the reload also skipped the refresh; the persisted options matched the
+new value but the displayed entity stayed at the old one.
+
+These tests run inside a real ``HomeAssistant`` instance (via the
+``hass`` fixture from ``pytest-homeassistant-custom-component``) and
+assert on ``sem_real_hass.states.get(...)`` — the user-visible contract — not on
+internal coordinator state. They are the tier-2 gate the
+``[live-test-before-deploy]`` memory exists to demand: any future
+``set_option`` / ``set_value`` / per-charger select rewrite must keep
+all of these green.
+
+Each test follows the canonical HA Platinum-tier pattern:
+
+1. Pre-create the sensors SEM expects to read from (so coordinator
+   first-refresh doesn't bail).
+2. ``entry.add_to_hass(hass)`` + ``async_setup`` + ``async_block_till_done``.
+3. Call the service via ``sem_real_hass.services.async_call(..., blocking=True)``.
+4. ``await sem_real_hass.async_block_till_done()`` to flush coordinator side-effects.
+5. Assert on ``sem_real_hass.states.get(entity_id).state`` — never on
+   ``coordinator.config`` or ``entry.options``, because those don't
+   match what the user sees.
+"""
+from __future__ import annotations
+
+import pytest
+
+from custom_components.solar_energy_management.const import DOMAIN
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _seed_sem_input_sensors(sem_real_hass) -> None:
+    """Seed the input sensors SEM reads at first refresh.
+
+    SEM's coordinator pulls from grid / battery / solar / EV sensors on
+    every cycle; if they don't exist the setup fails with
+    ConfigEntryNotReady. The fixture's data dict references these by
+    name so the seed values just need to be parseable floats / strings.
+    Test-specific sensor needs (e.g. multi-charger seeds the second
+    Wallbox's entities too) layer on top in their own fixtures.
+    """
+    sem_real_hass.states.async_set("sensor.test_grid_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("sensor.test_battery_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("sensor.test_battery_soc", "50", {"unit_of_measurement": "%"})
+    sem_real_hass.states.async_set("sensor.test_solar_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("sensor.test_ev_total_energy", "0", {"unit_of_measurement": "kWh"})
+    sem_real_hass.states.async_set("sensor.test_ev_charging_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("binary_sensor.test_ev_connected", "off")
+    sem_real_hass.states.async_set("binary_sensor.test_ev_charging", "off")
+    sem_real_hass.states.async_set("number.test_charger_current", "0", {"unit_of_measurement": "A"})
+
+
+async def _setup_sem(sem_real_hass, entry) -> None:
+    """Register + set up the SEM integration on ``hass``.
+
+    Returns when setup is fully settled (all platforms forwarded,
+    coordinator first-refreshed, services registered).
+    """
+    entry.add_to_hass(sem_real_hass)
+    assert await sem_real_hass.config_entries.async_setup(entry.entry_id), (
+        "SEM setup failed — check that all required input sensors are seeded "
+        "via _seed_sem_input_sensors() before calling _setup_sem()."
+    )
+    await sem_real_hass.async_block_till_done()
+
+
+# ---------------------------------------------------------------------------
+# v1.7.3-beta.1 regression — entity refreshes when set_option writes a tunable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_option_tunable_refreshes_number_entity(
+    sem_real_hass, sem_config_entry,
+) -> None:
+    """``set_option`` must update the number entity's displayed state.
+
+    The v1.7.3-beta.1 regression: ``set_option`` persisted the new
+    value to ``entry.options`` but the number entity stayed at its old
+    state because the skip-reload optimization also skipped the
+    entity refresh.
+
+    With the v1.7.3-beta.2 hotfix (route tunables through
+    ``number.set_value``), the entity's own write path runs and
+    ``_attr_native_value`` updates synchronously. This test asserts
+    the user-visible state actually changed.
+    """
+    _seed_sem_input_sensors(sem_real_hass)
+    await _setup_sem(sem_real_hass, sem_config_entry)
+
+    # Read the initial state to know what we're changing from.
+    initial = sem_real_hass.states.get("number.sem_cheap_price_threshold")
+    assert initial is not None, "number.sem_cheap_price_threshold should exist post-setup"
+    new_value = round(float(initial.state) + 0.07, 2)
+
+    # Drive the service call through the registry — same path the
+    # Config card uses in production.
+    await sem_real_hass.services.async_call(
+        DOMAIN, "set_option",
+        {"options": {"cheap_price_threshold": new_value}},
+        blocking=True,
+    )
+    await sem_real_hass.async_block_till_done()
+
+    after = sem_real_hass.states.get("number.sem_cheap_price_threshold")
+    assert after is not None
+    assert float(after.state) == new_value, (
+        f"Beta.1 regression: number entity stuck at {after.state} after "
+        f"set_option wrote {new_value}. Entity refresh broken — the user "
+        f"sees stale data even though entry.options has the new value."
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_option_tunable_does_not_trigger_reload(
+    sem_real_hass, sem_config_entry,
+) -> None:
+    """``set_option`` on a tunable key should NOT reload the integration.
+
+    The whole point of the v1.7.3-beta.1/beta.2 fix is to KEEP the
+    coordinator state alive across tunable changes — without that,
+    every Config-card tweak destroys the SensorReader's split-grid
+    discovery state (root cause for #461) and the per-charger context
+    across the multi-charger loop (root cause for #462 / #464).
+
+    We assert "no reload" by checking the coordinator instance is the
+    SAME object before and after. A reload destroys and recreates
+    runtime_data, so identity comparison catches the regression.
+    """
+    _seed_sem_input_sensors(sem_real_hass)
+    await _setup_sem(sem_real_hass, sem_config_entry)
+
+    coordinator_before = sem_config_entry.runtime_data
+    assert coordinator_before is not None
+
+    await sem_real_hass.services.async_call(
+        DOMAIN, "set_option",
+        {"options": {"cheap_price_threshold": 0.42}},
+        blocking=True,
+    )
+    await sem_real_hass.async_block_till_done()
+
+    coordinator_after = sem_config_entry.runtime_data
+    assert coordinator_after is coordinator_before, (
+        "Tunable set_option triggered a coordinator reload — destroys "
+        "split-grid discovery state, per-charger context, and the v1.7.1 "
+        "behavior #467/#468 restored. Don't add tunable keys to "
+        "_SET_OPTION_STRUCTURAL_KEYS without a strong reason."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smart-merge contract — set_option(ev_chargers=...) preserves siblings (#467)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_set_option_ev_chargers_partial_submit_preserves_sibling(
+    sem_real_hass, sem_multi_wallbox_config_entry,
+) -> None:
+    """A partial ``set_option`` on ``ev_chargers`` must not drop sibling chargers.
+
+    Reproduces the #464 cross-talk: in v1.7.2 the Config card could
+    send a one-charger ``ev_chargers`` payload and the naïve shallow
+    merge dropped the other charger from persisted state. The smart-
+    merge in #467 keys on ``id`` so a partial submit updates the
+    matching charger while keeping siblings untouched.
+
+    Runs against the dual-Wallbox fixture (RienduPre's setup shape).
+    """
+    _seed_sem_input_sensors(sem_real_hass)
+    # Multi-Wallbox needs its second charger's sensors too.
+    sem_real_hass.states.async_set("sensor.test_wb_left_charging_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("sensor.test_wb_right_charging_power", "0", {"unit_of_measurement": "W"})
+    sem_real_hass.states.async_set("number.test_wb_left_max_current", "0", {"unit_of_measurement": "A"})
+    sem_real_hass.states.async_set("number.test_wb_right_max_current", "0", {"unit_of_measurement": "A"})
+    sem_real_hass.states.async_set("binary_sensor.test_wb_left_cable_connected", "off")
+    sem_real_hass.states.async_set("binary_sensor.test_wb_right_cable_connected", "off")
+    sem_real_hass.states.async_set("sensor.test_wb_left_status", "idle")
+    sem_real_hass.states.async_set("sensor.test_wb_right_status", "idle")
+
+    await _setup_sem(sem_real_hass, sem_multi_wallbox_config_entry)
+
+    # Partial submit: only charger 1 in the payload, with one field changed.
+    await sem_real_hass.services.async_call(
+        DOMAIN, "set_option",
+        {"options": {"ev_chargers": [{"id": "ev_charger", "ev_target_soc": 85}]}},
+        blocking=True,
+    )
+    await sem_real_hass.async_block_till_done()
+
+    persisted = sem_multi_wallbox_config_entry.options.get("ev_chargers")
+    assert persisted is not None, "ev_chargers must be persisted to options"
+    by_id = {c["id"]: c for c in persisted}
+
+    # Sibling preserved
+    assert "ev_charger_1" in by_id, (
+        "#464 regression: sibling charger (ev_charger_1) dropped after "
+        "partial ev_chargers submit. Smart-merge by id is broken."
+    )
+    # Sibling's mode unchanged
+    assert by_id["ev_charger_1"]["charge_mode"] == "solar_plus_cheap"
+    # Modified charger has the new value
+    assert by_id["ev_charger"]["ev_target_soc"] == 85
+    # Modified charger's untouched fields preserved
+    assert by_id["ev_charger"]["charge_mode"] == "always_max"
+
+
+# ---------------------------------------------------------------------------
+# Per-charger fallback contract — entry.data wins when options is missing (#469)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_per_charger_select_falls_back_to_entry_data(
+    sem_real_hass, sem_multi_wallbox_config_entry,
+) -> None:
+    """A per-charger select write must fall back to ``entry.data.ev_chargers``
+    when ``entry.options.ev_chargers`` is missing.
+
+    Reproduces #469: a fresh install has ev_chargers in entry.data but
+    not entry.options. If the per-charger select setter reads only
+    entry.options, it iterates an empty list, no charger matches, and
+    the write silently no-ops AND clobbers entry.options.ev_chargers
+    with an empty list — which on next reload overrides entry.data's
+    chargers via the standard merge.
+
+    This test puts entry.options in the pre-#469 state (no ev_chargers
+    key), flips a per-charger select, and asserts (a) the change took
+    effect and (b) both chargers are still discoverable afterward.
+    """
+    _seed_sem_input_sensors(sem_real_hass)
+    for eid in (
+        "sensor.test_wb_left_charging_power", "sensor.test_wb_right_charging_power",
+        "number.test_wb_left_max_current", "number.test_wb_right_max_current",
+    ):
+        sem_real_hass.states.async_set(eid, "0", {"unit_of_measurement": "W"})
+    for eid in (
+        "binary_sensor.test_wb_left_cable_connected",
+        "binary_sensor.test_wb_right_cable_connected",
+    ):
+        sem_real_hass.states.async_set(eid, "off")
+    for eid in ("sensor.test_wb_left_status", "sensor.test_wb_right_status"):
+        sem_real_hass.states.async_set(eid, "idle")
+
+    # Fresh-install state: ev_chargers in data, NOT in options.
+    assert "ev_chargers" not in sem_multi_wallbox_config_entry.options
+    assert "ev_chargers" in sem_multi_wallbox_config_entry.data
+
+    await _setup_sem(sem_real_hass, sem_multi_wallbox_config_entry)
+
+    # Flip charger 2's mode via its per-charger select.
+    await sem_real_hass.services.async_call(
+        "select", "select_option",
+        {
+            "entity_id": "select.sem_charger_ev_charger_1_charge_mode",
+            "option": "off",
+        },
+        blocking=True,
+    )
+    await sem_real_hass.async_block_till_done()
+
+    # (a) charger 2's mode updated in persisted state
+    persisted = sem_multi_wallbox_config_entry.options.get("ev_chargers") or []
+    by_id = {c["id"]: c for c in persisted if isinstance(c, dict)}
+    assert by_id.get("ev_charger_1", {}).get("charge_mode") == "off", (
+        "#469 regression: per-charger select write silently no-op'd "
+        "because entry.options.ev_chargers was missing and the setter "
+        "didn't fall back to entry.data.ev_chargers."
+    )
+    # (b) sibling charger preserved — NOT clobbered to empty
+    assert "ev_charger" in by_id, (
+        "#469 regression: sibling charger (ev_charger) dropped from "
+        "entry.options.ev_chargers because the setter wrote [] back when "
+        "it couldn't find the key in options."
+    )

--- a/tests/test_setup_entry_smoke.py
+++ b/tests/test_setup_entry_smoke.py
@@ -82,7 +82,8 @@ def test_sem_config_entry_uses_current_schema_version(sem_config_entry) -> None:
 
     assert isinstance(sem_config_entry, MockConfigEntry)
     assert sem_config_entry.domain == DOMAIN
-    assert sem_config_entry.version == 7
+    assert sem_config_entry.version == 12
+    assert sem_config_entry.minor_version == 1
     # Multi-charger schema — wrapped list, not legacy flat keys.
     assert "ev_chargers" in sem_config_entry.data
     assert isinstance(sem_config_entry.data["ev_chargers"], list)
@@ -109,4 +110,4 @@ async def test_config_entry_can_register_with_hass(
     entries = hass.config_entries.async_entries(DOMAIN)
     assert len(entries) == 1
     assert entries[0].entry_id == sem_config_entry.entry_id
-    assert entries[0].version == 7
+    assert entries[0].version == 12


### PR DESCRIPTION
## Summary

Bridges the gap between pytest contract tests (which run in a vacuum) and the live-HA verification policy ([live-test-before-deploy] memory added after the beta.1 incident). **Caught a real bug** in the process — the smart-merge in \`set_option\` had the same entry.options / entry.data fall-through gap that PR #469 fixed for the per-charger setters. The test failed pre-fix, passes post-fix.

## What ships

### `tests/conftest.py`
- Bumps `sem_config_entry` fixture from v7 → v12.1 to match current schema (v7 pin had been stale since v11→v12 migration #135)
- Adds `sem_multi_wallbox_config_entry` — seeded from RienduPre's diagnostic dump on #462/#464 (two Wallbox Pulsars, distinct priorities + modes + vehicles + bindings). Reusable for any multi-charger contract test.
- Adds `sem_real_hass` composed fixture (`hass` + `enable_custom_integrations`). **NOT autouse** — making `enable_custom_integrations` autouse broke `test_ev_daily_reset_boundary.py` via HA's component-discovery side effects. Opt-in by requesting `sem_real_hass`.

### `tests/test_services_real.py` — 4 real-HA integration tests
1. **`test_set_option_tunable_refreshes_number_entity`** — the test that would have caught v1.7.3-beta.1's number-entity staleness bug. Calls the service through the registry, awaits coordinator settle, asserts on `hass.states.get(...).state`.
2. **`test_set_option_tunable_does_not_trigger_reload`** — coordinator identity check across a tunable change. Catches regression of the v1.7.1 skip-reload behavior #467/#468 restored.
3. **`test_set_option_ev_chargers_partial_submit_preserves_sibling`** — smart-merge contract under partial submit. **Caught a real bug** (see below).
4. **`test_per_charger_select_falls_back_to_entry_data`** — #469 contract: per-charger select write when entry.options doesn't have ev_chargers falls back to entry.data.

### `__init__.py` — fixes the smart-merge fall-through (caught by test 3)

```python
existing_list = (
    (target_entry.options or {}).get("ev_chargers")
    or (target_entry.data or {}).get("ev_chargers")
    or []
)
```

Same fall-through class PR #469 fixed in `select.py` and `number.py`, but I'd missed it in the `__init__.py` set_option smart-merge. When `entry.options.ev_chargers` doesn't exist (fresh install, never used Config card), the smart-merge gets `existing=[]` and can't preserve siblings from `entry.data`. A partial submit would append the incoming charger and DROP the others on next reload. Latent since the v1.7.2-beta.2 set_option rework; RienduPre wouldn't have hit it because by the time he made the multi-charger reports, his entry.options had already been populated by the Config card.

The framework test surfaced this immediately on the dual-Wallbox fixture — exactly the kind of regression the framework tests exist to catch.

### `tests/test_setup_entry_smoke.py`
- Schema-version assertions bumped to v12 / minor_version=1.

## Test plan

- [x] All 4 real-HA tests pass against current code
- [x] Pre-existing `test_ev_daily_reset_boundary.py` still passes (verified explicit opt-in fixture avoids the autouse leak)
- [x] Pure-helper contract tests in `test_set_option_smart_merge.py` still pass (20 tests, unchanged)
- [ ] After merge: rest of full suite green in CI

## Performance note

Each real-HA test takes 35–45s because it boots a real HomeAssistant per test. Total ~3 min for the 4 tests in this file. That's the standard cost of `pytest-homeassistant-custom-component` — comparable to HA core's own integration tests. CI-acceptable.

## What this unblocks

The `[live-test-before-deploy]` memory was a band-aid. With this PR landed, any future PR touching `set_option` / per-charger setters / entity write paths gets the same green-or-red signal pytest already gives for pure-helper bugs. Phase 2 of the testing-framework adoption (per the earlier plan file).

Refs #467 #468 #469