### PR TITLE
fix(scheduler): int-coerce trigger_hour/minute — options-flow floats crashed every evaluation (#493)

### DIFF
--- a/coordinator/battery_charge_scheduler.py
+++ b/coordinator/battery_charge_scheduler.py
@@ -225,13 +225,15 @@ class SchedulerConfig:
             battery_max_charge_power_w=config.get("battery_max_charge_power_w", 5000.0),
             roundtrip_efficiency=config.get("battery_roundtrip_efficiency", 0.92),
             battery_cycle_cost=config.get("battery_cycle_cost", 0.0),
-            # int() coercion is load-bearing (#493): the options-flow
-            # NumberSelector stores floats (21.0) and
+            # int(float()) coercion is load-bearing (#493): the
+            # options-flow NumberSelector stores floats (21.0) and
             # datetime.replace(hour=21.0) raises TypeError — killing the
             # scheduler evaluation on every cycle for any user who ever
-            # saved the battery-scheduler options page.
-            trigger_hour=int(config.get("battery_precharge_trigger_hour", 21)),
-            trigger_minute=int(config.get("battery_precharge_trigger_minute", 0)),
+            # saved the battery-scheduler options page. The float() hop
+            # also survives string-shaped storage ("21.0"), which a bare
+            # int() would re-crash on with ValueError.
+            trigger_hour=int(float(config.get("battery_precharge_trigger_hour", 21))),
+            trigger_minute=int(float(config.get("battery_precharge_trigger_minute", 0))),
             replan_interval_min=max(5, int(config.get("battery_replan_interval_min", 30))),
             planning_window_hours=max(1, min(24, int(config.get("battery_planning_window_hours", 9)))),
             prefer_consecutive_window=config.get("battery_prefer_consecutive_window", True),

--- a/coordinator/battery_charge_scheduler.py
+++ b/coordinator/battery_charge_scheduler.py
@@ -225,8 +225,13 @@ class SchedulerConfig:
             battery_max_charge_power_w=config.get("battery_max_charge_power_w", 5000.0),
             roundtrip_efficiency=config.get("battery_roundtrip_efficiency", 0.92),
             battery_cycle_cost=config.get("battery_cycle_cost", 0.0),
-            trigger_hour=config.get("battery_precharge_trigger_hour", 21),
-            trigger_minute=config.get("battery_precharge_trigger_minute", 0),
+            # int() coercion is load-bearing (#493): the options-flow
+            # NumberSelector stores floats (21.0) and
+            # datetime.replace(hour=21.0) raises TypeError — killing the
+            # scheduler evaluation on every cycle for any user who ever
+            # saved the battery-scheduler options page.
+            trigger_hour=int(config.get("battery_precharge_trigger_hour", 21)),
+            trigger_minute=int(config.get("battery_precharge_trigger_minute", 0)),
             replan_interval_min=max(5, int(config.get("battery_replan_interval_min", 30))),
             planning_window_hours=max(1, min(24, int(config.get("battery_planning_window_hours", 9)))),
             prefer_consecutive_window=config.get("battery_prefer_consecutive_window", True),

--- a/tests/test_battery_charge_scheduler.py
+++ b/tests/test_battery_charge_scheduler.py
@@ -832,6 +832,38 @@ class TestSchedulerConfig:
         assert config.peak_limit_w == 9000.0
         assert config.ev_priority is False
 
+    def test_from_config_float_trigger_hour_from_options_flow(self, mock_hass):
+        """#493: the options-flow NumberSelector stores floats (21.0).
+
+        ``datetime.replace(hour=21.0)`` raises ``TypeError: 'float'
+        object cannot be interpreted as an integer`` — on PROD
+        (RienduPre, #487 comment, v1.7.3-beta.9) this killed the
+        scheduler evaluation on every coordinator cycle for any user
+        who ever saved the battery-scheduler options page. Defaults
+        stay int, which is why soaks on untouched configs missed it.
+
+        Exercise the exact crashing path: float-shaped config →
+        ``should_trigger_evaluation`` → ``_in_planning_window`` →
+        ``_window_start`` → ``now.replace(hour=...)``.
+        """
+        config = SchedulerConfig.from_config({
+            "battery_charge_scheduler_enabled": True,
+            "battery_precharge_trigger_hour": 21.0,
+            "battery_precharge_trigger_minute": 0.0,
+        })
+        assert config.trigger_hour == 21
+        assert isinstance(config.trigger_hour, int)
+        assert isinstance(config.trigger_minute, int)
+
+        adapter = MagicMock(spec=BatteryChargeAdapter)
+        scheduler = BatteryChargeScheduler(mock_hass, adapter, config)
+        # Must not raise — and inside the window it must trigger, so
+        # the call demonstrably reached the production logic.
+        in_window = dt_util.now().replace(hour=21, minute=5, second=0)
+        assert scheduler.should_trigger_evaluation(in_window) is True
+        outside = dt_util.now().replace(hour=12, minute=0, second=0)
+        assert scheduler.should_trigger_evaluation(outside) is False
+
 
 # ---------------------------------------------------------------------------
 # Integration-style Tests

--- a/tests/test_battery_charge_scheduler.py
+++ b/tests/test_battery_charge_scheduler.py
@@ -855,6 +855,16 @@ class TestSchedulerConfig:
         assert isinstance(config.trigger_hour, int)
         assert isinstance(config.trigger_minute, int)
 
+        # String-shaped storage ("21.0") must coerce too — a bare int()
+        # would swap the TypeError for a ValueError (review finding on
+        # PR #496).
+        config_str = SchedulerConfig.from_config({
+            "battery_precharge_trigger_hour": "21.0",
+            "battery_precharge_trigger_minute": "30",
+        })
+        assert config_str.trigger_hour == 21
+        assert config_str.trigger_minute == 30
+
         adapter = MagicMock(spec=BatteryChargeAdapter)
         scheduler = BatteryChargeScheduler(mock_hass, adapter, config)
         # Must not raise — and inside the window it must trigger, so


### PR DESCRIPTION
## Summary

PROD report (@RienduPre on #487, v1.7.3-beta.9): `Battery scheduler evaluate failed: 'float' object cannot be interpreted as an integer` — 32 occurrences in 5 minutes; the scheduler evaluation died on **every** coordinator cycle.

Root cause: `battery_precharge_trigger_hour` comes from an options-flow `NumberSelector` slider, and HA NumberSelectors always store **floats** (`21.0`). `SchedulerConfig.from_config` passed it through unconverted and `datetime.replace(hour=21.0)` raises. Anyone who ever saved the battery-scheduler options page is affected; untouched configs keep the int default — which is why TEST/PROD soaks missed it.

`replan_interval_min` / `planning_window_hours` already had the `int()` wrap; `trigger_hour` / `trigger_minute` were missed. Class audit: all other `.replace(hour=...)` sites parse via `int()` or iterate `range(24)`; `StaticTariffProvider.peak_start/peak_end` are never config-fed — this was the only instance.

## Changes
- `int()` coercion for `trigger_hour` / `trigger_minute` in `SchedulerConfig.from_config`
- Regression test exercising the exact crashing path (`should_trigger_evaluation` → `_window_start` → `now.replace`) with float-shaped options, asserting it both runs and still triggers correctly in/out of the window

## Testing
- Scheduler test files: 164 passed
- **Live on HA-TEST**: stored `battery_precharge_trigger_hour: 21.0` (float) + scheduler enabled in the config entry, restarted — scheduler pipeline runs every cycle (`battery_scheduler_state: idle` populated), **zero** `TypeError`/`evaluate failed` log lines, where beta.9 logged the crash 6×/minute

Refs #493