### PR TITLE
fix: actuation hardening + triage surfaces (#462 follow-up batch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [Unreleased]
+
+## 🔌 Actuation hardening + triage surfaces (#462 follow-up batch)
+
+RienduPre's attached error log revealed the final #462 mechanism: with `ev_charger_service: number.set_value`, SEM sent `{current: X}` through the service path — `number.set_value` only accepts `value`, so **every current command on both chargers failed** (`extra keys not allowed @ data['current']`), including the 0 A for off-mode, with the evidence buried in per-cycle ERROR log lines.
+
+### 🛠️ Fixes
+
+- **`number.set_value` as charger service is now mapped to the number-entity write it was meant to be** (`value` + entity_id) — the misconfigured-but-recoverable shape can no longer leave a charger silently uncontrollable
+- **Repair issue on repeated actuation failure**: 3 consecutive rejected set-current commands raise a user-visible Repair naming the charger and the error (severity ERROR, translated EN/NL/DE + EN fallback for the rest); clears automatically on the next successful write
+- **Registration WARNING** when `ev_charger_service=number.set_value` has no `number.*` target entity
+- **Fleet `charging_strategy` / `charging_strategy_reason` are now consistent** — the per-charger loop let the *last* charger overwrite `charging_strategy` while `charging_strategy_reason` kept the primary's value ("always_max …" next to "off mode …" in the same dump); only the primary charger writes both now (per-charger detail lives in `charger_<id>_charging_state`)
+
+### 🔍 Triage surfaces
+
+- **In-memory SEM log ring buffer** — the diagnose payload's `recent_logs` now carries the last ~300 INFO+ SEM log lines on EVERY install type; Supervisor installs (journald, no flat log file) previously got a "please run `ha core logs`" placeholder, which left the whole #461/#462 triage blind
+- **Manual-grid audit is dual-tariff aware** — the sign cross-check sums the import/export counter *lists*, so NL DSMR tarief-1/2 splits no longer blind it during one tariff's hours
+- **Blocking `open()` calls removed from the event loop** ("Detected blocking call" in RienduPre's log): translations and the manifest version are warmed off-loop at setup and cached (`diag_version` no longer re-opens manifest.json every cycle)
+- TROUBLESHOOTING: manual grid entity checklist (import vs export roles, power-not-energy, both-or-neither) + Dutch dual-tariff Energy-Dashboard guidance
+
+### 🧪 Tests
+
+- New framework tier `tests/test_actuation_real.py`: real-HA schema-strict `number.set_value` shape test + the failure → Repair → recovery → clear cycle through the real issue registry
+- `test_services_real.py`: diagnose `recent_logs` served from the ring buffer (Supervisor parity) + cached version
+- Unit: actuation routing/param contracts, Repair threshold/idempotence/intermittent-flap behavior, log-buffer capture/capacity/idempotence, dual-tariff audit summing
+
+---
+
 # [1.7.3-beta.7] - 10.06.2026
 
 ## 🔎 Manual grid override validation + sign audit (#461 follow-up)

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -198,6 +198,14 @@ read-only by design — SEM can't suppress it), but the cards will load.
 | Fronius | + = import, - = export | Auto-negated |
 | Template sensor (HA convention) | + = import, - = export | Auto-negated |
 
+**If you configured the grid entities manually** (`grid_import_power_entity` / `grid_export_power_entity` in the SEM options): SEM uses exactly what you configured and does NOT auto-correct the sign — manual config is treated as explicit intent. Since v1.7.3-beta.7 SEM cross-checks your manual entities against the Energy Dashboard counters and logs a WARNING (`Manual grid power entities CONTRADICT…`) plus sets `diag_grid_manual_mismatch: true` in the diagnose dump when the two fields appear swapped. Checklist for the manual fields:
+
+- The **import** field takes the sensor that is non-zero while you draw from the grid; the **export** field the one that is non-zero while you feed in. When unsure, watch both in Developer Tools → States at a moment of known heavy import (e.g. EV charging at night).
+- Both fields must be **power** sensors (W/kW) — an energy counter (kWh) in either field is flagged with a WARNING and produces garbage values.
+- Configure **both** fields or neither. With only one side set, the other reads a hard 0 W and that flow direction can never show ("always exporting").
+
+**Dutch dual-tariff (DSMR) meters:** your meter splits each direction into *tarief 1* and *tarief 2* counters (`…verbruik_tarief_1/2`, `…productie_tarief_1/2`). Configure **all four** in the HA Energy Dashboard (Settings → Dashboards → Energy → Grid — you can add multiple flows per direction). With only one tariff's counters configured, SEM's grid energy statistics undercount during the other tariff's hours and the sign cross-check is blind in those windows.
+
 ---
 
 ## Battery charge/discharge values are swapped

--- a/__init__.py
+++ b/__init__.py
@@ -1008,6 +1008,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     # Initialize domain data storage (kept for backward compatibility with services)
     hass.data.setdefault(DOMAIN, {})
 
+    # In-memory SEM log ring buffer for the diagnose surface (#461/#462
+    # triage gap on Supervisor installs — no flat log file to tail).
+    # Idempotent across reloads. Stored under its own key so code that
+    # treats hass.data[DOMAIN] values as coordinators is unaffected.
+    from .utils.log_buffer import ensure_attached as _attach_log_buffer
+    hass.data[f"{DOMAIN}_log_buffer"] = _attach_log_buffer()
+
+    # Warm the blocking-I/O caches off the event loop (caught live as
+    # "Detected blocking call to open" on RienduPre's install): the
+    # dashboard translations file and the manifest version are both
+    # lazily opened from sync code inside the loop on first use.
+    from .utils.translate import preload_translations as _preload_translations
+    await hass.async_add_executor_job(_preload_translations)
+    await hass.async_add_executor_job(SEMCoordinator._get_version)
+
     # Fold the removed ev_limit_surplus switch (#235) into the Max ceiling (#245).
     # Idempotent; only acts while the legacy key is present.
     _migrate_limit_surplus_to_max(hass, entry)
@@ -1250,6 +1265,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
             if not ev_power_entity or not (ev_charger_service or ev_current_entity):
                 _LOGGER.debug("Charger %s missing power sensor or control method, skipping", charger_id)
                 continue
+
+            # #462 follow-up: ``number.set_value`` configured as the charger
+            # SERVICE needs a writable number entity to target. With a
+            # non-number target (RienduPre's old config pointed at a
+            # SENSOR), every set-current command bounces off the service
+            # schema and the charger is silently uncontrollable.
+            if ev_charger_service == "number.set_value":
+                _svc_target = ev_current_entity or ev_service_entity
+                if not _svc_target or not str(_svc_target).startswith("number."):
+                    _LOGGER.warning(
+                        "Charger '%s': ev_charger_service=number.set_value "
+                        "needs a number.* target entity, but got %s — current "
+                        "commands will fail. Set ev_current_control_entity to "
+                        "the charger's max-current number entity.",
+                        charger_id, _svc_target,
+                    )
 
             ev_device = CurrentControlDevice(
                 hass=hass,
@@ -3345,16 +3376,10 @@ async def _async_register_phase_services(
         else:
             recent_logs = list(all_logs)[-20:]
 
-        # Read SEM integration version (best effort)
-        sem_version = "unknown"
-        try:
-            import os as _os
-            import json as _json_v
-            manifest = _os.path.join(_os.path.dirname(__file__), "manifest.json")
-            with open(manifest) as _f:
-                sem_version = _json_v.load(_f).get("version", "unknown")
-        except Exception:  # noqa: BLE001
-            pass
+        # Read SEM integration version — cached classmethod, warmed off-loop
+        # at setup (the previous inline open() was a blocking call in the
+        # event loop on every diagnose invocation).
+        sem_version = SEMCoordinator._get_version()
 
         payload = {
             "version": sem_version,

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -695,17 +695,27 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             # Hold window exhausted — accept the zero as real.
             self._home_hold_count = held + 1
 
-    @staticmethod
-    def _get_version() -> str:
+    # Class-level cache — the manifest never changes within a run, but
+    # _get_version() used to re-open it on EVERY cycle (diag_version),
+    # flagged live as "Detected blocking call to open" (#476 follow-up).
+    # Setup warms the cache via async_add_executor_job so the single
+    # file read happens off the event loop.
+    _version_cache: str | None = None
+
+    @classmethod
+    def _get_version(cls) -> str:
         """Read version from manifest.json (single source of truth with HACS)."""
+        if cls._version_cache is not None:
+            return cls._version_cache
         import json as _json
         import os
         manifest = os.path.join(os.path.dirname(os.path.dirname(__file__)), "manifest.json")
         try:
             with open(manifest) as f:
-                return _json.load(f).get("version", "0.0.0")
+                cls._version_cache = _json.load(f).get("version", "0.0.0")
         except (OSError, ValueError):
-            return "0.0.0"
+            cls._version_cache = "0.0.0"
+        return cls._version_cache
 
     async def async_initialize_energy_dashboard(self, quiet: bool = False) -> bool:
         """Initialize sensors from HA Energy Dashboard.
@@ -1582,7 +1592,22 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             cid, per_mode, decision.intent.value,
                             decision.commanded_amps, decision.budget_w, decision.reason,
                         )
-                        charging_context.charging_strategy = decision.reason
+                        # Fleet-level strategy display: only the PRIMARY
+                        # charger may write it, and it writes BOTH fields.
+                        # Pre-fix every loop iteration overwrote
+                        # ``charging_strategy`` (last charger won) while
+                        # ``charging_strategy_reason`` kept the primary's
+                        # value — RienduPre's dump showed strategy from
+                        # charger 2 ("always_max …") next to reason from
+                        # charger 1 ("off mode …"). Per-charger detail
+                        # lives in ``charger_<id>_charging_state``.
+                        _fleet_primary_cid = (
+                            (self.config.get("ev_chargers") or [{}])[0].get("id")
+                            or "ev_charger"
+                        )
+                        if cid == _fleet_primary_cid:
+                            charging_context.charging_strategy = decision.reason
+                            charging_context.charging_strategy_reason = decision.reason
                         # Reflect decision into the effective_state sensor
                         # (for dashboards that read sem_charging_state).
                         #

--- a/coordinator/repair_issues.py
+++ b/coordinator/repair_issues.py
@@ -100,6 +100,53 @@ def clear_sensor_unavailable(hass: HomeAssistant, entity_id: str) -> None:
         _LOGGER.debug("issue_registry.delete failed for %s: %s", entity_id, e)
 
 
+def _actuation_issue_id(device_id: str) -> str:
+    return f"charger_actuation_failed_{device_id}"
+
+
+def raise_charger_actuation_failed(
+    hass: HomeAssistant,
+    device_id: str,
+    *,
+    name: str,
+    error: str,
+) -> None:
+    """File a repair when a charger rejects set-current commands repeatedly.
+
+    #462 follow-up: a misconfigured control surface (e.g.
+    ``number.set_value`` configured as the charger service, a renamed
+    entity after an upstream integration update) made EVERY command fail
+    with only per-cycle ERROR log lines as evidence. The user experience
+    was "SEM doesn't react" with nothing actionable in the UI. Raised by
+    ``CurrentControlDevice`` after 3 consecutive failures; cleared on the
+    next successful write.
+    """
+    try:
+        ir.async_create_issue(
+            hass,
+            domain=DOMAIN,
+            issue_id=_actuation_issue_id(device_id),
+            is_fixable=False,
+            is_persistent=True,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="charger_actuation_failed",
+            translation_placeholders={
+                "name": name,
+                "error": error,
+            },
+        )
+    except Exception as e:  # noqa: BLE001 — never fail the cycle over a repair
+        _LOGGER.debug("issue_registry.create failed for %s: %s", device_id, e)
+
+
+def clear_charger_actuation_failed(hass: HomeAssistant, device_id: str) -> None:
+    """Clear the actuation repair after a successful write."""
+    try:
+        ir.async_delete_issue(hass, DOMAIN, _actuation_issue_id(device_id))
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.debug("issue_registry.delete failed for %s: %s", device_id, e)
+
+
 # ---------------------------------------------------------------------------
 # Setup-time integration checks (once per setup)
 # ---------------------------------------------------------------------------

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -886,6 +886,23 @@ class SensorReader:
                 missing,
             )
 
+    def _sum_counter_states(self, entity_ids: list) -> Optional[float]:
+        """Sum energy-counter states; ``None`` when any is unreadable.
+
+        Partial sums are worse than no judgement — one missing tariff
+        counter mid-cycle would look like a counter reset.
+        """
+        total = 0.0
+        for eid in entity_ids:
+            state = self.hass.states.get(eid)
+            if not state or state.state in ("unknown", "unavailable"):
+                return None
+            try:
+                total += float(state.state)
+            except (ValueError, TypeError):
+                return None
+        return total
+
     def _audit_manual_grid_sign(self, grid_power: float, ed) -> None:
         """Observe-only cross-check of the manual grid sign (#461).
 
@@ -902,22 +919,25 @@ class SensorReader:
         SEM never silently re-flips it — it makes the misconfiguration loud
         instead.
         """
-        import_entity = getattr(ed, "grid_import_energy", None)
-        export_entity = getattr(ed, "grid_export_energy", None)
-        if not import_entity or not export_entity:
+        # Sum across the counter LISTS when present — Dutch dual-tariff
+        # DSMR meters split each direction into tarief 1 + tarief 2
+        # counters; judging from one tariff's counter alone leaves the
+        # audit blind during the other tariff's hours.
+        import_entities = (
+            list(getattr(ed, "grid_import_energy_list", None) or [])
+            or ([ed.grid_import_energy] if getattr(ed, "grid_import_energy", None) else [])
+        )
+        export_entities = (
+            list(getattr(ed, "grid_export_energy_list", None) or [])
+            or ([ed.grid_export_energy] if getattr(ed, "grid_export_energy", None) else [])
+        )
+        if not import_entities or not export_entities:
             return
         if abs(grid_power) < 100:
             return  # too little flow to judge direction
-        import_state = self.hass.states.get(import_entity)
-        export_state = self.hass.states.get(export_entity)
-        if not import_state or import_state.state in ("unknown", "unavailable"):
-            return
-        if not export_state or export_state.state in ("unknown", "unavailable"):
-            return
-        try:
-            import_val = float(import_state.state)
-            export_val = float(export_state.state)
-        except (ValueError, TypeError):
+        import_val = self._sum_counter_states(import_entities)
+        export_val = self._sum_counter_states(export_entities)
+        if import_val is None or export_val is None:
             return
 
         if self._manual_grid_import_baseline is None:

--- a/devices/base.py
+++ b/devices/base.py
@@ -535,6 +535,10 @@ class CurrentControlDevice(ControllableDevice):
         # whether to skip a same-value write (recent) or force a heartbeat
         # refresh (interval elapsed).
         self._last_write_at: float = 0.0
+        # #462 follow-up: consecutive set-current failures → Repair issue
+        # at 3 (cleared on the next successful write).
+        self._actuation_failures: int = 0
+        self._actuation_repair_raised: bool = False
         self._session_active: bool = False
         self._min_power_change_interval = min_power_change_interval
 
@@ -648,7 +652,22 @@ class CurrentControlDevice(ControllableDevice):
             return self._status.current_consumption_w
 
         try:
-            if self.charger_service:
+            if self.charger_service == "number.set_value":
+                # Misconfigured-but-recoverable shape (#462, RienduPre):
+                # ``number.set_value`` configured as the charger SERVICE.
+                # Its schema takes ``value`` + ``entity_id`` — sending the
+                # per-integration param name produced
+                # "extra keys not allowed @ data['current']" on EVERY
+                # command, so the charger never received a single
+                # setpoint (including the 0 A for off-mode). Map it to
+                # the number-entity write it was meant to be.
+                target = self.current_entity_id or self.charger_service_entity_id
+                await self.hass.services.async_call(
+                    "number", "set_value",
+                    {"entity_id": target, "value": current},
+                    blocking=True,
+                )
+            elif self.charger_service:
                 # Service-based control — param name varies per integration (#82)
                 domain, service = self.charger_service.split(".", 1)
                 service_data = {self.service_param_name: current}
@@ -671,6 +690,8 @@ class CurrentControlDevice(ControllableDevice):
                     blocking=True,
                 )
 
+            self._clear_actuation_failure()
+
             self._current_setpoint = current
             self._last_write_at = now  # #392: heartbeat tracker
             self._record_power_change()
@@ -691,7 +712,44 @@ class CurrentControlDevice(ControllableDevice):
             _LOGGER.error("Failed to set current on %s: %s", self.name, e)
             self._status.state = DeviceState.ERROR
             self._status.error_message = str(e)
+            self._record_actuation_failure(e)
             return self._status.current_consumption_w
+
+    def _record_actuation_failure(self, error: Exception) -> None:
+        """Track consecutive set-current failures; raise a Repair at 3.
+
+        RienduPre's #462 install failed EVERY current command for days
+        with the evidence buried in per-cycle ERROR log lines — the user
+        saw "SEM doesn't react" with no actionable surface. Three
+        consecutive failures now raise a user-visible Repair naming the
+        device and the error; it clears on the next successful write.
+        """
+        self._actuation_failures += 1
+        if self._actuation_failures < 3 or self._actuation_repair_raised:
+            return
+        self._actuation_repair_raised = True
+        try:
+            from ..coordinator import repair_issues as _ri
+            _ri.raise_charger_actuation_failed(
+                self.hass, self.device_id,
+                name=self.name, error=str(error),
+            )
+        except Exception as exc:  # noqa: BLE001 — never fail the cycle over a repair
+            _LOGGER.debug("actuation-failure repair raise failed: %s", exc)
+
+    def _clear_actuation_failure(self) -> None:
+        """Reset the failure streak; clear the Repair after a good write."""
+        if self._actuation_failures == 0 and not self._actuation_repair_raised:
+            return
+        self._actuation_failures = 0
+        if not self._actuation_repair_raised:
+            return
+        self._actuation_repair_raised = False
+        try:
+            from ..coordinator import repair_issues as _ri
+            _ri.clear_charger_actuation_failed(self.hass, self.device_id)
+        except Exception as exc:  # noqa: BLE001
+            _LOGGER.debug("actuation-failure repair clear failed: %s", exc)
 
     async def start_session(self, energy_target_kwh: float = 0) -> None:
         """Start a charging session.

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -42,6 +42,23 @@ async def _get_recent_sem_logs(hass: HomeAssistant) -> list[str]:
     raises: a failure here must not break the rest of the diagnostics
     dump.
     """
+    # Preferred source: the in-memory ring buffer attached at setup
+    # (utils/log_buffer.py). Works on EVERY install type — Supervisor
+    # routes HA's log to journald, so there is no flat file to tail and
+    # the whole #461/#462 triage ran blind on recent_logs. Type-guarded:
+    # tests run with MagicMock hass objects whose ``data.get`` returns a
+    # truthy mock.
+    from .utils.log_buffer import SEMLogBuffer
+    buffer = hass.data.get(f"{DOMAIN}_log_buffer")
+    if isinstance(buffer, SEMLogBuffer):
+        try:
+            lines = buffer.get_lines(_LOG_MAX_LINES)
+            if lines:
+                return lines
+            return ["<no SEM log records captured since startup>"]
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.debug("Log buffer read failed: %s", e)
+
     try:
         log_path = Path(hass.config.config_dir) / "home-assistant.log"
         if not log_path.exists():

--- a/strings.json
+++ b/strings.json
@@ -1215,6 +1215,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/tests/test_actuation_hardening.py
+++ b/tests/test_actuation_hardening.py
@@ -1,0 +1,146 @@
+"""Actuation hardening for CurrentControlDevice (#462 follow-up).
+
+RienduPre's install had ``ev_charger_service: number.set_value`` — the
+service path then sent ``{current: X}``, which ``number.set_value``'s
+schema rejects (``extra keys not allowed @ data['current']``). EVERY
+current command on both chargers failed for days, including the 0 A for
+off-mode, with only per-cycle ERROR log lines as evidence.
+
+Three contracts under test:
+
+1. ``number.set_value`` configured as the charger SERVICE is mapped to
+   the number-entity write it was meant to be (``value`` + entity_id).
+2. Genuine per-integration services still get ``service_param_name``.
+3. Three consecutive set-current failures raise a Repair issue; the next
+   successful write clears it.
+"""
+from __future__ import annotations
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.solar_energy_management.devices.base import (
+    CurrentControlDevice,
+)
+
+
+def _device(**kwargs) -> CurrentControlDevice:
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    defaults = dict(
+        hass=hass,
+        device_id="ev_charger_1",
+        name="Laadpaal Rechts",
+        min_current=6.0,
+        max_current=32.0,
+        phases=3,
+    )
+    defaults.update(kwargs)
+    return CurrentControlDevice(**defaults)
+
+
+@pytest.mark.unit
+class TestNumberSetValueServiceShape:
+    @pytest.mark.asyncio
+    async def test_number_set_value_service_routes_with_value_param(self):
+        """The misconfigured-but-recoverable shape: service=number.set_value
+        must send {entity_id, value}, never the per-integration param."""
+        dev = _device(
+            charger_service="number.set_value",
+            current_entity_id="number.wallbox_rechts_max_charging_current_2",
+        )
+        await dev._set_current(16)
+        dev.hass.services.async_call.assert_awaited_once_with(
+            "number", "set_value",
+            {
+                "entity_id": "number.wallbox_rechts_max_charging_current_2",
+                "value": 16,
+            },
+            blocking=True,
+        )
+
+    @pytest.mark.asyncio
+    async def test_number_set_value_falls_back_to_service_entity_id(self):
+        """No current_entity_id → the configured service entity is the target."""
+        dev = _device(
+            charger_service="number.set_value",
+            charger_service_entity_id="number.wallbox_max_current",
+        )
+        await dev._set_current(10)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[2]["entity_id"] == "number.wallbox_max_current"
+        assert call.args[2]["value"] == 10
+        assert "current" not in call.args[2]
+
+    @pytest.mark.asyncio
+    async def test_real_integration_service_keeps_param_name(self):
+        """KEBA-style global services keep the per-integration param."""
+        dev = _device(charger_service="keba.set_current")
+        dev.service_param_name = "current"
+        await dev._set_current(13)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[0] == "keba"
+        assert call.args[1] == "set_current"
+        assert call.args[2] == {"current": 13}
+
+
+@pytest.mark.unit
+class TestActuationFailureRepair:
+    @pytest.mark.asyncio
+    async def test_three_consecutive_failures_raise_repair(self):
+        dev = _device(current_entity_id="number.gone")
+        dev.hass.services.async_call = AsyncMock(
+            side_effect=Exception("extra keys not allowed @ data['current']"),
+        )
+        with patch(
+            "custom_components.solar_energy_management.coordinator."
+            "repair_issues.raise_charger_actuation_failed"
+        ) as raise_repair:
+            await dev._set_current(10)
+            await dev._set_current(10)
+            raise_repair.assert_not_called()  # streak of 2 — not yet
+            await dev._set_current(10)
+            raise_repair.assert_called_once()
+            kwargs = raise_repair.call_args
+            assert kwargs.args[1] == "ev_charger_1"
+            assert "extra keys" in kwargs.kwargs["error"]
+            # A 4th failure must not re-raise (idempotent guard)
+            await dev._set_current(10)
+            raise_repair.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_successful_write_clears_repair_and_streak(self):
+        dev = _device(current_entity_id="number.flaky")
+        dev.hass.services.async_call = AsyncMock(side_effect=Exception("boom"))
+        with patch(
+            "custom_components.solar_energy_management.coordinator."
+            "repair_issues.raise_charger_actuation_failed"
+        ), patch(
+            "custom_components.solar_energy_management.coordinator."
+            "repair_issues.clear_charger_actuation_failed"
+        ) as clear_repair:
+            for _ in range(3):
+                await dev._set_current(10)
+            assert dev._actuation_repair_raised is True
+
+            dev.hass.services.async_call = AsyncMock()  # recovers
+            await dev._set_current(12)
+            clear_repair.assert_called_once()
+            assert dev._actuation_failures == 0
+            assert dev._actuation_repair_raised is False
+
+    @pytest.mark.asyncio
+    async def test_intermittent_failures_never_raise(self):
+        """Fail-fail-succeed cycles (flaky Wi-Fi) stay below the threshold."""
+        dev = _device(current_entity_id="number.flaky")
+        with patch(
+            "custom_components.solar_energy_management.coordinator."
+            "repair_issues.raise_charger_actuation_failed"
+        ) as raise_repair:
+            for round_no in range(3):
+                dev.hass.services.async_call = AsyncMock(side_effect=Exception("x"))
+                await dev._set_current(10 + round_no)
+                await dev._set_current(11 + round_no)
+                dev.hass.services.async_call = AsyncMock()
+                await dev._set_current(12 + round_no)
+            raise_repair.assert_not_called()

--- a/tests/test_actuation_real.py
+++ b/tests/test_actuation_real.py
@@ -1,0 +1,132 @@
+"""Real-HA framework tests for charger actuation (#462 follow-up).
+
+The pure-mock tests in ``test_actuation_hardening.py`` verify the call
+shapes; what they can NOT see is HA's actual service-schema rejection
+and the Repair issue lifecycle in a real issue registry. These tests run
+against a real ``HomeAssistant`` instance and:
+
+* register a strict-schema ``number.set_value`` that mirrors the real
+  one (``entity_id`` + ``value``, extra keys forbidden) — the exact
+  schema RienduPre's install bounced off with
+  ``extra keys not allowed @ data['current']``;
+* register a strict per-integration service that rejects SEM's param to
+  drive the failure → Repair → recovery → clear cycle through the REAL
+  issue registry.
+
+Framework-tier policy: any future rewrite of ``_set_current`` /
+``_record_actuation_failure`` must keep these green.
+"""
+from __future__ import annotations
+
+import pytest
+import voluptuous as vol
+
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.solar_energy_management.const import DOMAIN
+from custom_components.solar_energy_management.devices.base import (
+    CurrentControlDevice,
+)
+
+
+def _register_strict_number_set_value(hass, calls: list) -> None:
+    """Mirror the real ``number.set_value`` schema: extra keys forbidden."""
+    schema = vol.Schema(
+        {
+            vol.Required("entity_id"): str,
+            vol.Required("value"): vol.Coerce(float),
+        },
+        extra=vol.PREVENT_EXTRA,
+    )
+
+    async def _handler(call):
+        calls.append(dict(call.data))
+
+    hass.services.async_register("number", "set_value", _handler, schema=schema)
+
+
+@pytest.mark.asyncio
+async def test_number_set_value_service_shape_passes_real_schema(sem_real_hass):
+    """service=number.set_value + number target must clear the REAL schema.
+
+    Pre-fix this sent ``{current: X}`` and bounced with
+    ``extra keys not allowed @ data['current']`` on every command —
+    the charger was silently uncontrollable (#462).
+    """
+    calls: list = []
+    _register_strict_number_set_value(sem_real_hass, calls)
+
+    dev = CurrentControlDevice(
+        hass=sem_real_hass,
+        device_id="ev_charger_1",
+        name="Laadpaal Rechts",
+        min_current=6.0,
+        max_current=32.0,
+        phases=3,
+        charger_service="number.set_value",
+        current_entity_id="number.wallbox_rechts_max_charging_current_2",
+    )
+    consumed = await dev._set_current(16)
+    await sem_real_hass.async_block_till_done()
+
+    assert calls == [
+        {
+            "entity_id": "number.wallbox_rechts_max_charging_current_2",
+            "value": 16.0,
+        },
+    ], (
+        "#462 regression: the number.set_value service shape did not pass "
+        "the real schema — charger would be uncontrollable."
+    )
+    assert consumed > 0  # 16 A × 3 × 230 V — the write counted as applied
+
+
+@pytest.mark.asyncio
+async def test_actuation_failures_raise_and_clear_real_repair(sem_real_hass):
+    """3 schema rejections → Repair in the REAL issue registry; a later
+    successful write clears it."""
+    # A per-integration service whose schema rejects SEM's default
+    # ``current`` param — the #462 failure shape, generalized.
+    schema = vol.Schema(
+        {vol.Required("amps"): vol.Coerce(float)}, extra=vol.PREVENT_EXTRA,
+    )
+
+    async def _handler(call):
+        return None
+
+    sem_real_hass.services.async_register(
+        "testcharger", "set_max", _handler, schema=schema,
+    )
+
+    dev = CurrentControlDevice(
+        hass=sem_real_hass,
+        device_id="ev_charger_1",
+        name="Laadpaal Rechts",
+        min_current=6.0,
+        max_current=32.0,
+        phases=3,
+        charger_service="testcharger.set_max",
+    )
+
+    issue_id = "charger_actuation_failed_ev_charger_1"
+    registry = ir.async_get(sem_real_hass)
+
+    # Three consecutive rejected commands → Repair raised.
+    for amps in (10, 11, 12):
+        await dev._set_current(amps)
+    await sem_real_hass.async_block_till_done()
+    issue = registry.async_get_issue(DOMAIN, issue_id)
+    assert issue is not None, (
+        "3 consecutive actuation failures must raise a user-visible Repair "
+        "— pre-fix the evidence was buried in per-cycle ERROR log lines."
+    )
+    assert issue.severity == ir.IssueSeverity.ERROR
+    assert issue.translation_key == "charger_actuation_failed"
+
+    # Operator fixes the param name → next write succeeds → Repair clears.
+    dev.service_param_name = "amps"
+    await dev._set_current(13)
+    await sem_real_hass.async_block_till_done()
+    assert registry.async_get_issue(DOMAIN, issue_id) is None, (
+        "Repair must clear automatically on the next successful write."
+    )

--- a/tests/test_log_buffer.py
+++ b/tests/test_log_buffer.py
@@ -1,0 +1,114 @@
+"""SEM log ring buffer (#461/#462 triage gap on Supervisor installs)."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from custom_components.solar_energy_management.utils.log_buffer import (
+    SEM_LOGGER_NAME,
+    SEMLogBuffer,
+    ensure_attached,
+)
+
+
+@pytest.fixture
+def clean_logger():
+    """Detach any buffers the tests (or prior tests) attached."""
+    logger = logging.getLogger(SEM_LOGGER_NAME)
+    yield logger
+    for handler in list(logger.handlers):
+        if isinstance(handler, SEMLogBuffer):
+            logger.removeHandler(handler)
+
+
+@pytest.mark.unit
+class TestLogBuffer:
+    def test_child_logger_records_are_captured(self, clean_logger):
+        buf = ensure_attached()
+        child = logging.getLogger(f"{SEM_LOGGER_NAME}.coordinator.sensor_reader")
+        child.warning("Manual grid power entities CONTRADICT the counters")
+        lines = buf.get_lines()
+        assert len(lines) == 1
+        assert "CONTRADICT" in lines[0]
+        assert "WARNING" in lines[0]
+        assert "sensor_reader" in lines[0]
+
+    def test_debug_records_are_excluded(self, clean_logger):
+        buf = ensure_attached()
+        child = logging.getLogger(f"{SEM_LOGGER_NAME}.coordinator")
+        child.setLevel(logging.DEBUG)
+        child.debug("noisy per-cycle detail")
+        child.info("worth keeping")
+        lines = buf.get_lines()
+        assert len(lines) == 1
+        assert "worth keeping" in lines[0]
+
+    def test_capacity_is_bounded_and_tail_ordered(self, clean_logger):
+        buf = SEMLogBuffer(capacity=5)
+        logging.getLogger(SEM_LOGGER_NAME).addHandler(buf)
+        log = logging.getLogger(f"{SEM_LOGGER_NAME}.x")
+        for i in range(12):
+            log.info("line %d", i)
+        lines = buf.get_lines(count=3)
+        assert len(lines) == 3
+        assert lines[-1].endswith("line 11")
+        assert lines[0].endswith("line 9")
+
+    def test_ensure_attached_is_idempotent(self, clean_logger):
+        first = ensure_attached()
+        second = ensure_attached()
+        assert first is second
+        buffers = [
+            h for h in clean_logger.handlers if isinstance(h, SEMLogBuffer)
+        ]
+        assert len(buffers) == 1
+
+    def test_handler_never_raises_on_bad_record(self, clean_logger):
+        """Mismatched format args raise inside Formatter — emit swallows.
+
+        Exercises ``emit`` directly: routing through the logger would ALSO
+        hit pytest's own capture handler, which deliberately re-raises
+        formatting errors and would fail the test for the wrong reason.
+        """
+        buf = ensure_attached()
+        record = logging.LogRecord(
+            name=f"{SEM_LOGGER_NAME}.bad", level=logging.INFO,
+            pathname=__file__, lineno=1,
+            msg="only %s and %s", args=("one-arg",), exc_info=None,
+        )
+        buf.emit(record)  # must not raise
+        assert isinstance(buf.get_lines(), list)
+
+
+@pytest.mark.unit
+class TestDiagnosticsPrefersBuffer:
+    @pytest.mark.asyncio
+    async def test_recent_logs_served_from_buffer(self, clean_logger):
+        from unittest.mock import MagicMock
+        from custom_components.solar_energy_management.const import DOMAIN
+        from custom_components.solar_energy_management.diagnostics import (
+            _get_recent_sem_logs,
+        )
+
+        buf = ensure_attached()
+        logging.getLogger(f"{SEM_LOGGER_NAME}.coordinator").info("buffered line")
+
+        hass = MagicMock()
+        hass.data = {f"{DOMAIN}_log_buffer": buf}
+        out = await _get_recent_sem_logs(hass)
+        assert out == buf.get_lines()
+        assert any("buffered line" in line for line in out)
+
+    @pytest.mark.asyncio
+    async def test_empty_buffer_reports_itself(self, clean_logger):
+        from unittest.mock import MagicMock
+        from custom_components.solar_energy_management.const import DOMAIN
+        from custom_components.solar_energy_management.diagnostics import (
+            _get_recent_sem_logs,
+        )
+
+        hass = MagicMock()
+        hass.data = {f"{DOMAIN}_log_buffer": ensure_attached()}
+        out = await _get_recent_sem_logs(hass)
+        assert out == ["<no SEM log records captured since startup>"]

--- a/tests/test_services_real.py
+++ b/tests/test_services_real.py
@@ -382,3 +382,41 @@ async def test_setup_heals_poisoned_options_ev_chargers(
         if isinstance(c, dict)
     }
     assert persisted["ev_charger_1"]["charge_mode"] == "off"
+
+
+# ---------------------------------------------------------------------------
+# Diagnose recent_logs from the in-memory ring buffer (Supervisor installs
+# have no flat log file — the #461/#462 triage ran blind on recent_logs)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_diagnose_recent_logs_come_from_ring_buffer(
+    sem_real_hass, sem_config_entry,
+) -> None:
+    """The diagnose payload's ``recent_logs`` must carry real SEM log lines
+    captured by the ring buffer — independent of whether a flat
+    ``home-assistant.log`` exists on disk (it doesn't on Supervisor)."""
+    import logging as _logging
+
+    _seed_sem_input_sensors(sem_real_hass)
+    await _setup_sem(sem_real_hass, sem_config_entry)
+
+    marker = "ring-buffer-framework-test-marker"
+    _logging.getLogger(
+        "custom_components.solar_energy_management.coordinator"
+    ).info("%s", marker)
+
+    response = await sem_real_hass.services.async_call(
+        "solar_energy_management", "diagnose",
+        {"section": "overview"},
+        blocking=True,
+        return_response=True,
+    )
+    logs = response["payload"]["recent_logs"]
+    assert any(marker in line for line in logs), (
+        "recent_logs did not include the in-memory buffer's records — "
+        "Supervisor installs would still get the journald placeholder."
+    )
+    # Version comes from the cached manifest read (warmed off-loop at setup)
+    assert response["payload"]["version"] not in ("unknown", "0.0.0")

--- a/tests/test_split_grid_integration.py
+++ b/tests/test_split_grid_integration.py
@@ -2054,3 +2054,42 @@ class TestManualGridAudit:
         power = reader.read_power()
         assert power.grid_power == 800  # permanently one-signed
         assert "Only one manual grid power entity" in caplog.text
+
+    def test_dual_tariff_counters_are_summed(self, caplog):
+        """NL DSMR meters split each direction into tarief 1/2 counters that
+        can move in different hours. The audit sums the LISTS, so a swap is
+        still caught when only the tarief-2 counter is moving."""
+        states = {
+            "sensor.solar": _state(0),
+            "sensor.real_import": _state(1500, device_class="power"),
+            "sensor.real_export": _state(0, device_class="power"),
+            "sensor.import_t1": _state(100.0, unit="kWh"),
+            "sensor.import_t2": _state(200.0, unit="kWh"),
+            "sensor.export_t1": _state(50.0, unit="kWh"),
+            "sensor.export_t2": _state(30.0, unit="kWh"),
+        }
+        hass = MagicMock()
+        ed = _make_energy_dashboard_config(
+            solar_power="sensor.solar",
+            grid_import_power=None,
+            grid_import_energy="sensor.import_t1",
+            grid_export_energy="sensor.export_t1",
+            battery_power=None,
+        )
+        ed.grid_import_energy_list = ["sensor.import_t1", "sensor.import_t2"]
+        ed.grid_export_energy_list = ["sensor.export_t1", "sensor.export_t2"]
+        # Swapped manual fields, as in the two-counter base case.
+        reader = _make_reader_with_states(
+            hass, states, ed,
+            extra_config={
+                "grid_import_power_entity": "sensor.real_export",
+                "grid_export_power_entity": "sensor.real_import",
+            },
+        )
+
+        for cycle in range(7):
+            # Only the tarief-2 import counter moves (peak hours).
+            states["sensor.import_t2"] = _state(200.0 + 0.1 * cycle, unit="kWh")
+            reader.read_power()
+
+        assert reader._manual_grid_mismatch is True

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/da.json
+++ b/translations/da.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/de.json
+++ b/translations/de.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor nicht verfügbar",
       "description": "Der Sensor `{entity_id}` ({friendly_name}) ist seit {minutes}+ Minuten nicht verfügbar. SEM kann ihn nicht in Berechnungen einbeziehen, bis er wieder verfügbar ist. Prüfen Sie die zugrundeliegende Integration (Huawei modbus / Solcast / Forecast.Solar / Ihr Wechselrichter-Netzwerk). Wird automatisch gelöscht, sobald der Sensor wieder einen gültigen Wert meldet."
     },
+    "charger_actuation_failed": {
+      "title": "E-Auto-Ladegerät nimmt keine Befehle an: {name}",
+      "description": "Die letzten 3+ Strombefehle von SEM an **{name}** wurden abgelehnt: `{error}`. Das Ladegerät steht derzeit NICHT unter SEM-Kontrolle — es macht weiter, was zuletzt befohlen wurde (einschließlich Laden mit voller Leistung im Aus-Modus). Häufigste Ursachen: Die Steuer-Entität wurde durch ein Update der Upstream-Integration umbenannt, oder `ev_charger_service` zeigt auf einen Dienst mit anderem Parameterschema. Prüfe die Steuer-Entität/den Dienst des Ladegeräts in der SEM-Konfiguration. Dieser Hinweis verschwindet automatisch nach dem nächsten erfolgreichen Befehl."
+    },
     "no_forecast_integration": {
       "title": "Keine Solar-Prognose-Integration erkannt",
       "description": "SEM hat eine Stunde nach Start nach einer Solar-Prognose-Integration (Forecast.Solar, Solcast PV Solar oder ein benutzerdefinierter Sensor) gesucht, aber keine gefunden. Prognose-Funktionen (beste Überschussfenster, smarte Nachtladung, Prognose-Dämpfung) sind inaktiv, bis Sie eine installieren. Wird automatisch gelöscht, sobald SEM eine Prognose-Integration erkennt."

--- a/translations/en.json
+++ b/translations/en.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/es.json
+++ b/translations/es.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/it.json
+++ b/translations/it.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor niet beschikbaar",
       "description": "De sensor `{entity_id}` ({friendly_name}) is al {minutes}+ minuten niet beschikbaar. SEM kan deze niet meenemen in berekeningen totdat de sensor weer actief is. Controleer de bovenliggende integratie (Huawei modbus / Solcast / Forecast.Solar / uw omvormernetwerk). Deze melding verdwijnt automatisch zodra de sensor weer een geldige waarde rapporteert."
     },
+    "charger_actuation_failed": {
+      "title": "EV-lader accepteert geen commando's: {name}",
+      "description": "De laatste 3+ stroomcommando's van SEM naar **{name}** zijn geweigerd: `{error}`. De lader staat op dit moment NIET onder controle van SEM — hij blijft doen wat hem het laatst is opgedragen (inclusief op vol vermogen laden in de uit-stand). Meest voorkomende oorzaken: de besturingsentiteit van de lader is hernoemd door een update van de bovenliggende integratie, of `ev_charger_service` verwijst naar een service met een ander parameterschema. Controleer de besturingsentiteit/service van de lader in de SEM-configuratie. Deze melding verdwijnt automatisch na het eerstvolgende geslaagde commando."
+    },
     "no_forecast_integration": {
       "title": "Geen zonneprognose-integratie gevonden",
       "description": "SEM heeft na het opstarten een uur lang gezocht naar een zonneprognose-integratie (Forecast.Solar, Solcast PV Solar of een aangepaste prognose-sensor), maar niets gevonden. Prognose-afhankelijke functies (tips voor het beste overschotvenster, slim nachtladen, prognose-demping) zijn inactief totdat u er een installeert. De melding verdwijnt automatisch zodra SEM een prognose-integratie detecteert."

--- a/translations/no.json
+++ b/translations/no.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1204,6 +1204,10 @@
       "title": "Sensor unavailable",
       "description": "The sensor `{entity_id}` ({friendly_name}) has been unavailable for {minutes}+ minutes. SEM cannot include it in calculations until it recovers. Check the upstream integration (Huawei modbus / Solcast / Forecast.Solar / your inverter network). This issue clears automatically when the sensor next reports a valid value."
     },
+    "charger_actuation_failed": {
+      "title": "EV charger not accepting commands: {name}",
+      "description": "SEM's last 3+ current commands to **{name}** were rejected: `{error}`. The charger is NOT under SEM control right now — it will keep doing whatever it was last told (including charging at full power in off mode). Most common causes: the charger's control entity was renamed by an upstream integration update, or `ev_charger_service` points at a service with a different parameter schema. Check the charger's control entity / service in the SEM config. This issue clears automatically on the next successful command."
+    },
     "no_forecast_integration": {
       "title": "No solar forecast integration detected",
       "description": "SEM looked for a solar-forecast integration (Forecast.Solar, Solcast PV Solar, or a custom forecast sensor) for an hour after startup and didn't find one. Forecast-aware features (best-surplus-window tips, smart night charging, forecast dampening) are inactive until you install one. The issue clears automatically when SEM detects a forecast integration."

--- a/utils/log_buffer.py
+++ b/utils/log_buffer.py
@@ -1,0 +1,58 @@
+"""In-memory ring buffer of SEM log records for the diagnose surface.
+
+Supervisor installs route Home Assistant's log to journald — there is no
+flat ``home-assistant.log`` to tail, so the diagnose payload's
+``recent_logs`` was a "please run `ha core logs`" placeholder on exactly
+the installs that report bugs most (the entire #461/#462 triage ran
+without log visibility). A ``logging.Handler`` attached to the
+integration's root logger captures every SEM record regardless of where
+HA routes its output: child loggers (``…solar_energy_management.coordinator
+.sensor_reader`` etc.) propagate to the ancestor logger, whose handlers
+see the records.
+
+INFO and above only — DEBUG would balloon the dump and the diagnose
+surface targets "what was SEM doing around the incident", not tracing.
+"""
+from __future__ import annotations
+
+import logging
+from collections import deque
+
+SEM_LOGGER_NAME = "custom_components.solar_energy_management"
+
+_FORMAT = "%(asctime)s %(levelname)s (%(name)s) %(message)s"
+
+
+class SEMLogBuffer(logging.Handler):
+    """Ring buffer handler — keeps the last ``capacity`` formatted lines."""
+
+    def __init__(self, capacity: int = 300) -> None:
+        super().__init__(level=logging.INFO)
+        self._lines: deque[str] = deque(maxlen=capacity)
+        self.setFormatter(logging.Formatter(_FORMAT))
+
+    def emit(self, record: logging.LogRecord) -> None:  # noqa: D102
+        try:
+            self._lines.append(self.format(record))
+        except Exception:  # noqa: BLE001 — a log handler must never raise
+            pass
+
+    def get_lines(self, count: int = 80) -> list[str]:
+        """Return up to the last ``count`` captured lines, oldest first."""
+        return list(self._lines)[-count:]
+
+
+def ensure_attached() -> SEMLogBuffer:
+    """Attach (or reuse) the buffer on the integration's root logger.
+
+    Idempotent across reloads — the logger object is module-global and
+    survives config-entry teardown, so a second setup finds and reuses
+    the existing handler instead of stacking duplicates.
+    """
+    logger = logging.getLogger(SEM_LOGGER_NAME)
+    for handler in logger.handlers:
+        if isinstance(handler, SEMLogBuffer):
+            return handler
+    buffer = SEMLogBuffer()
+    logger.addHandler(buffer)
+    return buffer

--- a/utils/translate.py
+++ b/utils/translate.py
@@ -35,6 +35,18 @@ def _load_translations() -> Dict[str, Dict[str, str]]:
     return _translations_cache
 
 
+def preload_translations() -> None:
+    """Warm the module cache from a worker thread.
+
+    ``_load_translations`` opens dashboard/translations.json lazily on the
+    first ``get_text`` call — which happens inside the event loop (caught
+    live as "Detected blocking call to open", utils/translate.py:30).
+    Setup calls this via ``hass.async_add_executor_job`` so the one-and-
+    only file read happens off-loop; every later call hits the cache.
+    """
+    _load_translations()
+
+
 def get_text(hass: HomeAssistant, key: str, default: str = "", **kwargs: Any) -> str:
     """Get translated text for a key.
 


### PR DESCRIPTION
## Summary

The full follow-up batch from RienduPre's feedback (error log + beta.7 dump). Four fixes, two triage surfaces, framework tests extended.

### Fixes

1. **Actuation hardening (#462 root mechanism)** — `ev_charger_service: number.set_value` made the service path send `{current: X}`, which `number.set_value`'s schema rejects (`extra keys not allowed @ data['current']`): every current command on both his chargers failed for days, including the 0 A for off-mode. The shape is now mapped to the number-entity write it was meant to be (`value` + entity_id); registration WARNs when the target isn't a `number.*` entity.
2. **Repair on repeated actuation failure** — 3 consecutive rejected set-current commands raise a user-visible `charger_actuation_failed` Repair (severity ERROR; EN/NL/DE translated, EN fallback in the other 12 languages); cleared automatically on the next successful write. Intermittent flaps never trigger it.
3. **Fleet `charging_strategy`/`charging_strategy_reason` consistency** — the per-charger loop let the *last* charger overwrite `charging_strategy` while `_reason` kept the primary's value (the "always_max …" next to "off mode …" pair in his dump). Only the primary writes both now.
4. **Blocking `open()` calls off the event loop** ("Detected blocking call" in his log) — translations + manifest version warmed via executor at setup and cached; `diag_version` no longer re-opens manifest.json every cycle.

### Triage surfaces

5. **SEM log ring buffer** (`utils/log_buffer.py`) — diagnose `recent_logs` now carries the last ~300 INFO+ SEM lines on every install type; Supervisor installs (journald, no flat file) previously got a placeholder, which left the whole #461/#462 triage blind.
6. **Dual-tariff-aware manual-grid audit** — the sign cross-check sums the import/export counter *lists* (NL DSMR tarief 1/2). TROUBLESHOOTING gains the manual-entity checklist + dual-tariff Energy-Dashboard guidance.

### Framework tests extended (as requested)

- New real-HA tier `tests/test_actuation_real.py`: the `number.set_value` shape against a schema-strict real service registration, and the failure → Repair → recovery → clear cycle through the **real issue registry**.
- `test_services_real.py`: diagnose `recent_logs` served from the ring buffer + cached version assertion.
- Unit: actuation routing/param contracts, Repair threshold/idempotence/flap behavior, log-buffer capture/capacity/idempotence/never-raises, dual-tariff audit summing.

## Verification

Full suite: **3344 passed, 8 skipped** (17 new).

Refs #461 #462 #476

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB)_