### PR TITLE
fix: #487 Wallbox entity-range bounds + honored stop switch + sign-vote warmup + health-log rate limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [1.7.3-beta.9] - 11.06.2026
 
+## 🔌 Wallbox actuation: entity-range bounds + working stop path (#487)
+
+RienduPre's error log exposed the real "keeps charging in off mode" mechanism: SEM wrote 0 A (stop) and >entity-max amps to the Wallbox max-current number entity — HA core rejects both with `out_of_range` **before anything reaches the charger** (167× per charger in the log).
+
+- **Current writes are bounded into the target entity's own min/max** — a charger whose entity allows 6–16 A gets 16 A when SEM wants 32, instead of a rejected command (by @traktore-org in #490)
+- **0 A stop intents skip the structurally impossible number write** — the stop goes through the adapter's pause-switch / stop_session path (Wallbox min=6 A, IEC 61851)
+- **`ev_start_stop_entity` is now actually honored** as the Wallbox pause/resume switch — the adapter's own WARNING recommended it as the workaround but never read the field (RienduPre's #462 finding)
+- **Health-check violation WARNINGs are rate-limited** — after 6 consecutive violating cycles they drop to debug until they clear (413 identical lines flooded the log + the diagnose ring buffer)
+
+## 🧭 Grid-sign restart hardening (live PROD flip, #487 follow-up)
+
+A restart locked `grid_sign_inverted=True` on a Huawei install whose convention needs NO correction — 3 sign votes cast while HA's recorder was still replaying counter states (#476 items 5/6 gap, observed live 2026-06-11).
+
+- **Sign votes are ignored for the first 12 cycles after startup** (~2 min) — baselines stay fresh, nothing locks
+- **The sign-lock log line now names the voting counter entities**, so a wrong lock is diagnosable after the fact
+
+## 🖼️ Diagram card blank on Home tab (#488)
+
+- **Backticks inside a lit-template HTML comment terminated the template literal** — the remainder re-parsed as a tagged-template chain: syntactically valid JS (rollup/CI green) that threw at render time, blanking the system diagram. Fixed + a lint test forbidding backticks in card-template comments (by @traktore-org in #489)
+
 ## 🔍 Pre-stable review batch (#485)
 
 A full 7-angle review of everything on develop since v1.7.2 surfaced 23 verified findings — two of them stable-release blockers in this release's headline features. All fixed in one batch.

--- a/coordinator/charger_adapters/wallbox.py
+++ b/coordinator/charger_adapters/wallbox.py
@@ -86,6 +86,20 @@ class WallboxAdapter(GenericAdapter):
             return self._pause_switch_entity
         self._pause_switch_searched = True
 
+        # #487/#475: an explicitly configured switch wins — the WARNING
+        # below has been telling users to set ev_start_stop_entity as
+        # the workaround, but the adapter never actually read it
+        # (RienduPre's "#462: adapter ignores ev_start_stop_entity").
+        configured = getattr(self._device, "start_stop_entity", None) or ""
+        if str(configured).startswith("switch."):
+            self._pause_switch_entity = str(configured)
+            _LOGGER.info(
+                "Wallbox %s: using configured ev_start_stop_entity %s "
+                "as the pause/resume switch",
+                self._device.name, configured,
+            )
+            return self._pause_switch_entity
+
         hass = getattr(self._device, "hass", None)
         if hass is None:
             return None

--- a/coordinator/health_check.py
+++ b/coordinator/health_check.py
@@ -8,9 +8,15 @@ _LOGGER = logging.getLogger(__name__)
 class HealthCheck:
     """Validates energy balance and calculation integrity each cycle."""
 
+    # After this many consecutive violating cycles the per-cycle WARNING
+    # drops to debug until the violations clear (#487 triage logs: 413
+    # near-identical lines drowned the log + diagnose ring buffer).
+    _WARN_CYCLES = 6
+
     def __init__(self) -> None:
         self._violation_count: int = 0
         self._last_violations: list[str] = []
+        self._violation_streak: int = 0
 
     def check_power_balance(self, power: PowerReadings) -> list[str]:
         """Verify energy balance: solar + import + discharge ≈ home + ev + export + charge."""
@@ -126,8 +132,24 @@ class HealthCheck:
         if violations:
             self._violation_count += len(violations)
             self._last_violations = violations
-            for v in violations:
-                _LOGGER.warning("Health check violation: %s", v)
+            self._violation_streak += 1
+            if self._violation_streak <= self._WARN_CYCLES:
+                for v in violations:
+                    _LOGGER.warning("Health check violation: %s", v)
+                if self._violation_streak == self._WARN_CYCLES:
+                    _LOGGER.warning(
+                        "Health check violations persist — further "
+                        "occurrences drop to debug until they clear "
+                        "(diag: sem health sensors keep counting)",
+                    )
+            else:
+                for v in violations:
+                    _LOGGER.debug("Health check violation: %s", v)
+        else:
+            if self._violation_streak > self._WARN_CYCLES:
+                _LOGGER.info("Health check violations cleared")
+            self._violation_streak = 0
+            self._last_violations = []
 
         return violations
 

--- a/coordinator/sensor_reader.py
+++ b/coordinator/sensor_reader.py
@@ -72,6 +72,14 @@ class SensorReader:
         self._grid_sign_votes: int = 0  # Consecutive same-sign detections needed
         self._grid_import_baseline: Optional[float] = None
         self._grid_export_baseline: Optional[float] = None
+        # #487 follow-up (live PROD flip 2026-06-11): during HA's
+        # come-up window counter states replay in bursts while power
+        # sensors are already live — 3 quick wrong votes locked
+        # grid_sign_inverted=True on a Huawei install whose convention
+        # needs NO correction (RAM-only state, #476 item 5/6 gap).
+        # Sign votes are ignored for the first cycles after
+        # construction (~2 min at the 10 s interval).
+        self._sign_vote_warmup: int = 12
         # Battery sign autodetect — #404: per-battery state.
         # Multi-battery installs (≥ 2 ``battery_power_list`` entries) run
         # the detection independently per battery using each one's own
@@ -247,6 +255,12 @@ class SensorReader:
         """Read all power values from sensors."""
         readings = PowerReadings()
 
+        # Sign-vote warm-up ticks once per cycle (#487 follow-up) —
+        # decremented here so it expires even on installs where one
+        # voter early-returns before its own check.
+        if self._sign_vote_warmup > 0:
+            self._sign_vote_warmup -= 1
+
         # Try Energy Dashboard config first, then legacy config
         if self._energy_dashboard_config:
             readings = self._read_from_energy_dashboard()
@@ -362,6 +376,17 @@ class SensorReader:
         if not import_entities or not export_entities:
             return False
 
+        # Startup warm-up (#487 follow-up): no votes while HA's
+        # recorder is still replaying counter states — keep baselines
+        # fresh but cast nothing.
+        if self._sign_vote_warmup > 0:
+            iv = self._sum_counter_states(import_entities)
+            ev = self._sum_counter_states(export_entities)
+            if iv is not None and ev is not None:
+                self._grid_import_baseline = iv
+                self._grid_export_baseline = ev
+            return self._grid_sign_inverted
+
         # Need meaningful power to detect (ignore noise)
         power = readings.grid_power
         if abs(power) < 100:
@@ -424,11 +449,17 @@ class SensorReader:
             if abs(self._grid_sign_votes) >= 3:
                 self._grid_sign_inverted = detected
                 self._grid_sign_detected = True
+                # Name the evidence (#487 follow-up): a wrong lock is
+                # otherwise undiagnosable after the fact — the 2026-06-11
+                # PROD flip left only 'diag_grid_sign: negated' with no
+                # trail of WHICH counters voted.
                 _LOGGER.info(
                     "Grid sign detected from Energy Dashboard counters: %s "
-                    "(power=%.0fW, import_delta=%.3f, export_delta=%.3f)",
+                    "(power=%.0fW, import_delta=%.3f, export_delta=%.3f, "
+                    "import_counters=%s, export_counters=%s)",
                     "negating (HA convention)" if detected else "no correction (SEM convention)",
                     power, import_delta, export_delta,
+                    import_entities, export_entities,
                 )
 
         return self._grid_sign_inverted
@@ -485,6 +516,12 @@ class SensorReader:
         self._battery_discharge_baseline.setdefault(bid, None)
 
         if not charge_entity or not discharge_entity:
+            return self._battery_sign_inverted[bid]
+
+        # Startup warm-up (#487 follow-up) — same restart-window
+        # protection as the grid voter; baselines refresh below on
+        # the first post-warmup cycle.
+        if self._sign_vote_warmup > 0:
             return self._battery_sign_inverted[bid]
 
         # Need meaningful power to detect (ignore noise)

--- a/devices/base.py
+++ b/devices/base.py
@@ -634,6 +634,37 @@ class CurrentControlDevice(ControllableDevice):
         )
         return await self._set_current(target_current)
 
