### PR TITLE
release: v1.7.3-beta.5 — poisoned ev_chargers storage heal + writer recovery (#462 #464)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
-# [Unreleased]
+# [1.7.3-beta.5] - 10.06.2026
 
 ## 🩹 Storage heal for poisoned `options.ev_chargers` (#462/#464 follow-up #3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [Unreleased]
+
+## 🩹 Storage heal for poisoned `options.ev_chargers` (#462/#464 follow-up #3)
+
+The writer fixes shipped in beta.1–beta.4 (#467/#468/#469 + the smart-merge
+fall-through) stopped **new** corruption of the options-side charger list, but
+none of them repaired storage that the v1.7.2 .. v1.7.3-beta.3 builds had
+already corrupted. Once `entry.options.ev_chargers` is a *partial* list
+(e.g. charger 1 only — the auto-discovery reseed plants exactly that shape
+after a `[]` clobber), the `{**data, **options}` merge hides the data-side
+sibling forever and every per-charger write targeting the missing id
+silently no-ops: the persistent "changing charger 2 does nothing at all"
+report on #462/#464 that survived all three betas. The #469 `or`-fallback
+only fires for missing/empty lists, not partial ones.
+
+### 🛠️ Bug fixes
+
+- **Setup-time storage heal** — `async_setup_entry` reconciles a poisoned `options.ev_chargers` against `entry.data` by id-union (options fields win per charger, data-only siblings restored, id-less ghost entries dropped). Idempotent: one healing write, then quiet. Logs a WARNING naming the before/after ids so support can see it happened
+- **Per-charger writers never silently no-op** — `SEMPerChargerSelect.async_select_option` / `SEMPerChargerNumber.async_set_native_value` recover a charger missing from the stored list out of `entry.data` (full dict, or a minimal `{"id": ...}` stub) and append it, with a WARNING — instead of dropping the write on the floor
+- **`_merge_ev_chargers_by_id` drops id-less entries** — they're untargetable by every write path and at registration get assigned a positional `ev_charger_<idx>` id that can collide with a real sibling (ghost charger)
+- **Config card stamps the charger `id`** — the nested per-charger editors (`sem-config-card.js`) now always carry `id` on the entries they submit, so a partial submit can never produce an id-less ghost
+
+### 🔍 Diagnostics
+
+- `diagnose` payload for the `ev_chargers` (and `all`) section now includes `ev_chargers_storage_split` — the per-side `entry.data` vs `entry.options` charger lists (id / name / charge_mode). The merged `config` block hid exactly the fact that mattered during the #462/#464 triage
+
+### 🧪 Tests
+
+- `tests/test_ev_chargers_storage_heal.py` — heal contract, writer recovery (select + number), ghost-drop contract
+- `tests/test_services_real.py::test_setup_heals_poisoned_options_ev_chargers` — real-HA boot with RienduPre-shaped poisoned storage: asserts the options list heals, charger 2 registers, and a charger-2 mode flip lands
+
+---
+
 # [1.7.3-beta.4] - 09.06.2026
 
 ## 🧪 Framework tests + caught third instance of #469 fall-through

--- a/__init__.py
+++ b/__init__.py
@@ -246,10 +246,20 @@ def _merge_ev_chargers_by_id(
             base.update(inc)
             merged.append(base)
             seen_ids.add(cid)
-        else:
+        elif cid:
             merged.append(dict(inc))
-            if cid:
-                seen_ids.add(cid)
+            seen_ids.add(cid)
+        else:
+            # Id-less entries are untargetable ghosts: per-charger writes
+            # match on ``id``, and at registration a ghost gets assigned a
+            # positional ``ev_charger_<idx>`` id that can collide with a
+            # real sibling. The Config card's nested editors used to
+            # materialize such entries (``newChargers[idx] = {}``) — drop
+            # them instead of appending.
+            _LOGGER.warning(
+                "Dropping id-less ev_chargers entry from merge: %s",
+                dict(inc),
+            )
     # Preserve existing chargers not mentioned in the incoming list —
     # appended after the incoming-derived entries to keep the result
     # deterministic.
@@ -257,6 +267,37 @@ def _merge_ev_chargers_by_id(
         if cid not in seen_ids:
             merged.append(c)
     return merged
+
+
+def _heal_ev_chargers_options(
+    data_chargers: list | None, opts_chargers: list | None,
+) -> list | None:
+    """Reconcile a poisoned ``entry.options.ev_chargers`` against entry.data.
+
+    v1.7.2 through v1.7.3-beta.3 builds could corrupt the options-side
+    charger list in several ways: the naive set_option full-replace from a
+    stale Config-card cache (#464), the pre-#469 ``[]`` clobber in the
+    per-charger select/number writers, the pre-beta.4 smart-merge
+    fall-through, and the setup-time auto-discovery reseed that plants a
+    single ``id: "ev_charger"`` entry when the merged list comes up empty.
+    Once poisoned, the merge ``{**data, **options}`` hides data-side
+    chargers forever and per-charger writes for the missing ids silently
+    no-op — the "charger 2 does nothing" symptom (#462/#464).
+
+    Heals by union-by-id: options-side fields win per charger, chargers
+    that only exist in ``entry.data`` are restored, id-less ghost entries
+    are dropped. Returns the healed list, or ``None`` when the stored list
+    is already complete (no write needed). Pure function — tested in
+    ``tests/test_ev_chargers_storage_heal.py``.
+    """
+    cleaned = [
+        c for c in (opts_chargers or [])
+        if isinstance(c, dict) and c.get("id")
+    ]
+    healed = _merge_ev_chargers_by_id(data_chargers or [], cleaned)
+    if healed == list(opts_chargers or []):
+        return None
+    return healed
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
@@ -970,6 +1011,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     # Fold the removed ev_limit_surplus switch (#235) into the Max ceiling (#245).
     # Idempotent; only acts while the legacy key is present.
     _migrate_limit_surplus_to_max(hass, entry)
+
+    # Heal a poisoned ``options.ev_chargers`` list (#462/#464 follow-up).
+    # v1.7.2..v1.7.3-beta.3 builds could leave options with a partial or
+    # ghost-ridden charger list that shadows entry.data on the merge below;
+    # writer fixes alone don't repair already-corrupted storage. Idempotent:
+    # after one healing write the reconcile returns None on every later boot.
+    if "ev_chargers" in (entry.options or {}):
+        _healed = _heal_ev_chargers_options(
+            (entry.data or {}).get("ev_chargers"),
+            entry.options.get("ev_chargers"),
+        )
+        if _healed is not None:
+            _LOGGER.warning(
+                "Healed ev_chargers options list: stored ids %s -> healed ids %s "
+                "(data-side ids: %s). See #462/#464.",
+                [c.get("id") for c in (entry.options.get("ev_chargers") or [])
+                 if isinstance(c, dict)],
+                [c.get("id") for c in _healed],
+                [c.get("id") for c in ((entry.data or {}).get("ev_chargers") or [])
+                 if isinstance(c, dict)],
+            )
+            hass.config_entries.async_update_entry(
+                entry, options={**entry.options, "ev_chargers": _healed},
+            )
 
     # Remove orphaned per-charger set-default button entities — the
     # button itself was retired in v1.7.0-beta.11 (#355 follow-up).
@@ -3247,17 +3312,42 @@ async def _async_register_phase_services(
         except Exception:  # noqa: BLE001
             pass
 
-        return {
-            "section": section,
-            "payload": {
-                "version": sem_version,
-                "entry_id": target.entry_id,
-                "entry_version": f"{target.version}.{getattr(target, 'minor_version', 0)}",
-                "config": config,
-                "state": state,
-                "recent_logs": recent_logs,
-            },
+        payload = {
+            "version": sem_version,
+            "entry_id": target.entry_id,
+            "entry_version": f"{target.version}.{getattr(target, 'minor_version', 0)}",
+            "config": config,
+            "state": state,
+            "recent_logs": recent_logs,
         }
+
+        # ev_chargers storage split (#462/#464 follow-up). The merged
+        # ``config`` block hides whether a charger entry lives in
+        # entry.data or entry.options — the load-bearing fact when a
+        # per-charger write silently no-ops because the options-side
+        # list is partial. Surface both sides so the next triage round
+        # doesn't need .storage access.
+        if section in ("all", "ev_chargers"):
+            def _chargers_brief(side: dict | None):
+                lst = (side or {}).get("ev_chargers")
+                if not isinstance(lst, list):
+                    return "absent"
+                return [
+                    {
+                        "id": c.get("id"),
+                        "name": c.get("name"),
+                        "charge_mode": c.get("charge_mode"),
+                    }
+                    if isinstance(c, dict)
+                    else {"invalid_entry": type(c).__name__}
+                    for c in lst
+                ]
+            payload["ev_chargers_storage_split"] = {
+                "data": _chargers_brief(target.data),
+                "options": _chargers_brief(target.options),
+            }
+
+        return {"section": section, "payload": payload}
 
     hass.services.async_register(
         DOMAIN,

--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -5879,11 +5879,11 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                         <ha-icon icon="mdi:ev-station" style="--mdc-icon-size:18px;color:#5BC8D8"></ha-icon>
                         ${this._chargerFriendlyName(a)}
                     </div>
-                    ${this._renderPickerNested(r,"ev_connected_sensor","config_ev_connected_sensor","binary_sensor",null,e,"config_help_ev_connected_sensor")}
-                    ${this._renderPickerNested(r,"ev_charging_power_sensor","config_ev_charging_power","sensor","power",e,"config_help_ev_charging_power")}
-                    ${this._renderPickerNested(r,"ev_current_control_entity","config_ev_current_control","number",null,e,"config_help_ev_current_control")}
-                    ${this._renderPickerNested(r,"vehicle_soc_entity","config_ev_vehicle_soc","sensor",null,e,"config_help_ev_vehicle_soc")}
-                    ${this._renderTargetTypeSelectNested(r,i,e)}
+                    ${this._renderPickerNested(r,a,"ev_connected_sensor","config_ev_connected_sensor","binary_sensor",null,e,"config_help_ev_connected_sensor")}
+                    ${this._renderPickerNested(r,a,"ev_charging_power_sensor","config_ev_charging_power","sensor","power",e,"config_help_ev_charging_power")}
+                    ${this._renderPickerNested(r,a,"ev_current_control_entity","config_ev_current_control","number",null,e,"config_help_ev_current_control")}
+                    ${this._renderPickerNested(r,a,"vehicle_soc_entity","config_ev_vehicle_soc","sensor",null,e,"config_help_ev_vehicle_soc")}
+                    ${this._renderTargetTypeSelectNested(r,a,i,e)}
                     <div class="stepper-pair">
                         ${this._renderStepper(`number.sem_charger_${a}_minimum_current`,"minimum_soc",t,"tile_help_min_amps")}
                         ${this._renderStepper(`number.sem_charger_${a}_vehicle_min_current`,"vehicle_min_current",t,"tile_help_vehicle_min_amps")}
@@ -6007,40 +6007,40 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                 ${this._renderOptionSlider("hot_water_minimum_temperature","config_hw_min_temperature",{min:30,max:55,step:1,unit:"°C",default:40},e,"config_help_hw_min_temperature")}
                 ${this._renderOptionSlider("hot_water_priority","config_hw_priority",{min:1,max:10,step:1,unit:"",default:5},e,"config_help_hw_priority")}
             </div>
-        `}_renderTargetTypeSelectNested(t,e,i){const s=e.ev_target_type||"kwh",r=!!e.vehicle_soc_entity,a=`ev_chargers.${t}.ev_target_type`,o=this._saveStatus[a];return W`
+        `}_renderTargetTypeSelectNested(t,e,i,s){const r=i.ev_target_type||"kwh",a=!!i.vehicle_soc_entity,o=`ev_chargers.${t}.ev_target_type`,n=this._saveStatus[o];return W`
             <div class="stepper-cell">
                 <div class="ctrl-row">
                     <span class="ctrl-label">${this._t("config_ev_target_type")}</span>
-                    <select class="sem-select" .value=${s} @change=${async e=>{const s=e.target.value,r=(i.ev_chargers||[]).map(t=>({...t}));r[t]||(r[t]={}),r[t].ev_target_type=s,await this._saveOption("ev_chargers",r,a)}}>
-                        <option value="kwh" ?selected=${"soc"!==s}>
+                    <select class="sem-select" .value=${r} @change=${async i=>{const r=i.target.value,a=(s.ev_chargers||[]).map(t=>({...t}));a[t]||(a[t]={}),!a[t].id&&e&&(a[t].id=e),a[t].ev_target_type=r,await this._saveOption("ev_chargers",a,o)}}>
+                        <option value="kwh" ?selected=${"soc"!==r}>
                             ${this._t("config_ev_target_type_kwh")}
                         </option>
-                        <option value="soc" ?disabled=${!r}
-                                            ?selected=${"soc"===s}>
-                            ${this._t("config_ev_target_type_soc")}${r?"":" — "+this._t("config_ev_target_type_requires_sensor")}
+                        <option value="soc" ?disabled=${!a}
+                                            ?selected=${"soc"===r}>
+                            ${this._t("config_ev_target_type_soc")}${a?"":" — "+this._t("config_ev_target_type_requires_sensor")}
                         </option>
                     </select>
                 </div>
-                ${"saving"===o?W`<div class="save-status">${this._t("config_saving")}…</div>`:K}
-                ${"ok"===o?W`<div class="save-status ok">✓</div>`:K}
+                ${"saving"===n?W`<div class="save-status">${this._t("config_saving")}…</div>`:K}
+                ${"ok"===n?W`<div class="save-status ok">✓</div>`:K}
                 ${this._showHelp?W`<div class="setting-help-text">${this._t("config_help_ev_target_type")}</div>`:K}
             </div>
-        `}_renderPickerNested(t,e,i,s,r,a,o){const n=a.ev_chargers||[],l=n[t]?.[e]||"",c=`ev_chargers.${t}.${e}`,d=this._saveStatus[c],p=async i=>{const s=(a.ev_chargers||[]).map(t=>({...t}));s[t]||(s[t]={}),s[t][e]=i,await this._saveOption("ev_chargers",s,c)};return W`
+        `}_renderPickerNested(t,e,i,s,r,a,o,n){const l=o.ev_chargers||[],c=l[t]?.[i]||"",d=`ev_chargers.${t}.${i}`,p=this._saveStatus[d],h=async s=>{const r=(o.ev_chargers||[]).map(t=>({...t}));r[t]||(r[t]={}),!r[t].id&&e&&(r[t].id=e),r[t][i]=s,await this._saveOption("ev_chargers",r,d)};return W`
             <div class="picker-cell">
                 <div class="picker-row">
-                    <span class="picker-label">${this._t(i)}</span>
+                    <span class="picker-label">${this._t(s)}</span>
                     <ha-entity-picker
                         .hass=${this._hass}
-                        .value=${l}
-                        .includeDomains=${[s]}
-                        .includeDeviceClasses=${r?[r]:void 0}
+                        .value=${c}
+                        .includeDomains=${[r]}
+                        .includeDeviceClasses=${a?[a]:void 0}
                         .allowCustomEntity=${!1}
-                        @value-changed=${t=>p(t.detail?.value||"")}>
+                        @value-changed=${t=>h(t.detail?.value||"")}>
                     </ha-entity-picker>
                 </div>
-                ${"saving"===d?W`<div class="save-status">${this._t("config_saving")}…</div>`:K}
-                ${"ok"===d?W`<div class="save-status ok">✓ ${this._t("config_saved")}</div>`:K}
-                ${this._showHelp&&o?W`<div class="setting-help-text">${this._t(o)}</div>`:K}
+                ${"saving"===p?W`<div class="save-status">${this._t("config_saving")}…</div>`:K}
+                ${"ok"===p?W`<div class="save-status ok">✓ ${this._t("config_saved")}</div>`:K}
+                ${this._showHelp&&n?W`<div class="setting-help-text">${this._t(n)}</div>`:K}
             </div>
         `}_renderPicker(t,e,i,s,r,a){const o=r[t]||"",n=this._saveStatus[t];return W`
             <div class="picker-cell">

--- a/dashboard/card/src/cards/sem-config-card.js
+++ b/dashboard/card/src/cards/sem-config-card.js
@@ -528,15 +528,15 @@ class SEMConfigCard extends SEMLitBase {
                         <ha-icon icon="mdi:ev-station" style="--mdc-icon-size:18px;color:#5BC8D8"></ha-icon>
                         ${this._chargerFriendlyName(cid)}
                     </div>
-                    ${this._renderPickerNested(idx, 'ev_connected_sensor', 'config_ev_connected_sensor',
+                    ${this._renderPickerNested(idx, cid, 'ev_connected_sensor', 'config_ev_connected_sensor',
                         'binary_sensor', null, opts, 'config_help_ev_connected_sensor')}
-                    ${this._renderPickerNested(idx, 'ev_charging_power_sensor', 'config_ev_charging_power',
+                    ${this._renderPickerNested(idx, cid, 'ev_charging_power_sensor', 'config_ev_charging_power',
                         'sensor', 'power', opts, 'config_help_ev_charging_power')}
-                    ${this._renderPickerNested(idx, 'ev_current_control_entity', 'config_ev_current_control',
+                    ${this._renderPickerNested(idx, cid, 'ev_current_control_entity', 'config_ev_current_control',
                         'number', null, opts, 'config_help_ev_current_control')}
-                    ${this._renderPickerNested(idx, 'vehicle_soc_entity', 'config_ev_vehicle_soc',
+                    ${this._renderPickerNested(idx, cid, 'vehicle_soc_entity', 'config_ev_vehicle_soc',
                         'sensor', null, opts, 'config_help_ev_vehicle_soc')}
-                    ${this._renderTargetTypeSelectNested(idx, charger, opts)}
+                    ${this._renderTargetTypeSelectNested(idx, cid, charger, opts)}
                     <div class="stepper-pair">
                         ${this._renderStepper(`number.sem_charger_${cid}_minimum_current`, 'minimum_soc', T, 'tile_help_min_amps')}
                         ${this._renderStepper(`number.sem_charger_${cid}_vehicle_min_current`, 'vehicle_min_current', T, 'tile_help_vehicle_min_amps')}
@@ -757,7 +757,7 @@ class SEMConfigCard extends SEMLitBase {
     // no ``vehicle_soc_entity`` configured — preventing the saved-bad-state
     // class of bug that idled PROD 2026-06-06. The runtime trusts the
     // saved config; the GUI is the only gatekeeper.
-    _renderTargetTypeSelectNested(chargerIndex, charger, opts) {
+    _renderTargetTypeSelectNested(chargerIndex, cid, charger, opts) {
         const cur = charger.ev_target_type || 'kwh';
         const hasSensor = !!charger.vehicle_soc_entity;
         const statusKey = `ev_chargers.${chargerIndex}.ev_target_type`;
@@ -766,6 +766,10 @@ class SEMConfigCard extends SEMLitBase {
             const val = e.target.value;
             const newChargers = (opts.ev_chargers || []).map(c => ({ ...c }));
             if (!newChargers[chargerIndex]) newChargers[chargerIndex] = {};
+            // Always carry the charger id — the backend smart-merge targets
+            // by id and drops id-less entries (would otherwise become a
+            // ghost charger colliding with a real sibling, #462/#464).
+            if (!newChargers[chargerIndex].id && cid) newChargers[chargerIndex].id = cid;
             newChargers[chargerIndex].ev_target_type = val;
             await this._saveOption('ev_chargers', newChargers, statusKey);
         };
@@ -792,7 +796,7 @@ class SEMConfigCard extends SEMLitBase {
 
     // Entity picker bound to ev_chargers[index][key] — writes the nested
     // list shape back via config_entries/update.
-    _renderPickerNested(chargerIndex, chargerKey, labelKey, domain, deviceClass, opts, helpKey) {
+    _renderPickerNested(chargerIndex, cid, chargerKey, labelKey, domain, deviceClass, opts, helpKey) {
         const chargers = opts.ev_chargers || [];
         const cur = chargers[chargerIndex]?.[chargerKey] || '';
         const statusKey = `ev_chargers.${chargerIndex}.${chargerKey}`;
@@ -800,6 +804,10 @@ class SEMConfigCard extends SEMLitBase {
         const onChange = async (val) => {
             const newChargers = (opts.ev_chargers || []).map(c => ({ ...c }));
             if (!newChargers[chargerIndex]) newChargers[chargerIndex] = {};
+            // Always carry the charger id — the backend smart-merge targets
+            // by id and drops id-less entries (would otherwise become a
+            // ghost charger colliding with a real sibling, #462/#464).
+            if (!newChargers[chargerIndex].id && cid) newChargers[chargerIndex].id = cid;
             newChargers[chargerIndex][chargerKey] = val;
             await this._saveOption('ev_chargers', newChargers, statusKey);
         };

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.3-beta.4"
+  "version": "1.7.3-beta.5"
 }

--- a/number.py
+++ b/number.py
@@ -754,16 +754,36 @@ class SEMPerChargerNumber(CoordinatorEntity, NumberEntity):
         # merge ``{**data, **options}`` on next reload overrides data's chargers
         # with the empty list — every charger disappears. Same latent foot-gun
         # as in select.py:SEMPerChargerSelect.async_select_option.
-        source_chargers = (
-            new_options.get("ev_chargers")
-            or (self._entry.data or {}).get("ev_chargers")
-            or []
-        )
-        ev_chargers = [dict(c) for c in source_chargers]
+        data_chargers = (self._entry.data or {}).get("ev_chargers") or []
+        source_chargers = new_options.get("ev_chargers") or data_chargers
+        ev_chargers = [dict(c) for c in source_chargers if isinstance(c, dict)]
         for charger in ev_chargers:
             if charger.get("id") == self._charger_id:
                 charger[self._config_key] = value
                 break
+        else:
+            # This charger's id is missing from the options-side list — a
+            # *partially* poisoned ``options.ev_chargers`` (v1.7.2 ..
+            # v1.7.3-beta.3 builds could strip a sibling from it). The
+            # ``or``-fallback above only fires for missing/empty lists, so
+            # without this branch the write is a silent no-op and the user
+            # sees "changing charger 2 does nothing" (#462/#464). Recover
+            # the charger's dict from entry.data and append it.
+            recovered = next(
+                (dict(c) for c in data_chargers
+                 if isinstance(c, dict) and c.get("id") == self._charger_id),
+                {"id": self._charger_id},
+            )
+            recovered[self._config_key] = value
+            ev_chargers.append(recovered)
+            _LOGGER.warning(
+                "Charger '%s' was missing from the stored ev_chargers list "
+                "(ids: %s) — recovered it from entry.data so the %s write "
+                "isn't lost",
+                self._charger_id,
+                [c.get("id") for c in ev_chargers[:-1]],
+                self._config_key,
+            )
         new_options["ev_chargers"] = ev_chargers
 
         if hasattr(self.coordinator, "config") and isinstance(self.coordinator.config, dict):

--- a/select.py
+++ b/select.py
@@ -371,16 +371,36 @@ class SEMPerChargerSelect(CoordinatorEntity, SelectEntity):
         # go unavailable. Latent since multi-charger landed; would manifest the
         # first time any user clicked a per-charger select without first having
         # touched a Config-card field that populates options.ev_chargers.
-        source_chargers = (
-            new_options.get("ev_chargers")
-            or (self._entry.data or {}).get("ev_chargers")
-            or []
-        )
-        ev_chargers = [dict(c) for c in source_chargers]
+        data_chargers = (self._entry.data or {}).get("ev_chargers") or []
+        source_chargers = new_options.get("ev_chargers") or data_chargers
+        ev_chargers = [dict(c) for c in source_chargers if isinstance(c, dict)]
         for charger in ev_chargers:
             if charger.get("id") == self._charger_id:
                 charger[self._config_key] = option
                 break
+        else:
+            # This charger's id is missing from the options-side list — a
+            # *partially* poisoned ``options.ev_chargers`` (v1.7.2 ..
+            # v1.7.3-beta.3 builds could strip a sibling from it). The
+            # ``or``-fallback above only fires for missing/empty lists, so
+            # without this branch the write is a silent no-op and the user
+            # sees "changing charger 2 does nothing" (#462/#464). Recover
+            # the charger's dict from entry.data and append it.
+            recovered = next(
+                (dict(c) for c in data_chargers
+                 if isinstance(c, dict) and c.get("id") == self._charger_id),
+                {"id": self._charger_id},
+            )
+            recovered[self._config_key] = option
+            ev_chargers.append(recovered)
+            _LOGGER.warning(
+                "Charger '%s' was missing from the stored ev_chargers list "
+                "(ids: %s) — recovered it from entry.data so the %s write "
+                "isn't lost",
+                self._charger_id,
+                [c.get("id") for c in ev_chargers[:-1]],
+                self._config_key,
+            )
         new_options["ev_chargers"] = ev_chargers
         if isinstance(getattr(self.coordinator, "config", None), dict):
             self.coordinator.config.update({**self._entry.data, **new_options})

--- a/tests/test_ev_chargers_storage_heal.py
+++ b/tests/test_ev_chargers_storage_heal.py
@@ -1,0 +1,261 @@
+"""Storage-heal + writer-recovery tests for poisoned ``options.ev_chargers``.
+
+Follow-up to #462/#464. The writer fixes (#467/#468/#469 + the beta.4
+smart-merge fall-through) stopped NEW corruption of the options-side
+charger list, but none of them repaired storage that earlier builds
+(v1.7.2 .. v1.7.3-beta.3) had already corrupted:
+
+* naive set_option full-replace from a stale Config-card cache could
+  drop a sibling charger,
+* the pre-#469 per-charger select/number writers could clobber the
+  list to ``[]``,
+* the setup-time auto-discovery reseed then planted a single
+  ``id: "ev_charger"`` entry — permanently shadowing the data-side
+  chargers via the ``{**data, **options}`` merge.
+
+Once poisoned, a per-charger write for a missing id silently no-op'd
+(the #469 ``or``-fallback only fires for missing/EMPTY lists, not
+partial ones) — the "changing charger 2 does nothing" symptom.
+
+Three layers under test here:
+
+1. ``_heal_ev_chargers_options`` — pure setup-time reconcile that
+   unions data + options by id (options fields win) and drops id-less
+   ghost entries.
+2. ``SEMPerChargerSelect`` / ``SEMPerChargerNumber`` — when the
+   charger id is missing from the stored list, the write recovers the
+   charger from ``entry.data`` and appends it (with a WARNING) instead
+   of silently no-op'ing.
+3. ``_merge_ev_chargers_by_id`` — id-less incoming entries are dropped
+   (they'd otherwise become positional ghosts colliding with real
+   siblings at registration).
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import MagicMock
+
+from homeassistant.components.number import NumberEntityDescription
+from homeassistant.components.select import SelectEntityDescription
+
+from custom_components.solar_energy_management import (
+    _heal_ev_chargers_options,
+    _merge_ev_chargers_by_id,
+)
+from custom_components.solar_energy_management.number import SEMPerChargerNumber
+from custom_components.solar_energy_management.select import SEMPerChargerSelect
+
+
+TWO_CHARGERS_DATA = [
+    {
+        "id": "ev_charger",
+        "name": "Laadpaal Links",
+        "charge_mode": "solar_only",
+        "ev_target_soc": 80,
+        "vehicle_soc_entity": "sensor.audi_soc",
+    },
+    {
+        "id": "ev_charger_1",
+        "name": "Laadpaal Rechts",
+        "charge_mode": "solar_plus_cheap",
+        "ev_target_soc": 100,
+        "vehicle_soc_entity": "sensor.cooper_soc",
+    },
+]
+
+
+# ─────────────────────────────────────────────────────────────────
+# 1. _heal_ev_chargers_options — the setup-time storage repair
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestHealEvChargersOptions:
+    def test_partial_options_restores_data_sibling(self):
+        """The RienduPre shape: options has charger 1 only, data has both."""
+        poisoned = [{"id": "ev_charger", "name": "Laadpaal Links",
+                     "charge_mode": "always_max"}]
+        healed = _heal_ev_chargers_options(TWO_CHARGERS_DATA, poisoned)
+        assert healed is not None
+        by_id = {c["id"]: c for c in healed}
+        assert set(by_id) == {"ev_charger", "ev_charger_1"}
+        # options-side field wins for the charger that was in options
+        assert by_id["ev_charger"]["charge_mode"] == "always_max"
+        # data-only fields of that charger are preserved (union, not replace)
+        assert by_id["ev_charger"]["ev_target_soc"] == 80
+        # the data-only sibling is restored verbatim
+        assert by_id["ev_charger_1"]["charge_mode"] == "solar_plus_cheap"
+
+    def test_empty_options_list_restores_all_data_chargers(self):
+        """The pre-#469 ``[]`` clobber shape."""
+        healed = _heal_ev_chargers_options(TWO_CHARGERS_DATA, [])
+        assert healed is not None
+        assert [c["id"] for c in healed] == ["ev_charger", "ev_charger_1"]
+
+    def test_idless_ghost_entries_are_dropped(self):
+        """Ghosts (Config-card ``newChargers[idx] = {}``) are removed."""
+        poisoned = [
+            {"id": "ev_charger", "charge_mode": "off"},
+            {"ev_target_type": "soc"},  # ghost — no id
+        ]
+        healed = _heal_ev_chargers_options(TWO_CHARGERS_DATA, poisoned)
+        assert healed is not None
+        assert all(c.get("id") for c in healed)
+        assert {c["id"] for c in healed} == {"ev_charger", "ev_charger_1"}
+
+    def test_complete_options_list_is_left_alone(self):
+        """Healthy storage → no write (returns None) so setup stays quiet."""
+        complete = _heal_ev_chargers_options(TWO_CHARGERS_DATA, [])
+        # one heal pass produces the stable union…
+        assert complete is not None
+        # …which a second pass recognises as already-healed
+        assert _heal_ev_chargers_options(TWO_CHARGERS_DATA, complete) is None
+
+    def test_options_only_charger_is_preserved(self):
+        """A charger that exists only in options (added via flow) survives."""
+        opts = [{"id": "ev_charger_2", "name": "Garage", "charge_mode": "off"}]
+        healed = _heal_ev_chargers_options(TWO_CHARGERS_DATA, opts)
+        assert healed is not None
+        assert {c["id"] for c in healed} == {
+            "ev_charger", "ev_charger_1", "ev_charger_2",
+        }
+
+    def test_no_data_side_chargers_is_noop_for_healthy_options(self):
+        """Installs whose chargers live purely in options stay untouched."""
+        opts = [dict(c) for c in TWO_CHARGERS_DATA]
+        assert _heal_ev_chargers_options(None, opts) is None
+
+
+# ─────────────────────────────────────────────────────────────────
+# 2. Per-charger writers recover a charger missing from the stored list
+# ─────────────────────────────────────────────────────────────────
+
+
+def _mock_coordinator(config: dict) -> MagicMock:
+    coord = MagicMock()
+    coord.last_update_success = True
+    coord.config = config
+    coord.device_info = {"identifiers": {("solar_energy_management", "test")}}
+    return coord
+
+
+def _mock_entry(data: dict, options: dict) -> MagicMock:
+    entry = MagicMock()
+    entry.data = data
+    entry.options = options
+    entry.entry_id = "test_entry_poisoned"
+    return entry
+
+
+def _poisoned_fixtures():
+    """data has both chargers; options has charger 1 ONLY (poisoned)."""
+    data = {"ev_chargers": [dict(c) for c in TWO_CHARGERS_DATA]}
+    options = {"ev_chargers": [
+        {"id": "ev_charger", "name": "Laadpaal Links", "charge_mode": "always_max"},
+    ]}
+    coord = _mock_coordinator({**data, **options})
+    entry = _mock_entry(data, options)
+    return coord, entry
+
+
+@pytest.mark.unit
+class TestPerChargerWriterRecovery:
+    @pytest.mark.asyncio
+    async def test_select_write_recovers_charger_missing_from_options(self, caplog):
+        """#462/#464: charger 2's mode flip must land even when its id is
+        missing from a non-empty ``options.ev_chargers`` list."""
+        coord, entry = _poisoned_fixtures()
+        desc = SelectEntityDescription(
+            key="charger_ev_charger_1_charge_mode",
+            options=["solar_only", "min_plus_solar", "always_max", "off"],
+        )
+        sel = SEMPerChargerSelect(
+            coord, desc, entry, "ev_charger_1", "charge_mode", "solar_plus_cheap",
+        )
+        sel.hass = coord.hass = MagicMock()
+        sel.async_write_ha_state = MagicMock()
+
+        await sel.async_select_option("off")
+
+        sel.hass.config_entries.async_update_entry.assert_called_once()
+        new_options = sel.hass.config_entries.async_update_entry.call_args[1]["options"]
+        by_id = {c["id"]: c for c in new_options["ev_chargers"]}
+        # the write landed — recovered from entry.data, not silently dropped
+        assert by_id["ev_charger_1"]["charge_mode"] == "off"
+        # recovery pulled the full data-side dict, not a bare stub
+        assert by_id["ev_charger_1"]["vehicle_soc_entity"] == "sensor.cooper_soc"
+        # the sibling that WAS in options is untouched
+        assert by_id["ev_charger"]["charge_mode"] == "always_max"
+        # the runtime config mirror sees the recovered charger too
+        runtime_by_id = {
+            c["id"]: c for c in coord.config["ev_chargers"]
+        }
+        assert runtime_by_id["ev_charger_1"]["charge_mode"] == "off"
+        # never silent: the anomaly is logged
+        assert "missing from the stored ev_chargers list" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_number_write_recovers_charger_missing_from_options(self, caplog):
+        coord, entry = _poisoned_fixtures()
+        desc = NumberEntityDescription(key="charger_ev_charger_1_target_soc")
+        num = SEMPerChargerNumber(
+            coord, desc, entry, "ev_charger_1", "ev_target_soc", 100,
+        )
+        num.hass = coord.hass = MagicMock()
+        num.async_write_ha_state = MagicMock()
+
+        await num.async_set_native_value(80.0)
+
+        num.hass.config_entries.async_update_entry.assert_called_once()
+        new_options = num.hass.config_entries.async_update_entry.call_args[1]["options"]
+        by_id = {c["id"]: c for c in new_options["ev_chargers"]}
+        assert by_id["ev_charger_1"]["ev_target_soc"] == 80.0
+        assert by_id["ev_charger"]["charge_mode"] == "always_max"
+        assert "missing from the stored ev_chargers list" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_select_write_unknown_charger_creates_stub(self):
+        """Charger missing from BOTH sides still persists the write under a
+        minimal ``{"id": ...}`` stub rather than vanishing."""
+        coord, entry = _poisoned_fixtures()
+        entry.data = {"ev_chargers": []}
+        desc = SelectEntityDescription(
+            key="charger_ev_charger_9_charge_mode",
+            options=["solar_only", "off"],
+        )
+        sel = SEMPerChargerSelect(
+            coord, desc, entry, "ev_charger_9", "charge_mode", "solar_only",
+        )
+        sel.hass = coord.hass = MagicMock()
+        sel.async_write_ha_state = MagicMock()
+
+        await sel.async_select_option("off")
+
+        new_options = sel.hass.config_entries.async_update_entry.call_args[1]["options"]
+        by_id = {c["id"]: c for c in new_options["ev_chargers"]}
+        assert by_id["ev_charger_9"] == {"id": "ev_charger_9", "charge_mode": "off"}
+
+
+# ─────────────────────────────────────────────────────────────────
+# 3. _merge_ev_chargers_by_id drops id-less ghosts
+# ─────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestMergeDropsGhosts:
+    def test_incoming_without_id_is_dropped(self):
+        existing = [{"id": "A", "charge_mode": "off"}]
+        incoming = [{"name": "Stray", "charge_mode": "solar_only"}]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert result == [{"id": "A", "charge_mode": "off"}]
+
+    def test_ghost_drop_keeps_valid_incoming_entries(self):
+        existing = [{"id": "A", "charge_mode": "off"}]
+        incoming = [
+            {"ev_target_type": "soc"},          # ghost
+            {"id": "A", "charge_mode": "always_max"},
+            {"id": "B", "name": "New"},
+        ]
+        result = _merge_ev_chargers_by_id(existing, incoming)
+        assert {c["id"] for c in result} == {"A", "B"}
+        assert next(c for c in result if c["id"] == "A")["charge_mode"] == "always_max"

--- a/tests/test_services_real.py
+++ b/tests/test_services_real.py
@@ -285,3 +285,100 @@ async def test_per_charger_select_falls_back_to_entry_data(
         "entry.options.ev_chargers because the setter wrote [] back when "
         "it couldn't find the key in options."
     )
+
+
+# ---------------------------------------------------------------------------
+# Poisoned-storage heal (#462/#464 follow-up) — setup repairs a partial
+# options.ev_chargers list left behind by v1.7.2..v1.7.3-beta.3 builds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_heals_poisoned_options_ev_chargers(
+    sem_real_hass, sem_multi_wallbox_config_entry,
+) -> None:
+    """Setup must repair a PARTIAL ``options.ev_chargers`` list.
+
+    The writer fixes (#467/#468/#469 + beta.4) stopped new corruption,
+    but an install that went through the broken builds can already have
+    options.ev_chargers = [charger 1 only] in storage (e.g. via the
+    pre-#469 ``[]`` clobber followed by the auto-discovery reseed). The
+    ``{**data, **options}`` merge then hides charger 2 forever: it never
+    registers, and per-charger writes targeting its id silently no-op —
+    the persistent "charger 2 does nothing" report on #462/#464.
+
+    This test seeds exactly that storage shape, boots SEM, and asserts:
+    (a) the options list is healed to contain both chargers, with the
+    options-side field winning for the charger that was present;
+    (b) charger 2 registered (its per-charger select exists);
+    (c) a charger-2 mode flip lands in persisted options.
+    """
+    _seed_sem_input_sensors(sem_real_hass)
+    for eid in (
+        "sensor.test_wb_left_charging_power", "sensor.test_wb_right_charging_power",
+        "number.test_wb_left_max_current", "number.test_wb_right_max_current",
+    ):
+        sem_real_hass.states.async_set(eid, "0", {"unit_of_measurement": "W"})
+    for eid in (
+        "binary_sensor.test_wb_left_cable_connected",
+        "binary_sensor.test_wb_right_cable_connected",
+    ):
+        sem_real_hass.states.async_set(eid, "off")
+    for eid in ("sensor.test_wb_left_status", "sensor.test_wb_right_status"):
+        sem_real_hass.states.async_set(eid, "idle")
+
+    entry = sem_multi_wallbox_config_entry
+    entry.add_to_hass(sem_real_hass)
+    # Poisoned shape: options has charger 1 ONLY (with a diverged mode),
+    # data still has both chargers. Mirrors the auto-discovery reseed
+    # aftermath seen on RienduPre's install.
+    sem_real_hass.config_entries.async_update_entry(
+        entry,
+        options={
+            "ev_chargers": [
+                {
+                    "id": "ev_charger",
+                    "name": "Laadpaal Links",
+                    "charge_mode": "always_max",
+                },
+            ],
+        },
+    )
+
+    assert await sem_real_hass.config_entries.async_setup(entry.entry_id)
+    await sem_real_hass.async_block_till_done()
+
+    # (a) storage healed: both chargers back, options-side mode preserved
+    healed = entry.options.get("ev_chargers") or []
+    by_id = {c["id"]: c for c in healed if isinstance(c, dict)}
+    assert set(by_id) == {"ev_charger", "ev_charger_1"}, (
+        "setup-time heal did not restore the data-side sibling into "
+        "options.ev_chargers — partial options list still shadows entry.data."
+    )
+    assert by_id["ev_charger"]["charge_mode"] == "always_max"
+    assert by_id["ev_charger_1"]["charge_mode"] == "solar_plus_cheap"
+
+    # (b) charger 2 actually registered — its per-charger select exists
+    assert sem_real_hass.states.get(
+        "select.sem_charger_ev_charger_1_charge_mode"
+    ) is not None, (
+        "charger 2 did not register its per-charger entities — the merged "
+        "config at setup still came up without it."
+    )
+
+    # (c) a charger-2 write lands
+    await sem_real_hass.services.async_call(
+        "select", "select_option",
+        {
+            "entity_id": "select.sem_charger_ev_charger_1_charge_mode",
+            "option": "off",
+        },
+        blocking=True,
+    )
+    await sem_real_hass.async_block_till_done()
+    persisted = {
+        c["id"]: c
+        for c in (entry.options.get("ev_chargers") or [])
+        if isinstance(c, dict)
+    }
+    assert persisted["ev_charger_1"]["charge_mode"] == "off"

--- a/tests/test_set_option_smart_merge.py
+++ b/tests/test_set_option_smart_merge.py
@@ -131,16 +131,23 @@ class TestMergeEvChargersById:
         result[0]["charge_mode"] = "always_max"
         assert existing[0]["charge_mode"] == "off"
 
-    def test_incoming_without_id_is_appended(self):
-        """An incoming dict missing an id is appended (no merge target)."""
+    def test_incoming_without_id_is_dropped(self):
+        """An incoming dict missing an id is dropped, not appended.
+
+        Contract changed post-beta.4 (#462/#464 follow-up): id-less
+        entries are untargetable by every per-charger write path, and at
+        registration they get assigned a positional ``ev_charger_<idx>``
+        id that can collide with a real sibling — a ghost charger. The
+        Config card's nested editors used to materialize exactly this
+        shape (``newChargers[idx] = {}``).
+        """
         existing = [{"id": "A", "charge_mode": "off"}]
         incoming = [{"name": "Stray", "charge_mode": "solar_only"}]
         result = _merge_ev_chargers_by_id(existing, incoming)
-        assert len(result) == 2
-        # Existing 'A' preserved
-        assert any(c.get("id") == "A" for c in result)
-        # Stray appended
-        assert any(c.get("name") == "Stray" for c in result)
+        assert len(result) == 1
+        # Existing 'A' preserved; stray ghost dropped
+        assert result[0].get("id") == "A"
+        assert not any(c.get("name") == "Stray" for c in result)
 
     def test_non_dict_entries_are_skipped(self):
         """Defensive — garbage entries on either side never raise."""


### PR DESCRIPTION
## Summary

Ships the poisoned-storage fix for the persistent #462/#464 "charger 2 does nothing" reports, plus the v1.7.3-beta.5 release bump.

The writer fixes in beta.1–beta.4 (#467/#468/#469 + smart-merge fall-through) stopped **new** corruption of `options.ev_chargers`, but never repaired storage the v1.7.2..v1.7.3-beta.3 builds had already corrupted. A *partial* options list (charger 1 only — the auto-discovery reseed plants exactly that after a `[]` clobber) shadows `entry.data` via `{**data, **options}` forever, and the #469 `or`-fallback only fires for missing/EMPTY lists. Every write targeting the missing charger id silently no-op'd.

Four layers:

1. **Setup-time storage heal** (`__init__.py`) — reconciles `options.ev_chargers` against `entry.data` by id-union (options fields win, data-only siblings restored, id-less ghosts dropped). Idempotent; WARNING names before/after ids.
2. **Writers never silently no-op** (`select.py` / `number.py`) — a charger missing from the stored list is recovered from `entry.data` and appended, with a WARNING.
3. **Ghost prevention** — `_merge_ev_chargers_by_id` drops id-less entries; the Config card's nested editors now always stamp the charger `id` (bundle rebuilt).
4. **Diagnostics** — `diagnose` `ev_chargers` section now reports `ev_chargers_storage_split` (entry.data vs entry.options per side).

## Verification

- New `tests/test_ev_chargers_storage_heal.py` (heal contract + writer recovery + ghost drop)
- New real-HA `test_setup_heals_poisoned_options_ev_chargers` — boots with RienduPre-shaped poisoned storage, asserts heal + charger-2 registration + a landed charger-2 mode flip
- Full suite: 3308 passed, 8 skipped · `test_services_real.py`: 5 passed · card JS tests green

Refs #462 #464 #467 #468 #469

https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB)_