### PR TITLE
fix(sensor_reader): manual grid override validation + sign audit (#461) — v1.7.3-beta.7

### DIFF
--- a/.github/release-notes/v1.7.3-beta.7.md
+++ b/.github/release-notes/v1.7.3-beta.7.md
@@ -1,0 +1,28 @@
+# [1.7.3-beta.7] - 10.06.2026
+
+## 🔎 Manual grid override validation + sign audit (#461 follow-up)
+
+Beta.6's pick-stability fix addressed the auto-discovery path — but an install with `grid_import_power_entity` / `grid_export_power_entity` set **explicitly** bypasses ALL sign machinery, so a swapped, one-sided, or wrong-kind (energy counter as power sensor) configuration produces a statically inverted grid with zero feedback. That's the verified #461 shape: explicit entities configured, no discovery log lines, grid shows export while importing, house consumption 0, surplus invisible to every controller (EV + heat pump).
+
+### 🛠️ Fixes
+
+- **Manual grid config validation** (warn-once): flags an ENERGY counter (kWh) configured in a POWER field, and a one-sided config (only import OR export set while the Energy Dashboard tracks both flows — the missing side reads a hard 0 W, so that direction can never show) (by @traktore-org in [#481](https://github.com/traktore-org/sem-community/pull/481))
+- **Observe-only sign audit**: the manual-computed grid sign is cross-checked against the Energy Dashboard import/export counters every cycle; 5 consecutive contradictions log a WARNING naming both configured entities ("most likely SWAPPED") and set `diag_grid_manual_mismatch` in the diagnose payload. SEM never silently overrides manual config — it makes the misconfiguration loud (by @traktore-org in [#481](https://github.com/traktore-org/sem-community/pull/481))
+
+## 🧰 Robustness batch (#476, part 1)
+
+- Back-to-back runtime entity writes no longer trigger a spurious integration reload (options-listener snapshot kept on match, cleared on mismatch)
+- Energy-counter reset guard for grid + per-battery sign voting (Growatt midnight counter resets can no longer cast a wrong vote)
+- `set_option` mixed structural+tunable payloads no longer arm a stale skip snapshot
+- WARNING on id-less / duplicate charger ids at registration
+- Config card: per-charger rows without a resolvable id are skipped; save-status and copy timers cancelled on disconnect
+
+(by @traktore-org in [#480](https://github.com/traktore-org/sem-community/pull/480))
+
+## 🧪 Tests
+
+- 3327 tests pass (9 new since beta.6): manual-grid audit contract (swapped / correct / clears-on-agreement / energy-unit / one-sided), back-to-back skip regression, counter-reset guards
+
+## 🙏 Thanks
+
+- **@RienduPre** — the beta.6 verdict ("explicit entities already set, no log lines, still inverted") was the data that pinpointed the unvalidated manual path.

--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v1.7.3-beta.6",
-  "title": "v1.7.3-beta.6 — split-grid pick stability (#461) + storage heal (#462/#464)",
+  "tag": "v1.7.3-beta.7",
+  "title": "v1.7.3-beta.7 — manual grid override audit (#461) + #476 robustness batch",
   "prerelease": true,
-  "notes_file": ".github/release-notes/v1.7.3-beta.6.md"
+  "notes_file": ".github/release-notes/v1.7.3-beta.7.md"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
-# [Unreleased]
+# [1.7.3-beta.7] - 10.06.2026
+
+## 🔎 Manual grid override validation + sign audit (#461 follow-up)
+
+v1.7.3-beta.6's pick-stability fix addressed the auto-discovery path — but an install with `grid_import_power_entity` / `grid_export_power_entity` set explicitly bypasses ALL sign machinery, so a swapped, one-sided, or wrong-kind (energy counter as power sensor) configuration produces a statically inverted grid with zero feedback. Exactly the verified #461 shape: explicit entities configured, no discovery log lines, grid shows export while importing, house consumption 0, surplus invisible to every controller.
+
+### 🛠️ Fixes
+
+- **Manual grid config validation** (warn-once): an ENERGY counter (kWh) configured in a POWER field; only one side configured while the Energy Dashboard tracks both flows (the missing side reads a hard 0 W — "always exporting")
+- **Observe-only sign audit**: the manual-computed grid sign is cross-checked against the Energy Dashboard import/export counters every cycle; 5 consecutive contradictions log a WARNING naming both configured entities ("most likely SWAPPED") and set `diag_grid_manual_mismatch` in the diagnostics — SEM never silently overrides manual config, it makes the misconfiguration loud
+- Counter-reset and ambiguous-delta cycles are excluded from the audit (same guards as the autodetect path)
 
 ## 🧰 Robustness batch (#476, part 1)
 

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2065,6 +2065,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             _disc = getattr(self._sensor_reader, "_split_grid_discovery", None) or {}
             if self.config.get("grid_import_power_entity") or self.config.get("grid_export_power_entity"):
                 result["diag_grid_mode"] = "manual"
+                # #461 follow-up: observe-only audit verdict — True when the
+                # manual import/export assignment has contradicted the
+                # Energy Dashboard counters for 5+ cycles (swapped fields).
+                result["diag_grid_manual_mismatch"] = bool(
+                    getattr(self._sensor_reader, "_manual_grid_mismatch", False)
+                )
             elif _disc.get("import"):
                 result["diag_grid_mode"] = "split" if _disc.get("confidence") == "same-device" else "split-lowconf"
             else:

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -121,6 +121,19 @@ class SensorReader:
         # Warn-once guard for the discovery-*exception* path (#259); distinct from the
         # dict "warned" key (which guards "no sensor found"). Reset on cache invalidate.
         self._split_grid_discovery_warned: bool = False
+        # Manual grid override audit (#461 follow-up). When the user sets
+        # grid_import_power_entity / grid_export_power_entity explicitly,
+        # ALL sign auto-detection is bypassed — a swapped, single-sided or
+        # wrong-kind (energy counter as power) configuration produces a
+        # statically inverted grid with zero feedback. The audit compares
+        # the manual-computed sign against the Energy Dashboard counters
+        # in observe-only mode and warns loudly on sustained contradiction.
+        self._manual_grid_config_warned: set[str] = set()
+        self._manual_grid_import_baseline: Optional[float] = None
+        self._manual_grid_export_baseline: Optional[float] = None
+        self._manual_grid_mismatch_votes: int = 0
+        self._manual_grid_mismatch: bool = False
+        self._manual_grid_mismatch_warned: bool = False
 
     def _parse_config(self, config: Dict[str, Any]) -> SensorConfig:
         """Parse configuration into SensorConfig."""
@@ -604,11 +617,17 @@ class SensorReader:
         manual_import = self._raw_config.get("grid_import_power_entity")
         manual_export = self._raw_config.get("grid_export_power_entity")
         if manual_import or manual_export:
-            # Manual override — user explicitly set grid power sensors
+            # Manual override — user explicitly set grid power sensors.
+            # NO auto-detection runs on this path, so misconfiguration
+            # (swapped roles, one side missing, energy counter instead of
+            # power sensor) yields a statically wrong grid sign with zero
+            # feedback (#461, RienduPre). Validate + audit below.
+            self._validate_manual_grid_config(ed, manual_import, manual_export)
             import_w = self._read_sensor(manual_import, "grid_import") if manual_import else 0.0
             export_w = self._read_sensor(manual_export, "grid_export") if manual_export else 0.0
             readings.grid_power = export_w - import_w
             self._grid_sign_detected = True
+            self._audit_manual_grid_sign(readings.grid_power, ed)
         elif len(ed.grid_power_list) > 1:
             # Multiple grid power sensors — sum all (e.g. multi-meter setups)
             readings.grid_power = self._read_sensors_sum(ed.grid_power_list, "grid")
@@ -816,6 +835,142 @@ class SensorReader:
             )
 
         return readings
+
+    def _validate_manual_grid_config(
+        self, ed, manual_import: Optional[str], manual_export: Optional[str],
+    ) -> None:
+        """One-shot sanity checks on explicitly configured grid entities (#461).
+
+        Each finding warns once per install run (keyed per entity / shape):
+
+        * Entity is an ENERGY counter (kWh device-class/unit) — the manual
+          fields take POWER sensors; a counter reads as a huge pseudo-watt
+          value and swamps ``grid_power = export - import``.
+        * Only one side is configured while the Energy Dashboard has BOTH
+          flow counters — the missing side reads a hard 0 W, so the grid
+          can never show that direction ("always exporting" / "always
+          importing").
+        """
+        for role, eid in (("import", manual_import), ("export", manual_export)):
+            if not eid or eid in self._manual_grid_config_warned:
+                continue
+            state = self.hass.states.get(eid)
+            if state is None:
+                continue  # unavailability is handled by _read_sensor/Repairs
+            unit = (state.attributes.get("unit_of_measurement") or "").lower()
+            device_class = state.attributes.get("device_class")
+            if device_class == "energy" or unit in ("wh", "kwh", "mwh"):
+                self._manual_grid_config_warned.add(eid)
+                _LOGGER.warning(
+                    "grid_%s_power_entity is set to %s, which is an ENERGY "
+                    "counter (%s) — this field takes a POWER sensor (W/kW). "
+                    "The computed grid power will be wrong until this is "
+                    "fixed in the SEM config. (#461)",
+                    role, eid, unit or device_class,
+                )
+        one_sided = bool(manual_import) != bool(manual_export)
+        if (
+            one_sided
+            and "__one_sided__" not in self._manual_grid_config_warned
+            and getattr(ed, "grid_import_energy", None)
+            and getattr(ed, "grid_export_energy", None)
+        ):
+            self._manual_grid_config_warned.add("__one_sided__")
+            missing = "grid_export_power_entity" if manual_import else "grid_import_power_entity"
+            _LOGGER.warning(
+                "Only one manual grid power entity is configured (%s is "
+                "missing) while the Energy Dashboard tracks BOTH import and "
+                "export. The missing side always reads 0 W, so SEM can never "
+                "see that flow direction — the energy flow will look stuck "
+                "on one side. Configure both entities (or neither). (#461)",
+                missing,
+            )
+
+    def _audit_manual_grid_sign(self, grid_power: float, ed) -> None:
+        """Observe-only cross-check of the manual grid sign (#461).
+
+        The Energy Dashboard's import/export counters are ground truth for
+        flow DIRECTION. Under SEM convention (negative = import), the
+        import counter growing while the manual-computed ``grid_power`` is
+        positive (or export growing while it's negative) means the manual
+        entities are assigned in swapped roles — or the wrong sensors
+        entirely. Five consecutive contradictions set
+        ``_manual_grid_mismatch`` (surfaced as ``diag_grid_manual_mismatch``)
+        and log one WARNING naming the configured entities.
+
+        Observe-only by design: manual config is explicit user intent, so
+        SEM never silently re-flips it — it makes the misconfiguration loud
+        instead.
+        """
+        import_entity = getattr(ed, "grid_import_energy", None)
+        export_entity = getattr(ed, "grid_export_energy", None)
+        if not import_entity or not export_entity:
+            return
+        if abs(grid_power) < 100:
+            return  # too little flow to judge direction
+        import_state = self.hass.states.get(import_entity)
+        export_state = self.hass.states.get(export_entity)
+        if not import_state or import_state.state in ("unknown", "unavailable"):
+            return
+        if not export_state or export_state.state in ("unknown", "unavailable"):
+            return
+        try:
+            import_val = float(import_state.state)
+            export_val = float(export_state.state)
+        except (ValueError, TypeError):
+            return
+
+        if self._manual_grid_import_baseline is None:
+            self._manual_grid_import_baseline = import_val
+            self._manual_grid_export_baseline = export_val
+            return
+        import_delta = import_val - self._manual_grid_import_baseline
+        export_delta = export_val - self._manual_grid_export_baseline
+        self._manual_grid_import_baseline = import_val
+        self._manual_grid_export_baseline = export_val
+
+        # Counter reset (#476) or ambiguous deltas → no judgement this cycle.
+        if import_delta < -0.001 or export_delta < -0.001:
+            return
+        if import_delta > 0.001 and export_delta < 0.001:
+            counters_say_export = False
+        elif export_delta > 0.001 and import_delta < 0.001:
+            counters_say_export = True
+        else:
+            return
+
+        manual_says_export = grid_power > 0
+        if manual_says_export != counters_say_export:
+            self._manual_grid_mismatch_votes += 1
+        else:
+            self._manual_grid_mismatch_votes = 0
+            if self._manual_grid_mismatch:
+                self._manual_grid_mismatch = False
+                _LOGGER.info(
+                    "Manual grid entities agree with the Energy Dashboard "
+                    "counters again — clearing the mismatch flag."
+                )
+            return
+
+        if self._manual_grid_mismatch_votes >= 5 and not self._manual_grid_mismatch:
+            self._manual_grid_mismatch = True
+            if not self._manual_grid_mismatch_warned:
+                self._manual_grid_mismatch_warned = True
+                _LOGGER.warning(
+                    "Manual grid power entities CONTRADICT the Energy "
+                    "Dashboard counters for 5+ cycles: SEM computes %s "
+                    "(grid_power=%.0f W) while the %s counter is the one "
+                    "increasing. grid_import_power_entity=%s / "
+                    "grid_export_power_entity=%s are most likely SWAPPED "
+                    "(or point at the wrong meters). SEM does not override "
+                    "manual config — fix the two fields in the SEM config. "
+                    "(#461)",
+                    "EXPORT" if manual_says_export else "IMPORT",
+                    grid_power,
+                    "import" if not counters_say_export else "export",
+                    self._raw_config.get("grid_import_power_entity"),
+                    self._raw_config.get("grid_export_power_entity"),
+                )
 
     def _should_adopt_split_grid_picks(self, disc: dict, new_confidence) -> bool:
         """Gate adopting freshly discovered split-grid picks (#461).

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.3-beta.6"
+  "version": "1.7.3-beta.7"
 }

--- a/tests/test_split_grid_integration.py
+++ b/tests/test_split_grid_integration.py
@@ -1931,3 +1931,126 @@ class TestSplitGridPickStability:
         states["sensor.mix_export_to_grid"] = _state(0, device_class="power")
         reader.read_power()
         assert reader._split_grid_discovery["import"] == "sensor.mix_import_from_grid"
+
+
+# ════════════════════════════════════════════
+# #461 follow-up: manual grid override validation + observe-only sign audit
+# ════════════════════════════════════════════
+
+class TestManualGridAudit:
+    """When grid_import/export_power_entity are set explicitly, all sign
+    auto-detection is bypassed — a swapped / one-sided / wrong-kind config
+    yields a statically inverted grid with zero feedback (RienduPre's #461
+    shape: explicit entities configured, no discovery logs, grid shows
+    export while importing). The audit compares the manual-computed sign
+    against the Energy Dashboard counters and warns on contradiction."""
+
+    def _reader(self, manual_import, manual_export, states):
+        hass = MagicMock()
+        ed = _make_energy_dashboard_config(
+            solar_power="sensor.solar",
+            grid_import_power=None,
+            grid_import_energy="sensor.grid_import_kwh",
+            grid_export_energy="sensor.grid_export_kwh",
+            battery_power=None,
+        )
+        extra = {}
+        if manual_import:
+            extra["grid_import_power_entity"] = manual_import
+        if manual_export:
+            extra["grid_export_power_entity"] = manual_export
+        reader = _make_reader_with_states(hass, states, ed, extra_config=extra)
+        return reader
+
+    def test_swapped_manual_entities_flag_mismatch(self, caplog):
+        """Physically importing 1500 W with the two fields swapped → SEM
+        computes +1500 (export) while the import counter grows. Five
+        consecutive contradictions set the mismatch flag + WARNING."""
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.real_import": _state(1500, device_class="power"),
+            "sensor.real_export": _state(0, device_class="power"),
+            "sensor.grid_import_kwh": _state(100.0, unit="kWh"),
+            "sensor.grid_export_kwh": _state(50.0, unit="kWh"),
+        }
+        # User swapped the roles: import field → the export meter, etc.
+        reader = self._reader("sensor.real_export", "sensor.real_import", states)
+
+        for cycle in range(7):
+            states["sensor.grid_import_kwh"] = _state(100.0 + 0.1 * cycle, unit="kWh")
+            power = reader.read_power()
+            assert power.grid_power == 1500  # statically inverted
+
+        assert reader._manual_grid_mismatch is True
+        assert "SWAPPED" in caplog.text
+        assert "sensor.real_export" in caplog.text
+
+    def test_correct_manual_entities_stay_clean(self):
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.real_import": _state(1500, device_class="power"),
+            "sensor.real_export": _state(0, device_class="power"),
+            "sensor.grid_import_kwh": _state(100.0, unit="kWh"),
+            "sensor.grid_export_kwh": _state(50.0, unit="kWh"),
+        }
+        reader = self._reader("sensor.real_import", "sensor.real_export", states)
+
+        for cycle in range(7):
+            states["sensor.grid_import_kwh"] = _state(100.0 + 0.1 * cycle, unit="kWh")
+            power = reader.read_power()
+            assert power.grid_power == -1500  # SEM convention: negative = import
+
+        assert reader._manual_grid_mismatch is False
+        assert reader._manual_grid_mismatch_votes == 0
+
+    def test_mismatch_clears_when_agreement_returns(self):
+        """After the user fixes the swap (counters and manual sign agree
+        again), the flag clears."""
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.real_import": _state(1500, device_class="power"),
+            "sensor.real_export": _state(0, device_class="power"),
+            "sensor.grid_import_kwh": _state(100.0, unit="kWh"),
+            "sensor.grid_export_kwh": _state(50.0, unit="kWh"),
+        }
+        reader = self._reader("sensor.real_export", "sensor.real_import", states)
+        for cycle in range(7):
+            states["sensor.grid_import_kwh"] = _state(100.0 + 0.1 * cycle, unit="kWh")
+            reader.read_power()
+        assert reader._manual_grid_mismatch is True
+
+        # Physical flow reverses to genuine export: the export counter now
+        # grows, matching the (still-positive) manual sign — agreement on
+        # the next judged cycle clears the flag.
+        for cycle in range(2):
+            states["sensor.grid_export_kwh"] = _state(50.0 + 0.1 * (cycle + 1), unit="kWh")
+            reader.read_power()
+        assert reader._manual_grid_mismatch is False
+
+    def test_energy_counter_in_power_field_warns(self, caplog):
+        """A kWh counter configured as a manual POWER entity is flagged."""
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.import_counter": _state(5432.1, unit="kWh", device_class="energy"),
+            "sensor.real_export": _state(0, device_class="power"),
+            "sensor.grid_import_kwh": _state(100.0, unit="kWh"),
+            "sensor.grid_export_kwh": _state(50.0, unit="kWh"),
+        }
+        reader = self._reader("sensor.import_counter", "sensor.real_export", states)
+        reader.read_power()
+        assert "ENERGY" in caplog.text
+        assert "sensor.import_counter" in caplog.text
+
+    def test_one_sided_manual_config_warns(self, caplog):
+        """Only one manual entity while both flow counters exist → the
+        missing side reads a hard 0 W and that direction can never show."""
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.real_export": _state(800, device_class="power"),
+            "sensor.grid_import_kwh": _state(100.0, unit="kWh"),
+            "sensor.grid_export_kwh": _state(50.0, unit="kWh"),
+        }
+        reader = self._reader(None, "sensor.real_export", states)
+        power = reader.read_power()
+        assert power.grid_power == 800  # permanently one-signed
+        assert "Only one manual grid power entity" in caplog.text


### PR DESCRIPTION
## Summary

#461 follow-up driven by RienduPre's beta.6 verdict, which **falsified the discovery-flicker mechanism for his install**: he has `grid_import_power_entity` / `grid_export_power_entity` set explicitly (for days), which takes the manual override path in `sensor_reader.py` — bypassing discovery AND sign autodetect entirely (consistent with "no `Split-grid sensor picks changed` lines in his log"), with **zero validation** of what the user configured. A swapped, one-sided, or wrong-kind (kWh counter in a power field) config yields a statically inverted grid: export shown while importing, house consumption 0, surplus invisible to the EV + heat-pump controllers — his exact report.

### Changes

1. `_validate_manual_grid_config` (warn-once): flags an ENERGY counter configured in a POWER field, and a one-sided config while the Energy Dashboard tracks both flows (the missing side reads a hard 0 W → "always exporting").
2. `_audit_manual_grid_sign` (observe-only): cross-checks the manual-computed sign against the ED import/export counters every cycle. Five consecutive contradictions → WARNING naming both configured entities ("most likely SWAPPED") + `diag_grid_manual_mismatch` in the diagnose payload. Clears itself when agreement returns. Never overrides manual config — loud, not clever. Counter-reset/ambiguous cycles excluded (same guards as autodetect).
3. Release bump to **v1.7.3-beta.7** incl. release-request — merging this PR publishes the release (also carries the #480 robustness batch).

## Verification

Full suite: **3327 passed, 8 skipped** (5 new audit-contract tests: swapped → flag+WARNING; correct → clean; clears on agreement; energy-unit warn; one-sided warn).

Refs #461 #476

https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB)_