+    def _bound_to_entity_range(
+        self, entity_id: str, current: float,
+    ) -> tuple:
+        """Bound a current command to the target number entity's range.
+
+        Returns ``(bounded_current, skip_write)``. ``skip_write`` is
+        True for a stop intent (``current <= 0``) on an entity whose
+        minimum is above 0 — the write would be rejected by HA core's
+        range validation before reaching the charger (#487), so the
+        caller must rely on the adapter's stop mechanism instead.
+        Unreadable entities/attributes leave the command untouched.
+        """
+        state = self.hass.states.get(entity_id) if entity_id else None
+        attrs = getattr(state, "attributes", None) or {}
+        try:
+            ent_min = float(attrs["min"]) if attrs.get("min") is not None else None
+        except (TypeError, ValueError):
+            ent_min = None
+        try:
+            ent_max = float(attrs["max"]) if attrs.get("max") is not None else None
+        except (TypeError, ValueError):
+            ent_max = None
+
+        if current <= 0:
+            return current, bool(ent_min is not None and ent_min > 0)
+        if ent_max is not None and current > ent_max:
+            current = ent_max
+        if ent_min is not None and current < ent_min:
+            current = ent_min
+        return current, False
+
     async def _set_current(self, current: float) -> float:
         """Set charging current via entity or service."""
         current = round(current, 0)
@@ -662,8 +693,45 @@ class CurrentControlDevice(ControllableDevice):
         # configured as the charger service bounced identically.
         _svc = (self.charger_service or "").strip().lower()
         _entity_svc_domain = _svc.split(".", 1)[0] if "." in _svc else ""
