### PR TITLE
fix(diagram-card): backticks in lit-template comment blanked the Home-tab diagram (#488)

### DIFF
--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -4618,8 +4618,11 @@ const t=globalThis,e=t.ShadowRoot&&(void 0===t.ShadyCSS||t.ShadyCSS.nativeShadow
                          battery_soc and battery_power have been
                          unavailable for >60 s (Huawei modbus hard
                          dropout). Brief flickers (<60 s) are absorbed
-                         by ``_readWithHold`` upstream so the user
-                         doesn't see a visual emergency. -->
+                         by '_readWithHold' upstream so the user
+                         doesn't see a visual emergency. (NEVER put
+                         backticks inside this lit template: they
+                         terminate the template literal and the whole
+                         card renders blank, #488.) -->
                     <g filter="url(#glowBattery)" class="clickable"
                        opacity="${g?.35:1}"
                        @click=${()=>this._showMoreInfo("battery_soc")}>

--- a/dashboard/card/src/cards/sem-system-diagram-card.js
+++ b/dashboard/card/src/cards/sem-system-diagram-card.js
@@ -686,8 +686,11 @@ class SEMSystemDiagramCard extends SEMLitBase {
                          battery_soc and battery_power have been
                          unavailable for >60 s (Huawei modbus hard
                          dropout). Brief flickers (<60 s) are absorbed
-                         by ``_readWithHold`` upstream so the user
-                         doesn't see a visual emergency. -->
+                         by '_readWithHold' upstream so the user
+                         doesn't see a visual emergency. (NEVER put
+                         backticks inside this lit template: they
+                         terminate the template literal and the whole
+                         card renders blank, #488.) -->
                     <g filter="url(#glowBattery)" class="clickable"
                        opacity="${battSensorStale ? 0.35 : 1}"
                        @click=${() => this._showMoreInfo('battery_soc')}>

--- a/tests/test_card_template_lint.py
+++ b/tests/test_card_template_lint.py
@@ -1,0 +1,39 @@
+"""Lint: no backticks inside HTML comments in card sources (#488).
+
+The card sources are LitElement templates — giant ``html`` tagged
+template literals. A backtick inside an HTML comment within such a
+template legally TERMINATES the template literal; the remainder
+re-parses as a tagged-template chain that is **syntactically valid
+JS** (rollup, node --check, and CI all pass) but throws
+``TypeError: html(...) is not a function`` at render time, leaving the
+card blank. Exactly this shipped in 26d4616 (RST-style
+````_readWithHold```` in a comment) and blanked the system diagram on
+TEST and PROD.
+
+This is the FLEET-READ-style structural guard for the class: scan
+every card source for backticks between ``<!--`` and ``-->``.
+"""
+import re
+from pathlib import Path
+
+CARD_SRC = Path(__file__).resolve().parent.parent / "dashboard" / "card" / "src"
+
+
+def test_no_backticks_inside_html_comments():
+    assert CARD_SRC.is_dir(), f"card src dir missing: {CARD_SRC}"
+    offenders = []
+    for path in sorted(CARD_SRC.rglob("*.js")):
+        src = path.read_text(encoding="utf-8")
+        for m in re.finditer(r"<!--.*?-->", src, re.S):
+            if "`" in m.group(0):
+                line = src[: m.start()].count("\n") + 1
+                offenders.append(
+                    f"{path.relative_to(CARD_SRC.parent.parent.parent)}:{line}: "
+                    f"{m.group(0)[:80]!r}"
+                )
+    assert not offenders, (
+        "Backtick inside an HTML comment in a lit template — this "
+        "TERMINATES the template literal and the card renders blank "
+        "at runtime while every syntax check stays green (#488):\n"
+        + "\n".join(offenders)
+    )


### PR DESCRIPTION
## Summary

The system diagram rendered an empty shadow root on the Home tab (TEST + PROD) since the #484-merge bundle was deployed. Root cause: the battery-flicker-hold comment from 26d4616 contained RST-style double backticks INSIDE the lit `html``` template — backticks terminate the template literal, and the remainder re-parses as a tagged-template chain that is syntactically valid JS (rollup / node --check / CI all green) but throws `TypeError: html(...) is not a function` at render time.

## Fix

- Comment now uses plain quotes, with an inline never-again warning
- `tests/test_card_template_lint.py` — structural guard: no backtick may appear inside `<!-- -->` comments in any card source (the class is invisible to every syntax check)
- Bundle rebuilt

## Verification

- Headless playwright on HA-TEST: diagram renders 900×693 px, 62 kB shadow DOM, zero console errors, zero error cards (screenshot in #488 thread)
- HA-PROD redeployed and verified: 0 broken comments in the served bundle, 0 SEM errors in the log

Fixes #488