### PR TITLE
release: v1.7.3-beta.8 — charger actuation hardening + Repair surface + log buffer (#462)

### DIFF
--- a/.github/release-notes/v1.7.3-beta.8.md
+++ b/.github/release-notes/v1.7.3-beta.8.md
@@ -1,0 +1,27 @@
+# [1.7.3-beta.8] - 10.06.2026
+
+## 🔌 Actuation hardening + triage surfaces (#462 follow-up batch)
+
+RienduPre's attached error log revealed the final #462 mechanism: with `ev_charger_service: number.set_value`, SEM sent `{current: X}` through the service path — `number.set_value` only accepts `value`, so **every current command on both chargers failed** (`extra keys not allowed @ data['current']`), including the 0 A for off-mode, with the evidence buried in per-cycle ERROR log lines.
+
+### 🛠️ Fixes
+
+- **`number.set_value` as charger service is mapped to the number-entity write it was meant to be** (`value` + entity_id) — this config shape can no longer leave a charger silently uncontrollable (by @traktore-org in [#482](https://github.com/traktore-org/sem-community/pull/482))
+- **Repair issue on repeated actuation failure** — 3 consecutive rejected set-current commands raise a user-visible Repair naming the charger and the error (severity ERROR, translated EN/NL/DE); clears automatically on the next successful write. Intermittent flaps never trigger it (by @traktore-org in [#482](https://github.com/traktore-org/sem-community/pull/482))
+- **Registration WARNING** when `ev_charger_service=number.set_value` has no `number.*` target entity
+- **Fleet `charging_strategy` / `charging_strategy_reason` are now consistent** — the per-charger loop let the *last* charger overwrite `charging_strategy` while `_reason` kept the primary's value; only the primary charger writes both now (per-charger detail lives in `charger_<id>_charging_state`)
+
+### 🔍 Triage surfaces
+
+- **In-memory SEM log ring buffer** — the diagnose payload's `recent_logs` now carries the last ~300 INFO+ SEM log lines on EVERY install type; Supervisor installs (journald, no flat log file) previously got a placeholder, which left the whole #461/#462 triage blind
+- **Manual-grid sign audit is dual-tariff aware** — the cross-check sums the import/export counter *lists*, so NL DSMR tarief-1/2 splits no longer blind it during one tariff's hours
+- **Blocking `open()` calls removed from the event loop** — translations and the manifest version are warmed off-loop at setup and cached
+- TROUBLESHOOTING: manual grid entity checklist (import vs export roles, power-not-energy, both-or-neither) + Dutch dual-tariff Energy-Dashboard guidance
+
+### 🧪 Tests
+
+- 3344 tests pass (17 new). New framework tier `tests/test_actuation_real.py`: real-HA schema-strict `number.set_value` shape + the failure → Repair → recovery → clear cycle through the real issue registry; diagnose `recent_logs`-from-buffer test in `test_services_real.py`
+
+### 🙏 Thanks
+
+- **@RienduPre** — the attached error log carried the `extra keys not allowed @ data['current']` line that pinpointed the actuation failure, and the beta.7 dump confirmed the rest.

--- a/.github/release-request.json
+++ b/.github/release-request.json
@@ -1,6 +1,6 @@
 {
-  "tag": "v1.7.3-beta.7",
-  "title": "v1.7.3-beta.7 — manual grid override audit (#461) + #476 robustness batch",
+  "tag": "v1.7.3-beta.8",
+  "title": "v1.7.3-beta.8 — charger actuation hardening + Repair surface + log buffer (#462)",
   "prerelease": true,
-  "notes_file": ".github/release-notes/v1.7.3-beta.7.md"
+  "notes_file": ".github/release-notes/v1.7.3-beta.8.md"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
-# [Unreleased]
+# [1.7.3-beta.8] - 10.06.2026
 
 ## 🔌 Actuation hardening + triage surfaces (#462 follow-up batch)
 

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.3-beta.7"
+  "version": "1.7.3-beta.8"
 }


### PR DESCRIPTION
Release bump for **v1.7.3-beta.8** (manifest + changelog header + release request + notes). Merging this PR publishes the release via the release-request workflow — content is the #482 actuation-hardening batch already on develop.

Version-sanity tests pass (manifest format + cache-bust checks).

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7NjKovcvPCj9tripYG1nB)_