+
+        # #487: HA core validates number writes against the ENTITY's
+        # min/max BEFORE anything reaches the charger. Wallbox exposes
+        # min=6 (IEC 61851), so writing 0 A to stop is structurally
+        # impossible — it raised out_of_range every idle cycle (167×
+        # in RienduPre's log) and, since the actuation Repair landed,
+        # would false-trip it. Likewise a configured max above the
+        # entity's max (Links: 6-16 A) bounced every ramp-up command.
+        # Bound the write to the entity's range; a 0 A stop intent
+        # skips the write entirely — the actual stop is the adapter's
+        # job (pause switch / stop_session), and the number entity
+        # cannot express it.
+        _entity_target = None
+        if _entity_svc_domain in ("number", "input_number"):
+            _entity_target = self.current_entity_id or self.charger_service_entity_id
+        elif not self.charger_service and self.current_entity_id:
+            _entity_target = self.current_entity_id
+        skip_entity_write = False
+        if _entity_target:
+            bounded, skip_entity_write = self._bound_to_entity_range(
+                _entity_target, current,
+            )
+            if not skip_entity_write and bounded != current:
+                _LOGGER.debug(
+                    "%s: clamping commanded %.0f A into %s's range → %.0f A",
+                    self.name, current, _entity_target, bounded,
+                )
+                current = bounded
+
         try:
