### PR TITLE
fix(tariff): parse Tibber Grid Reward today_raw/tomorrow_raw price arrays (#491)

### DIFF
--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -641,6 +641,15 @@ class DynamicTariffProvider(TariffProvider):
           ``prices`` array with ``time`` + ``price``.
         * **Amber Electric** / **Octopus Energy**: ``forecasts`` /
           ``rates`` with ``start_time`` + ``per_kwh``.
+        * **Tibber Grid Reward** (HACS, #491 — covers Tibber Pulse
+          accounts where the core integration provisions no
+          ``electricity_price`` forecast sensor, upstream
+          core#153312): ``today_raw`` / ``tomorrow_raw`` with
+          ``time`` + ``price`` (its ``today`` / ``tomorrow`` are
+          comma-joined *strings*, skipped by the list guard). The
+          entity id (``sensor.current_price``) is too generic to
+          auto-detect — users configure it via
+          ``dynamic_tariff_entity``.
 
         v1.7.2-beta.3 (2026-06-07): also tries ``prices`` (singular)
         + ``time`` / ``hour`` timestamp keys after seeing them in
@@ -691,8 +700,11 @@ class DynamicTariffProvider(TariffProvider):
         prices = []
         attrs = state.attributes if state else {}
 
-        # Tibber + NL EnergyZero/EasyEnergy + generic
-        for key in ("prices_today", "prices_tomorrow", "today", "tomorrow", "prices"):
+        # Tibber + NL EnergyZero/EasyEnergy + Tibber Grid Reward + generic
+        for key in (
+            "prices_today", "prices_tomorrow", "today", "tomorrow",
+            "prices", "today_raw", "tomorrow_raw",
+        ):
             price_list = attrs.get(key, [])
             if isinstance(price_list, list):
                 for item in price_list:
@@ -861,7 +873,8 @@ class DynamicTariffProvider(TariffProvider):
             _LOGGER.warning(
                 "Tariff entity %s has a readable state but exposes no "
                 "recognised price-array attribute (prices_today / today / "
-                "tomorrow / prices / raw_today / forecasts / rates). "
+                "tomorrow / prices / today_raw / raw_today / forecasts / "
+                "rates). "
                 "Percentile classification and cheap-window planning are "
                 "degraded (#359). If this is a derivative/template sensor, "
                 "pass the provider's array through (attributes: "

--- a/tests/test_tariff_provider.py
+++ b/tests/test_tariff_provider.py
@@ -1274,6 +1274,94 @@ class TestExpandedParserShapes:
             assert provider._last_parsed_count == 0
             assert provider._last_parsed_gap_seconds is None
 
+    def test_tibber_grid_reward_today_raw_shape(self, mock_hass):
+        """Tibber Grid Reward (HACS) shape, #491 (RienduPre, Growatt NL).
+
+        Tibber Pulse accounts where core Tibber provisions no
+        ``electricity_price`` forecast sensor (core#153312) get their
+        only price arrays from the Grid Reward integration's
+        ``sensor.current_price``:
+
+        * ``today_raw`` / ``tomorrow_raw``: ``[{"time": iso,
+          "price": total, "rating": ...}, ...]``
+        * ``today`` / ``tomorrow``: comma-joined *strings* of the same
+          totals — must be skipped by the list guard, NOT parsed and
+          NOT double-counted against the raw arrays.
+
+        Users point ``dynamic_tariff_entity`` at the sensor (the
+        entity id is too generic to auto-detect).
+        """
+        now = datetime(2026, 6, 11, 0, 0, 0)
+        today_raw = []
+        for h in range(24):
+            ts = now + timedelta(hours=h)
+            today_raw.append({
+                "time": ts.isoformat(),
+                "price": 0.18 + 0.01 * h,
+                "rating": "NORMAL",
+            })
+        tomorrow_raw = []
+        for h in range(24):
+            ts = now + timedelta(hours=24 + h)
+            tomorrow_raw.append({
+                "time": ts.isoformat(),
+                "price": 0.15 + 0.01 * h,
+                "rating": "NORMAL",
+            })
+
+        state = _make_price_state(0.18, attributes={
+            "today": ", ".join(str(p["price"]) for p in today_raw),
+            "today_raw": today_raw,
+            "tomorrow": ", ".join(str(p["price"]) for p in tomorrow_raw),
+            "tomorrow_raw": tomorrow_raw,
+        })
+        mock_hass.states.get = MagicMock(return_value=state)
+
+        with patch(DT_UTIL_PATH) as mock_dt:
+            mock_dt.now.return_value = now
+            provider = DynamicTariffProvider(
+                mock_hass, price_entity="sensor.current_price"
+            )
+            parsed = provider._read_prices_list()
+
+        # 24 today + 24 tomorrow, no double-counting from the
+        # comma-joined string attributes
+        assert len(parsed) == 48
+        assert provider._last_parsed_count == 48
+        assert provider._last_parsed_attribute == "today_raw"
+        assert provider._last_parsed_gap_seconds == 3600.0
+        assert parsed[0].price == 0.18
+        assert parsed[-1].price == pytest.approx(0.15 + 0.01 * 23)
+
+    def test_tibber_grid_reward_no_tomorrow_yet(self, mock_hass):
+        """Before ~13:00 Tibber publishes no tomorrow prices — Grid
+        Reward emits ``tomorrow: None`` + ``tomorrow_raw: []``. The
+        parser must still return today's 24 points."""
+        now = datetime(2026, 6, 11, 8, 0, 0)
+        midnight = now.replace(hour=0)
+        today_raw = [
+            {"time": (midnight + timedelta(hours=h)).isoformat(),
+             "price": 0.20, "rating": "NORMAL"}
+            for h in range(24)
+        ]
+        state = _make_price_state(0.20, attributes={
+            "today": ", ".join("0.2" for _ in range(24)),
+            "today_raw": today_raw,
+            "tomorrow": None,
+            "tomorrow_raw": [],
+        })
+        mock_hass.states.get = MagicMock(return_value=state)
+
+        with patch(DT_UTIL_PATH) as mock_dt:
+            mock_dt.now.return_value = now
+            provider = DynamicTariffProvider(
+                mock_hass, price_entity="sensor.current_price"
+            )
+            parsed = provider._read_prices_list()
+
+        assert len(parsed) == 24
+        assert provider._last_parsed_attribute == "today_raw"
+
 
 class TestScheduleAfter15MinParse:
     """The chart's schedule must collapse 96 15-min points into


### PR DESCRIPTION
## Summary

Tibber Pulse accounts where core Tibber provisions no `electricity_price` forecast sensor (upstream core#153312) get their only price curve from the HACS [tibber_grid_reward](https://github.com/JohNan/homeassistant-tibber_grid_rewards) integration's `sensor.current_price`. Verified against that integration's source:

- `today_raw` / `tomorrow_raw`: `[{"time": iso, "price": total, "rating": ...}]` — the `time` + `price` item keys were **already** in the parser vocabulary (v1.7.2-beta.3); only the two attribute names were missing
- `today` / `tomorrow`: comma-joined **strings** of the same totals — skipped by the existing `isinstance(list)` guard, so no double-counting

The entity id (`sensor.current_price`) is too generic to auto-detect; the supported path is the existing `dynamic_tariff_entity` option (provider `custom`).

## Changes
- `today_raw` / `tomorrow_raw` added to the generic price-array key tuple in `_read_prices_list` + docstring + the #359 no-array diagnostic message
- 2 shape tests: full today+tomorrow (48 points, no double-count, attribute + interval diag pinned) and the pre-13:00 no-tomorrow case

## Testing
- Full suite: 3507 passed, 8 skipped
- **Live on HA-TEST** (beta.9 + this fix): injected a grid-reward-shaped sensor, set `dynamic_tariff_entity` → diagnose surface reports `tariff_parsed_attribute: today_raw`, `tariff_parsed_count: 48`, `tariff_parsed_interval_seconds: 3600`, `tariff_today_prices_count: 24`, provider `custom`

Refs #491