-            if _entity_svc_domain in ("number", "input_number"):
+            if skip_entity_write:
+                # Stop intent on a number entity that can't express 0 A.
+                _LOGGER.debug(
+                    "%s: 0 A stop not writable to %s (entity min > 0) — "
+                    "relying on the adapter stop path (pause switch / "
+                    "stop_session) (#487)",
+                    self.name, _entity_target,
+                )
+            elif _entity_svc_domain in ("number", "input_number"):
                 # Map it to the entity write it was meant to be.
                 target = self.current_entity_id or self.charger_service_entity_id
                 await self.hass.services.async_call(

--- a/devices/base.py
+++ b/devices/base.py
@@ -647,15 +647,26 @@ class CurrentControlDevice(ControllableDevice):
         Unreadable entities/attributes leave the command untouched.
         """
         state = self.hass.states.get(entity_id) if entity_id else None
-        attrs = getattr(state, "attributes", None) or {}
-        try:
-            ent_min = float(attrs["min"]) if attrs.get("min") is not None else None
-        except (TypeError, ValueError):
-            ent_min = None
-        try:
-            ent_max = float(attrs["max"]) if attrs.get("max") is not None else None
-        except (TypeError, ValueError):
-            ent_max = None
+        attrs = getattr(state, "attributes", None)
+        if not isinstance(attrs, dict):
+            return current, False
+
+        def _as_float(value):
+            # Real numerics/strings only — duck-typed mocks support
+            # __float__ and would fabricate bounds.
+            if isinstance(value, bool):
+                return None
+            if isinstance(value, (int, float)):
+                return float(value)
+            if isinstance(value, str):
+                try:
+                    return float(value)
+                except ValueError:
+                    return None
+            return None
+
+        ent_min = _as_float(attrs.get("min"))
+        ent_max = _as_float(attrs.get("max"))
 
         if current <= 0:
             return current, bool(ent_min is not None and ent_min > 0)

--- a/tests/test_487_wallbox_entity_bounds.py
+++ b/tests/test_487_wallbox_entity_bounds.py
@@ -1,0 +1,218 @@
+"""#487 — Wallbox number-entity range fixes + restart sign-vote warmup.
+
+RienduPre's log: 167× per charger ``Failed to set current: out_of_range``
+— SEM wrote 0 A (stop) and >entity-max amps to Wallbox max-current
+number entities; HA core rejects both BEFORE anything reaches the
+charger. Plus the live 2026-06-11 PROD grid-sign flip from restart
+window votes, and 413× health-check WARNING spam.
+"""
+import logging
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from custom_components.solar_energy_management.devices.base import (
+    CurrentControlDevice,
+)
+from custom_components.solar_energy_management.coordinator.charger_adapters.wallbox import (
+    WallboxAdapter,
+)
+from custom_components.solar_energy_management.coordinator.health_check import (
+    HealthCheck,
+)
+
+
+def _number_state(min_a=6.0, max_a=16.0):
+    state = MagicMock()
+    state.attributes = {"min": min_a, "max": max_a, "step": 1.0}
+    return state
+
+
+def _device(**kwargs):
+    hass = MagicMock()
+    hass.services.async_call = AsyncMock()
+    defaults = dict(
+        hass=hass, device_id="wb", name="Laadpaal Links",
+        min_current=6.0, max_current=32.0, phases=3,
+    )
+    defaults.update(kwargs)
+    return CurrentControlDevice(**defaults)
+
+
+@pytest.mark.unit
+class TestEntityRangeBounds:
+    @pytest.mark.asyncio
+    async def test_zero_stop_skips_write_on_min6_entity(self):
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.hass.states.get = MagicMock(return_value=_number_state(6.0, 16.0))
+        consumed = await dev._set_current(0)
+        dev.hass.services.async_call.assert_not_awaited()
+        assert consumed == 0.0
+        assert dev._current_setpoint == 0
+
+    @pytest.mark.asyncio
+    async def test_above_entity_max_is_clamped(self):
+        # Links: entity range 6-16 while SEM's configured max is 32.
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.hass.states.get = MagicMock(return_value=_number_state(6.0, 16.0))
+        await dev._set_current(32)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[2]["value"] == 16
+
+    @pytest.mark.asyncio
+    async def test_below_entity_min_clamps_up(self):
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.hass.states.get = MagicMock(return_value=_number_state(6.0, 16.0))
+        await dev._set_current(4)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[2]["value"] == 6
+
+    @pytest.mark.asyncio
+    async def test_unreadable_entity_leaves_command_untouched(self):
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.hass.states.get = MagicMock(return_value=None)
+        await dev._set_current(10)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[2]["value"] == 10
+
+    @pytest.mark.asyncio
+    async def test_zero_on_entity_allowing_zero_still_writes(self):
+        dev = _device(current_entity_id="number.charger_current")
+        dev.hass.states.get = MagicMock(return_value=_number_state(0.0, 32.0))
+        await dev._set_current(0)
+        call = dev.hass.services.async_call.await_args
+        assert call.args[2]["value"] == 0
+
+    @pytest.mark.asyncio
+    async def test_entity_service_shape_also_bounded(self):
+        dev = _device(
+            charger_service="number.set_value",
+            current_entity_id="number.wallbox_links_max_charging_current",
+        )
+        dev.hass.states.get = MagicMock(return_value=_number_state(6.0, 16.0))
+        await dev._set_current(0)
+        dev.hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.unit
+class TestWallboxConfiguredStopSwitch:
+    def test_configured_start_stop_entity_wins(self):
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.start_stop_entity = "switch.wallbox_links_pause_resume"
+        adapter = WallboxAdapter(dev)
+        assert adapter._discover_pause_switch() == "switch.wallbox_links_pause_resume"
+
+    def test_non_switch_config_falls_through_to_discovery(self):
+        dev = _device(current_entity_id="number.wallbox_links_max_charging_current")
+        dev.start_stop_entity = "button.wallbox_links_resume"
+        dev.hass = None  # discovery aborts cleanly
+        adapter = WallboxAdapter(dev)
+        assert adapter._discover_pause_switch() is None
+
+
+@pytest.mark.unit
+class TestHealthCheckLogRateLimit:
+    def test_warning_drops_to_debug_after_streak(self, caplog):
+        hc = HealthCheck()
+        power = MagicMock(
+            solar_power=1000.0, grid_import_power=0.0,
+            battery_discharge_power=0.0, home_consumption_power=5000.0,
+            ev_power=0.0, grid_export_power=0.0, battery_charge_power=0.0,
+        )
+        with caplog.at_level(logging.DEBUG):
+            for _ in range(hc._WARN_CYCLES + 4):
+                hc.run_all_checks(power)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING
+                    and "Health check violation" in r.message]
+        assert len(warnings) == hc._WARN_CYCLES
+        # the violations keep counting even while quiet
+        assert hc.total_violations >= hc._WARN_CYCLES + 4
+
+    def test_streak_resets_when_clean(self, caplog):
+        hc = HealthCheck()
+        bad = MagicMock(
+            solar_power=1000.0, grid_import_power=0.0,
+            battery_discharge_power=0.0, home_consumption_power=5000.0,
+            ev_power=0.0, grid_export_power=0.0, battery_charge_power=0.0,
+        )
+        good = MagicMock(
+            solar_power=1000.0, grid_import_power=0.0,
+            battery_discharge_power=0.0, home_consumption_power=1000.0,
+            ev_power=0.0, grid_export_power=0.0, battery_charge_power=0.0,
+        )
+        with caplog.at_level(logging.DEBUG):
+            for _ in range(hc._WARN_CYCLES + 2):
+                hc.run_all_checks(bad)
+            hc.run_all_checks(good)
+            caplog.clear()
+            hc.run_all_checks(bad)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings  # WARNING level again after a clean cycle
+
+
+@pytest.mark.unit
+class TestSignVoteWarmup:
+    """#487 follow-up: live PROD grid-sign flip from restart-window votes."""
+
+    def _reader(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        from custom_components.solar_energy_management.coordinator.types import (
+            PowerReadings,
+        )
+        hass = MagicMock()
+        reader = SensorReader(hass, {})
+        ed = MagicMock()
+        ed.grid_import_energy = "sensor.grid_import_total"
+        ed.grid_export_energy = "sensor.grid_export_total"
+        ed.grid_import_energy_list = ["sensor.grid_import_total"]
+        ed.grid_export_energy_list = ["sensor.grid_export_total"]
+        reader._energy_dashboard_config = ed
+        states = {}
+        hass.states.get = lambda eid: states.get(eid)
+
+        def set_counters(imp, exp):
+            for eid, v in (("sensor.grid_import_total", imp),
+                           ("sensor.grid_export_total", exp)):
+                s = MagicMock()
+                s.state = str(v)
+                s.attributes = {"unit_of_measurement": "kWh"}
+                states[eid] = s
+        return reader, set_counters, PowerReadings
+
+    def test_no_votes_during_warmup(self):
+        reader, set_counters, PowerReadings = self._reader()
+        assert reader._sign_vote_warmup > 0  # armed at construction
+        set_counters(100.0, 50.0)
+        reader._detect_grid_sign(PowerReadings(grid_power=800.0))
+        # import counter climbing while power positive would normally
+        # vote "negate" — warmup must swallow it.
+        for step in range(1, 5):
+            set_counters(100.0 + step * 0.1, 50.0)
+            result = reader._detect_grid_sign(PowerReadings(grid_power=800.0))
+        assert result is False
+        assert reader._grid_sign_votes == 0
+        assert reader._grid_sign_detected is False
+
+    def test_votes_resume_after_warmup(self):
+        reader, set_counters, PowerReadings = self._reader()
+        reader._sign_vote_warmup = 0
+        set_counters(100.0, 50.0)
+        reader._detect_grid_sign(PowerReadings(grid_power=800.0))  # baseline
+        for step in range(1, 4):
+            set_counters(100.0 + step * 0.1, 50.0)
+            result = reader._detect_grid_sign(PowerReadings(grid_power=800.0))
+        assert result is True  # locked after 3 consistent votes
+        assert reader._grid_sign_detected is True
+
+    def test_read_power_decrements_warmup(self):
+        from custom_components.solar_energy_management.coordinator.sensor_reader import (
+            SensorReader,
+        )
+        hass = MagicMock()
+        hass.states.get = MagicMock(return_value=None)
+        reader = SensorReader(hass, {})
+        reader._energy_dashboard_config = None
+        before = reader._sign_vote_warmup
+        reader.read_power()
+        assert reader._sign_vote_warmup == before - 1

--- a/tests/test_487_wallbox_entity_bounds.py
+++ b/tests/test_487_wallbox_entity_bounds.py
@@ -122,7 +122,7 @@ class TestHealthCheckLogRateLimit:
             for _ in range(hc._WARN_CYCLES + 4):
                 hc.run_all_checks(power)
         warnings = [r for r in caplog.records if r.levelno == logging.WARNING
-                    and "Health check violation" in r.message]
+                    and "Health check violation:" in r.message]
         assert len(warnings) == hc._WARN_CYCLES
         # the violations keep counting even while quiet
         assert hc.total_violations >= hc._WARN_CYCLES + 4

--- a/tests/test_battery_sign_detect.py
+++ b/tests/test_battery_sign_detect.py
@@ -59,7 +59,10 @@ def mock_hass():
 @pytest.fixture
 def sensor_reader(mock_hass):
     """Create a SensorReader with empty config."""
-    return SensorReader(mock_hass, {})
+    r = SensorReader(mock_hass, {})
+    r._sign_vote_warmup = 0
+    r._sign_vote_warmup = 0  # unit tests exercise post-warmup voting (#487)
+    return r
 
 
 class TestBatterySignAutoDetect:
@@ -300,6 +303,7 @@ class TestBatteryCapacityAutoDetect:
     def _make_reader(self, mock_hass):
         config = {"battery_power_sensor": "sensor.battery_power"}
         reader = SensorReader(mock_hass, config)
+        reader._sign_vote_warmup = 0
         ed = _make_energy_dashboard_config()
         reader.set_energy_dashboard_config(ed)
         return reader
@@ -552,6 +556,7 @@ class TestPerBatterySignAutoDetect404:
         hass = Mock()
         hass.states = Mock()
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         ed = _make_multi_battery_ed(
             battery_power_list=[f"sensor.b{i+1}_power" for i in range(len(charge_vals))],
             battery_charge_energy_list=[f"sensor.b{i+1}_charge" for i in range(len(charge_vals))],
@@ -676,6 +681,7 @@ class TestPerBatterySignAutoDetect404:
         returns the stored default (False) for that battery — no crash.
         """
         reader = SensorReader(Mock(states=Mock()), {})
+        reader._sign_vote_warmup = 0
         # No charge/discharge entities provided
         result = reader._detect_battery_sign_for("b1", 500.0, None, None)
         assert result is False
@@ -724,6 +730,7 @@ class TestPerBatterySignAutoDetect404:
         doesn't cross-contaminate.
         """
         reader = SensorReader(Mock(states=Mock()), {})
+        reader._sign_vote_warmup = 0
         # Prime fleet path
         reader._detect_battery_sign_for("b1", 500.0, None, None)
         reader._detect_battery_sign_for(reader._FLEET_BID, 500.0, None, None)

--- a/tests/test_e2e_hardware.py
+++ b/tests/test_e2e_hardware.py
@@ -334,6 +334,7 @@ class E2ETestBase:
             "ev_charging_sensor": self.charger.charging_sensor,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         # Solar power should be positive
         solar = reader._read_sensor(self.inverter.solar_power, "solar")
@@ -359,6 +360,7 @@ class E2ETestBase:
             hass.states.get = lambda eid: _state(3500, unit="W", device_class="power")
 
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         value = reader._read_sensor(self.charger.power_sensor, "ev")
         assert value == 3500.0, f"{self.charger.name}: expected 3500W, got {value}"
 
@@ -440,6 +442,7 @@ class E2ETestBase:
             "battery_soc_sensor": inv.battery_soc,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         # Set up Energy Dashboard config for sign detection
         ed = MagicMock()
@@ -487,6 +490,7 @@ class E2ETestBase:
             "battery_power_sensor": inv.battery_power,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         ed = MagicMock()
         ed.solar_power = inv.solar_power
@@ -540,6 +544,7 @@ class E2ETestBase:
 
         hass = MagicMock()
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         chg = self.charger
 
         # Test connected state

--- a/tests/test_ev_connected_physics_defence.py
+++ b/tests/test_ev_connected_physics_defence.py
@@ -48,6 +48,7 @@ def _build_reader(plug_state="off", charging_state="off", charging_power_w=0):
         "ev_charging_sensor": "binary_sensor.fake_charging",
     }
     reader = SensorReader(hass, config)
+    reader._sign_vote_warmup = 0
     return reader
 
 

--- a/tests/test_ev_energy_fix.py
+++ b/tests/test_ev_energy_fix.py
@@ -68,6 +68,7 @@ class TestLayer1ConfigKeyMismatch:
         config = {"ev_power_sensor": "sensor.keba_p30_charging_power"}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_power_sensor == "sensor.keba_p30_charging_power"
 
     def test_config_flow_key_ev_charging_power_sensor(self):
@@ -75,6 +76,7 @@ class TestLayer1ConfigKeyMismatch:
         config = {"ev_charging_power_sensor": "sensor.keba_p30_charging_power"}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_power_sensor == "sensor.keba_p30_charging_power"
 
     def test_both_keys_legacy_wins(self):
@@ -85,6 +87,7 @@ class TestLayer1ConfigKeyMismatch:
         }
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_power_sensor == "sensor.legacy_ev"
 
     def test_neither_key_is_none(self):
@@ -92,6 +95,7 @@ class TestLayer1ConfigKeyMismatch:
         config = {}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_power_sensor is None
 
     def test_legacy_read_uses_resolved_sensor(self):
@@ -104,6 +108,7 @@ class TestLayer1ConfigKeyMismatch:
         config = {"ev_charging_power_sensor": "sensor.keba_p30_charging_power"}
         hass = _make_hass(sensors)
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         readings = reader.read_power()
         assert readings.ev_power == 7200.0
 
@@ -128,6 +133,7 @@ class TestLayer2EnergyDashboardFallback:
         }
         hass = _make_hass(sensors)
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         ed = EnergyDashboardConfig(
             solar_power="sensor.ed_solar",
@@ -151,6 +157,7 @@ class TestLayer2EnergyDashboardFallback:
         }
         hass = _make_hass(sensors)
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         # Energy Dashboard has solar but no ev_power
         ed = EnergyDashboardConfig(
@@ -172,6 +179,7 @@ class TestLayer2EnergyDashboardFallback:
         config = {}
         hass = _make_hass(sensors)
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         ed = EnergyDashboardConfig(solar_power="sensor.ed_solar", ev_power=None)
         reader.set_energy_dashboard_config(ed)
@@ -340,6 +348,7 @@ class TestKebaAutoDetection:
         config = {"ev_charging_power_sensor": "sensor.keba_p30_charging_power"}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_daily_energy_sensor is None
 
     def test_non_keba_power_sensor_no_auto_detect(self):
@@ -347,6 +356,7 @@ class TestKebaAutoDetection:
         config = {"ev_charging_power_sensor": "sensor.wallbox_power"}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_daily_energy_sensor is None
 
     def test_explicit_daily_sensor_overrides_auto_detect(self):
@@ -357,6 +367,7 @@ class TestKebaAutoDetection:
         }
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_daily_energy_sensor == "sensor.my_custom_daily"
 
     def test_no_ev_sensor_no_crash(self):
@@ -364,6 +375,7 @@ class TestKebaAutoDetection:
         config = {}
         hass = _make_hass()
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_daily_energy_sensor is None
 
 
@@ -403,6 +415,7 @@ class TestEndToEndOriginalBug:
 
         # Layer 1: SensorReader resolves the key mismatch
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
         assert reader.config.ev_power_sensor == "sensor.keba_p30_charging_power"
 
         # Energy Dashboard has no ev_power

--- a/tests/test_grid_sign_invert_352.py
+++ b/tests/test_grid_sign_invert_352.py
@@ -63,6 +63,7 @@ class TestGridSignInvertOption:
         """With the flag off (default) auto-detect runs as before."""
         mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
         reader = SensorReader(mock_hass, {})  # no grid_sign_invert key
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(_ed_config())
 
         readings = reader.read_power()
@@ -76,6 +77,7 @@ class TestGridSignInvertOption:
         """``grid_sign_invert: True`` flips a positive read to negative."""
         mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
         reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(_ed_config())
 
         readings = reader.read_power()
@@ -88,6 +90,7 @@ class TestGridSignInvertOption:
         """A negative raw read flips to positive (export under SEM)."""
         mock_hass.states.get = lambda eid: _state(-1500) if eid == "sensor.grid_power" else None
         reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(_ed_config())
 
         readings = reader.read_power()
@@ -98,6 +101,7 @@ class TestGridSignInvertOption:
         """Auto-detect state is not touched when the manual override fires."""
         mock_hass.states.get = lambda eid: _state(2000) if eid == "sensor.grid_power" else None
         reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(_ed_config())
 
         # Pre-conditions: auto-detect state untouched.
@@ -119,6 +123,7 @@ class TestGridSignInvertOption:
         """0 → 0 under negation."""
         mock_hass.states.get = lambda eid: _state(0) if eid == "sensor.grid_power" else None
         reader = SensorReader(mock_hass, {"grid_sign_invert": True})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(_ed_config())
 
         readings = reader.read_power()

--- a/tests/test_hardware_compat.py
+++ b/tests/test_hardware_compat.py
@@ -87,6 +87,7 @@ class TestKEBADiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(3.5, unit="kW") if "power" in eid else None
         reader = SensorReader(hass, {"ev_power_sensor": "sensor.keba_kecontact_p30_charging_power"})
+        reader._sign_vote_warmup = 0
         value = reader._read_sensor("sensor.keba_kecontact_p30_charging_power", "ev")
         assert value == 3500.0  # 3.5 kW → 3500 W
 
@@ -95,6 +96,7 @@ class TestKEBADiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state("on")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_binary_sensor("binary_sensor.keba_kecontact_p30_plug", "ev_plug") is True
         hass.states.get = lambda eid: _state("off")
         assert reader._read_binary_sensor("binary_sensor.keba_kecontact_p30_plug", "ev_plug") is False
@@ -129,6 +131,7 @@ class TestEaseeDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state("ready_to_charge")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_plug") is True
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_charging") is False
 
@@ -137,6 +140,7 @@ class TestEaseeDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state("charging")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_plug") is True
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_charging") is True
 
@@ -145,6 +149,7 @@ class TestEaseeDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state("disconnected")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_plug") is False
         assert reader._read_binary_sensor("sensor.easee_home_status", "ev_charging") is False
 
@@ -153,6 +158,7 @@ class TestEaseeDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(3.5, unit="kW")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.easee_home_power", "ev") == 3500.0
 
 
@@ -183,6 +189,7 @@ class TestWallboxDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(7.4, unit="kW")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.wallbox_pulsar_plus_charging_power", "ev") == 7400.0
 
 
@@ -213,6 +220,7 @@ class TestGoEChargerMQTTDiscovery:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(4800, unit="W")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.go_echarger_123456_nrg_current_power", "ev") == 4800.0
 
 
@@ -318,6 +326,7 @@ class TestInverterSignConventions:
         """Create a SensorReader with mock Energy Dashboard config."""
         config = {"battery_power_sensor": "sensor.battery_power"}
         reader = SensorReader(mock_hass, config)
+        reader._sign_vote_warmup = 0
 
         ed = MagicMock()
         ed.solar_power = "sensor.solar_power"
@@ -584,6 +593,7 @@ class TestPowerUnitConversion:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(5.2, unit="kW")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.growatt_mix_wattage_pv_all", "solar") == 5200.0
 
     def test_powerwall_meter_kw(self):
@@ -591,6 +601,7 @@ class TestPowerUnitConversion:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(2.5, unit="kW")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.powerwall_solar_instant_power", "solar") == 2500.0
 
     def test_sma_daily_yield_wh(self):
@@ -598,6 +609,7 @@ class TestPowerUnitConversion:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(3500, unit="W")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.sma_pv_power", "solar") == 3500.0
 
     def test_solaredge_power_watts(self):
@@ -605,6 +617,7 @@ class TestPowerUnitConversion:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(8000, unit="W")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.solaredge_ac_power", "solar") == 8000.0
 
     def test_sonnen_power_watts(self):
@@ -612,6 +625,7 @@ class TestPowerUnitConversion:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(4500, unit="W")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         assert reader._read_sensor("sensor.sonnenbatterie_state_production", "solar") == 4500.0
 
 
@@ -632,6 +646,7 @@ class TestMonitoringOnlyChargers:
             "sensor.tesla_wall_connector_session_energy_wh": _state(12500, unit="Wh"),
         }.get(eid)
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         # No power sensor → returns 0
         assert reader._read_sensor("sensor.tesla_wall_connector_power", "ev") == 0.0
 
@@ -640,5 +655,6 @@ class TestMonitoringOnlyChargers:
         hass = MagicMock()
         hass.states.get = lambda eid: _state(3200, unit="W")
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         # Can read power (monitoring works)
         assert reader._read_sensor("sensor.myenergi_zappi_ct1_power", "ev") == 3200.0

--- a/tests/test_multi_device_aggregation.py
+++ b/tests/test_multi_device_aggregation.py
@@ -26,6 +26,7 @@ def _make_state(value, unit="W"):
 def _make_reader(mock_hass, config=None):
     """Create a SensorReader with mocked hass."""
     reader = SensorReader(mock_hass, config or {})
+    reader._sign_vote_warmup = 0
     return reader
 
 

--- a/tests/test_per_battery_sensors_phase_a.py
+++ b/tests/test_per_battery_sensors_phase_a.py
@@ -129,6 +129,7 @@ class TestSensorReaderSlugAssignment:
         ed.has_ev = False
 
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(ed)
 
         # Make the sensor reads return deterministic watts so the test
@@ -188,6 +189,7 @@ class TestSensorReaderSlugAssignment:
             if eid == "sensor.huawei_b1_power" else None
         )
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         reader.set_energy_dashboard_config(ed)
         readings = reader.read_power()
         # Fleet field populated; per-battery dict stays empty.

--- a/tests/test_per_charger_entities.py
+++ b/tests/test_per_charger_entities.py
@@ -382,6 +382,7 @@ class TestPerChargerAggregation:
         }
 
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         # Mock sensor states
         def mock_get(entity_id):
@@ -422,6 +423,7 @@ class TestPerChargerAggregation:
             "ev_chargers": three_chargers,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         def mock_get(entity_id):
             states = {
@@ -459,6 +461,7 @@ class TestPerChargerAggregation:
             "ev_chargers": four_chargers,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         def mock_get(entity_id):
             powers = {"sensor.c1_power": "1500", "sensor.c2_power": "2500",
@@ -532,6 +535,7 @@ class TestPerChargerAggregation:
             "ev_chargers": chargers,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         # Only charger 2 connected, charger 1 disconnected
         def mock_get(entity_id):
@@ -574,6 +578,7 @@ class TestPerChargerAggregation:
             "ev_chargers": chargers,
         }
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         def mock_get(entity_id):
             states = {
@@ -631,6 +636,7 @@ class TestPerChargerAggregation:
         }
 
         reader = SensorReader(hass, config)
+        reader._sign_vote_warmup = 0
 
         def mock_get(entity_id):
             states = {

--- a/tests/test_repair_issues.py
+++ b/tests/test_repair_issues.py
@@ -106,6 +106,7 @@ def test_sensor_reader_transient_flap_does_not_raise(mock_ri_module):
     states = {"sensor.foo": None}  # missing → counts as unavailable
     hass = _hass_with(states)
     reader = SensorReader(hass, {})
+    reader._sign_vote_warmup = 0
     # First call — sensor goes unavailable. No Repair on first miss.
     val = reader._read_sensor("sensor.foo", "test")
     assert val == 0.0
@@ -128,6 +129,7 @@ def test_sensor_reader_raises_after_threshold(mock_ri_module):
     states = {"sensor.foo": _state("unavailable", friendly="Foo Sensor")}
     hass = _hass_with(states)
     reader = SensorReader(hass, {})
+    reader._sign_vote_warmup = 0
 
     # First read → stamps the outage start.
     with patch("time.monotonic", return_value=1000.0):
@@ -159,6 +161,7 @@ def test_sensor_reader_clears_repair_on_recovery(mock_ri_module):
     states = {"sensor.foo": _state("unavailable")}
     hass = _hass_with(states)
     reader = SensorReader(hass, {})
+    reader._sign_vote_warmup = 0
 
     with patch("time.monotonic", return_value=1000.0):
         reader._read_sensor("sensor.foo", "test")

--- a/tests/test_split_grid_integration.py
+++ b/tests/test_split_grid_integration.py
@@ -87,7 +87,9 @@ def _make_reader_with_states(mock_hass, states_dict, ed_config, extra_config=Non
         config.update(extra_config)
 
     reader = SensorReader(mock_hass, config)
+    reader._sign_vote_warmup = 0
     reader._energy_dashboard_config = ed_config
+    reader._sign_vote_warmup = 0  # unit tests exercise post-warmup voting (#487)
     return reader
 
 
@@ -1224,6 +1226,7 @@ class TestChargerControlPipeline:
         """Charger reporting power in W should not be converted."""
         hass = MagicMock()
         reader = SensorReader(hass, {"update_interval": 10})
+        reader._sign_vote_warmup = 0
 
         w_state = _state(4500, unit="W", device_class="power")
         hass.states.get = lambda eid: w_state
@@ -2178,6 +2181,7 @@ class TestSplitGridScanThrottle:
         }
         hass.states.get = lambda eid: states.get(eid)
         reader = SensorReader(hass, {"update_interval": 10})
+        reader._sign_vote_warmup = 0
         reader._split_grid_discovery.update(
             {"import": imp, "export": exp, "confidence": "any-device"},
         )

--- a/tests/test_v14_integration.py
+++ b/tests/test_v14_integration.py
@@ -365,6 +365,7 @@ class TestMultiInverterSumming:
             "sensor.growatt_2_power": 2000,
         })
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         total = reader._read_sensors_sum(
             ["sensor.growatt_1_power", "sensor.growatt_2_power"], "solar"
         )
@@ -379,6 +380,7 @@ class TestMultiInverterSumming:
             "sensor.bat_3_power": -200,  # One discharging
         })
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         total = reader._read_sensors_sum(
             ["sensor.bat_1_power", "sensor.bat_2_power", "sensor.bat_3_power"], "battery"
         )
@@ -392,6 +394,7 @@ class TestMultiInverterSumming:
             # sensor.inv_2_power not in states (unavailable)
         })
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         total = reader._read_sensors_sum(
             ["sensor.inv_1_power", "sensor.inv_2_power"], "solar"
         )
@@ -402,6 +405,7 @@ class TestMultiInverterSumming:
         from custom_components.solar_energy_management.coordinator.sensor_reader import SensorReader
         hass = self._make_hass({"sensor.inverter_power": 4500})
         reader = SensorReader(hass, {})
+        reader._sign_vote_warmup = 0
         total = reader._read_sensors_sum(
             ["sensor.inverter_power"], "solar"
         )


### PR DESCRIPTION
## Summary

RienduPre's #487 log + the live 2026-06-11 PROD grid-sign flip, fixed together:

- **Entity-range-bounded current writes** — HA core validates number writes against the entity's own min/max BEFORE anything reaches the charger: 0 A stops were structurally impossible (Wallbox min=6) and >entity-max ramps bounced (Links: 6–16 A vs SEM commanding 32). 167× `out_of_range` per charger in the log; this is the real "keeps charging in off mode" mechanism behind #475/#462's hardware half.
- **0 A stop intents skip the doomed write** — the stop goes through the adapter's pause-switch / stop_session path.
- **`ev_start_stop_entity` honored** as the Wallbox pause switch — the adapter's own WARNING recommended exactly that workaround but never read the field.
- **Sign-vote startup warm-up (12 cycles)** — a PROD restart locked `grid_sign_inverted=True` on a Huawei install (needs NO correction) from 3 votes cast while the recorder replayed counter states; remediated live via reload, prevented structurally here. Lock log now names the voting counter entities.
- **Health-check WARNING rate limit** — 6 consecutive violating cycles, then debug until clear (413 identical lines flooded the log + diagnose ring buffer).
- CHANGELOG beta.9 sections for #487/#488.

## Verification

- Full suite green: 3505 passed / 0 failed (includes 14 new tests: entity bounds, configured stop switch, warmup, rate limit)
- PROD's flipped grid sign already remediated live (reload) and verified against the raw meter

Fixes #487
Refs #475 #461 #476