### PR TITLE
fix(ev): #501 min_plus_solar daytime self-consumption-maximizing — need-gated floor + shared capped assist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## ☀️ `min_plus_solar` daytime is self-consumption-maximizing again (#501)
+
+Daytime `min_plus_solar` in battery Zone 3/4 was draining the home battery into the EV and importing from the grid when it should maximize self-consumption — a cloudy afternoon at 70–90% SOC got ground into the car.
+
+- **The daytime min-current floor is now need-gated** — it engages only when the remaining daily Min can no longer be delivered by tonight's charging window (new per-charger `night_deliverable_kwh`). Otherwise daytime is pure surplus + capped battery assist, and idles below the charger minimum. Restores the documented "Min comes from the night top-up, not a forced grid pull at noon" promise; `always_max` stays the "just charge" escape hatch (#501)
+- **One shared, capped battery-assist formula** — `decide` and `flow_calculator` had diverged (ADR 0002 regression); both now use the same SOC-based *potential* (capped by `battery_assist_max_power`, zeroed below the assist-floor SOC, bounded to the surplus→min gap). No more measured-discharge branch, so a home-load spike can't ratchet the EV current upward, and #439's chicken-and-egg stays structurally fixed (#501)
+- Amends ADR 0010 pattern 1; `EV_CHARGING_LOGIC.md` mode table corrected
+
 # [1.7.3-beta.12] - 12.06.2026
 
 ## 🎨 Plan-strip legend always-visible + tariff colours (#464 follow-up)

--- a/coordinator/build_view.py
+++ b/coordinator/build_view.py
@@ -36,6 +36,7 @@ def build_charger_view(
     deadline_amps: int = 0,
     tariff_wait: bool = False,
     solar_committed_w: float = 0.0,
+    night_deliverable_kwh: float = float("inf"),
 ) -> ChargerView:
     """Construct a ChargerView from a per-cycle FleetCycleState +
     per-charger overrides.
@@ -128,8 +129,12 @@ def build_charger_view(
         auto_start_soc=float(config.get("battery_auto_start_soc", 90)),
         buffer_soc=float(config.get("battery_buffer_soc", 70)),
         priority_soc=float(config.get("battery_priority_soc", 30)),
-        battery_floor_soc=float(config.get("battery_assist_floor_soc", 60)),
+        battery_assist_floor_soc=float(config.get("battery_assist_floor_soc", 60)),
         battery_capacity_kwh=float(config.get("battery_capacity_kwh", 15)),
+        battery_assist_max_power_w=float(config.get(
+            "battery_assist_max_power",
+            config.get("super_charger_power", 4500),
+        )),
         solar_committed_w=float(solar_committed_w),
         forecast_remaining_kwh=fleet_state.forecast_remaining_kwh,
     )
@@ -149,4 +154,5 @@ def build_charger_view(
         target_kwh=target_kwh,
         target_soc=target_soc,
         deadline_amps=deadline_amps,
+        night_deliverable_kwh=night_deliverable_kwh,
     )

--- a/coordinator/charger_types.py
+++ b/coordinator/charger_types.py
@@ -505,8 +505,17 @@ class FleetContext:
     auto_start_soc: float = 90.0
     buffer_soc: float = 70.0
     priority_soc: float = 30.0
-    battery_floor_soc: float = 60.0
+    battery_assist_floor_soc: float = 60.0
     battery_capacity_kwh: float = 15.0
+
+    battery_assist_max_power_w: float = 4500.0
+    """User-configured discharge cap when the battery assists the EV
+    (``battery_assist_max_power``). #501: the Zone 3/4 day budget in
+    ``decide.battery_assist_budget_w`` is capped by this — pre-#501 it
+    added the battery's TOTAL measured discharge (including the share
+    serving the house), which both ignored this cap and created a
+    positive-feedback ratchet (home-load spike → more discharge →
+    bigger EV budget → higher commanded amps → more discharge)."""
 
     min_solar_w: float = 200.0
     """Solar below this is treated as "no meaningful solar" — the
@@ -613,6 +622,16 @@ class ChargerView:
     deadline_amps: int = 0
     """The peak-aware required current to reach Min by the per-
     charger ``ev_target_time`` (#246). ``0`` when no deadline."""
+
+    night_deliverable_kwh: float = float("inf")
+    """How much energy tonight's window (night start → this charger's
+    deadline) can deliver at the charger's max current (#501). The
+    daytime ``min_plus_solar`` floor only engages when
+    ``target_kwh > night_deliverable_kwh`` — i.e. when waiting for the
+    night top-up would genuinely risk the Min-by-deadline guarantee.
+    Default ``inf`` (floor never engages) so call sites that don't
+    compute it get the self-consumption-maximizing behaviour rather
+    than silent grid pull."""
 
 
 # ─────────────────────────────────────────────────────────────────

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1718,6 +1718,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                             deadline_amps=int(charging_context.night_deadline_amps or 0),
                             tariff_wait=bool(charging_context.night_tariff_wait),
                             solar_committed_w=self._solar_committed_w_per_cycle,
+                            night_deliverable_kwh=self._night_deliverable_kwh(charger_cfg),
                         )
                         decision = decide_v2(view)
                         # evcc-style stability layer (#461 flapping):
@@ -1850,6 +1851,9 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                     target_kwh=getattr(charging_context, "night_target_kwh", None),
                     deadline_amps=int(getattr(charging_context, "night_deadline_amps", 0) or 0),
                     tariff_wait=bool(getattr(charging_context, "night_tariff_wait", False)),
+                    night_deliverable_kwh=self._night_deliverable_kwh(
+                        self._primary_charger_cfg()
+                    ),
                 )
                 decision = decide_v2(view)
                 # evcc-style stability layer (#461 flapping) — the
@@ -3901,6 +3905,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
             # multi-charger loop downstream gets.
             tariff_wait=tariff_wait,
             deadline_amps=deadline_amps,
+            night_deliverable_kwh=self._night_deliverable_kwh(_primary_cfg),
         )
         _primary_decision = _decide(_primary_view)
         strategy = _primary_decision.intent.value
@@ -3941,6 +3946,13 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         override_max_w = None
         if canonical_strategy == EVBudgetStrategy.MIN_PV:
             # 6 A * 3 phases * 230 V — KEBA / Wallbox EU minimum.
+            min_power_floor_w = self.config.get(
+                "ev_min_current", 6,
+            ) * 3 * 230
+        elif canonical_strategy == EVBudgetStrategy.BATTERY_ASSIST:
+            # #501: BATTERY_ASSIST consumes the floor as the assist
+            # top-up bound (assist fills surplus→min gap only), NOT
+            # as a net_w floor — see the strategy branch.
             min_power_floor_w = self.config.get(
                 "ev_min_current", 6,
             ) * 3 * 230

--- a/coordinator/decide.py
+++ b/coordinator/decide.py
@@ -93,34 +93,54 @@ def self_consumption_surplus_w(view: ChargerView) -> float:
 def battery_assist_budget_w(view: ChargerView) -> float:
     """Budget for Zone 3/4 battery-assist charging.
 
-    In ``min_plus_solar`` / ``solar_plus_cheap`` / ``always_max``
-    modes (NOT solar_only / off), when the home battery is
-    high enough (Zone 3 or 4), it can discharge to bridge the gap
-    between solar surplus and EV demand. The budget here is:
+    Called exclusively from ``MinPlusSolarMode._decide_day()`` (the
+    Zone 3/4 path) — ``solar_plus_cheap`` delegates its day path to
+    ``solar_only`` and ``always_max`` ignores any budget. When the
+    home battery is high enough (Zone 3 or 4), it can discharge to
+    bridge the gap between solar surplus and EV demand.
 
-      Zone 4 (SOC ≥ auto_start_soc): solar - home + usable_battery
-        usable_battery = (SOC - floor_soc) / 100 × capacity, scaled
-        per-cycle so we don't drain in one cycle. Bound by
-        battery_discharge_w (the physical max the battery is
-        currently providing).
+    #501: the assist component is the shared SOC-based POTENTIAL
+    (``flow_calculator.battery_assist_potential_w``) — capped by the
+    user's ``battery_assist_max_power``, zeroed below the assist
+    floor SOC, and bounded to the GAP between surplus and the
+    charger minimum. Assist exists to make the min current
+    *reachable* when surplus falls just short (scenario-matrix row 4:
+    "battery assists, tops up to EV minimum") — never to boost past
+    surplus, which would cycle the battery for no self-consumption
+    gain.
 
-      Zone 3 (buffer_soc ≤ SOC < auto_start_soc): same formula but
-        only when forecast shows tomorrow has plenty of sun (legacy
-        ``_zone_based_strategy`` line 2742-2750 — forecast check
-        deferred to Step 5 here; for now we treat Zone 3 same as
-        Zone 4).
+    The pre-#501 formula added ``f.battery_discharge_w`` (the
+    battery's TOTAL measured discharge, house share included), which
+    ignored the config caps and ratcheted the commanded current
+    upward on every home-load spike: more home draw → more discharge
+    → bigger "EV budget" → higher amps → more discharge. Using
+    potential instead of measurement also preserves the #439 fix —
+    no chicken-and-egg gate on currently-flowing discharge.
 
       Zone 1/2: no battery assist. Return surplus only.
     """
+    from .flow_calculator import battery_assist_potential_w
+
     f = view.fleet
     surplus = self_consumption_surplus_w(view)
     zone = soc_zone(f.battery_soc, f.auto_start_soc, f.buffer_soc, f.priority_soc)
     if zone < 3:
         return surplus
-    # Zone 3 or 4: add the battery's actual current discharge to
-    # the EV budget. (Don't speculate on future discharge; use what
-    # the inverter is reporting right now.)
-    return surplus + f.battery_discharge_w
+    potential = battery_assist_potential_w(
+        f.battery_soc,
+        f.battery_assist_floor_soc,
+        f.buffer_soc,
+        f.auto_start_soc,
+        f.battery_assist_max_power_w,
+    )
+    cfg = view.config if isinstance(view.config, dict) else {}
+    min_power_w = (
+        effective_min_amps(cfg, 6)
+        * int(cfg.get("ev_phases", 3))
+        * int(cfg.get("ev_voltage", 230))
+    )
+    gap_w = max(0.0, min_power_w - surplus)
+    return surplus + min(potential, gap_w)
 
 
 def _relabel(decision: ChargerDecision, mode: str, prefix: str) -> ChargerDecision:
@@ -457,14 +477,10 @@ class MinPlusSolarMode(ModeStrategy):
                 _SOLAR_ONLY.decide(view), "min_plus_solar",
                 f"min_plus_solar day Zone 2 (SOC={f.battery_soc:.0f}%)",
             )
-        # Zone 3 / 4: commit-then-measure (#439, ADR 0010). The mode
-        # name promises "guarantee min from grid + solar up to max",
-        # and in Zone 3/4 the home battery is available to supplement.
-        # Offer ``min_amps`` unconditionally — the inverter / grid will
-        # fill the gap next cycle. Do NOT gate on "is the battery
-        # currently discharging?" — that's the chicken-and-egg bug
-        # that idled this mode when battery sat at 0 W discharge
-        # because the EV hadn't been told to start drawing yet.
+        # Zone 3 / 4: surplus + capped SOC-based battery assist (#501).
+        # The budget uses the battery's POTENTIAL (never gated on
+        # currently-flowing discharge — that was the #439
+        # chicken-and-egg) capped at ``battery_assist_max_power``.
         budget_w = battery_assist_budget_w(view)
         cfg = view.config if isinstance(view.config, dict) else {}
         min_amps = effective_min_amps(cfg, 6)
@@ -472,15 +488,54 @@ class MinPlusSolarMode(ModeStrategy):
         phases = int(cfg.get("ev_phases", 3))
         voltage = int(cfg.get("ev_voltage", 230))
         surplus_amps = amps_from_watts(budget_w, phases, voltage)
-        amps = max(min_amps, min(max_amps, surplus_amps))
+
+        # Need-gated min floor (#501, amends ADR 0010 pattern 1).
+        # The mode's Min guarantee lives in the night top-up; the
+        # daytime floor (commit-then-measure, grid backfills) engages
+        # ONLY when tonight's window can no longer deliver the
+        # remaining Min at max current — i.e. when waiting genuinely
+        # risks the guarantee. Pre-#501 the floor was unconditional
+        # in Zone 3/4: a cloudy afternoon at 70-90% SOC ground the
+        # home battery into the EV with sustained grid backfill, and
+        # the floor even applied after Min was already met.
+        remaining = view.target_kwh
+        floor_needed = (
+            remaining is not None
+            and remaining > 0.1
+            and remaining > view.night_deliverable_kwh
+        )
+        if floor_needed:
+            amps = max(min_amps, min(max_amps, surplus_amps))
+            return ChargerDecision(
+                charger_id=cid, mode="min_plus_solar",
+                intent=ChargerIntent.CHARGE_AT_AMPS,
+                commanded_amps=amps, budget_w=budget_w,
+                reason=(
+                    f"min_plus_solar day Zone {zone}: Min floor engaged "
+                    f"({remaining:.1f} kWh remaining > "
+                    f"{view.night_deliverable_kwh:.1f} kWh night-deliverable) "
+                    f"→ {amps}A (budget={budget_w:.0f}W, floor={min_amps}A)"
+                ),
+            )
+        if surplus_amps >= min_amps:
+            amps = min(max_amps, surplus_amps)
+            return ChargerDecision(
+                charger_id=cid, mode="min_plus_solar",
+                intent=ChargerIntent.CHARGE_AT_AMPS,
+                commanded_amps=amps, budget_w=budget_w,
+                reason=(
+                    f"min_plus_solar day Zone {zone}: budget={budget_w:.0f}W "
+                    f"→ {amps}A (solar surplus + capped battery assist)"
+                ),
+            )
+        remaining_str = f"{remaining:.1f}" if remaining is not None else "?"
         return ChargerDecision(
             charger_id=cid, mode="min_plus_solar",
-            intent=ChargerIntent.CHARGE_AT_AMPS,
-            commanded_amps=amps, budget_w=budget_w,
+            intent=ChargerIntent.IDLE,
             reason=(
                 f"min_plus_solar day Zone {zone}: budget={budget_w:.0f}W "
-                f"→ {amps}A floor={min_amps}A (solar={f.solar_w:.0f}W "
-                f"+ battery_dis={f.battery_discharge_w:.0f}W)"
+                f"below {min_amps}A min — Min ({remaining_str} kWh) is "
+                f"covered by the night window, staying self-consumption-only"
             ),
         )
 

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -241,6 +241,43 @@ class EVControlMixin:
 
         return plan
 
+    def _night_deliverable_kwh(self, charger_cfg: dict) -> float:
+        """Energy tonight's window can deliver to this charger (#501).
+
+        Hours from the night-window start to the charger's ``Charge by``
+        deadline (clamped to the window) × max current. Feeds the
+        daytime ``min_plus_solar`` floor gate in ``decide.py`` — the
+        floor only engages when the remaining Min exceeds this, i.e.
+        when deferring to the night top-up would risk the guarantee.
+
+        Uses max current (the rate a forcing deadline can ramp to),
+        not the peak-managed rate: the night planner's own reachability
+        check + "can't reach Min in time" notification remain the
+        backstop for peak-constrained nights. Errs toward
+        self-consumption (``inf`` on any parse failure = floor stays
+        off), matching the mode's documented daytime behaviour.
+        """
+        try:
+            night_start, night_end = self.time_manager.get_night_window()
+            window_h = self.time_manager.get_night_window_hours()
+            cfg = charger_cfg if isinstance(charger_cfg, dict) else {}
+            deadline = str(cfg.get("ev_target_time") or night_end)
+            sh, sm = night_start.split(":")[:2]
+            dh, dm = deadline.split(":")[:2]
+            start_min = int(sh) * 60 + int(sm)
+            deadline_min = int(dh) * 60 + int(dm)
+            hours = ((deadline_min - start_min) % (24 * 60)) / 60.0
+            hours = min(hours, window_h)
+            max_a = float(
+                cfg.get("ev_max_current")
+                or self.config.get("ev_max_current", 16)
+            )
+            phases = int(cfg.get("ev_phases") or self.config.get("ev_phases", 3))
+            voltage = float(cfg.get("ev_voltage") or self.config.get("ev_voltage", 230))
+            return hours * max_a * phases * voltage / 1000.0
+        except (ValueError, TypeError, AttributeError):
+            return float("inf")
+
     def _expected_night_home_w(self, energy: Any, window_hours: float = 8.0) -> float:
         """Expected average home consumption (W) over the upcoming night window.
 

--- a/coordinator/flow_calculator.py
+++ b/coordinator/flow_calculator.py
@@ -195,6 +195,48 @@ def battery_redirect_w(
         return 0
 
 
+def battery_assist_potential_w(
+    battery_soc: float,
+    battery_assist_floor_soc: float,
+    battery_buffer_soc: float,
+    battery_auto_start_soc: float,
+    battery_assist_max_power_w: float,
+) -> float:
+    """SOC-based POTENTIAL battery-assist power for the EV (#501).
+
+    The one assist formula. Used by BOTH the strategy decision
+    (``decide.battery_assist_budget_w``) and the canonical budget
+    (``FlowCalculator._calculate_battery_assist_w``) so the two layers
+    cannot disagree (the #282 class).
+
+    Deliberately has NO measured-discharge input:
+
+    * Not gated on "is the battery currently discharging" — that was
+      the #439 chicken-and-egg (EV never starts because the battery
+      hasn't started covering a draw that doesn't exist yet).
+    * Not raised to the measured discharge either — total discharge
+      includes the share serving the HOUSE; attributing it to the EV
+      budget created a positive-feedback ratchet (home-load spike →
+      more discharge → bigger EV budget → higher amps) and silently
+      bypassed the user's ``battery_assist_max_power`` cap (#501).
+
+    Shape:
+      * SOC ≤ assist floor          → 0 (battery off-limits)
+      * SOC ≥ auto_start (Zone 4)   → full ``battery_assist_max_power_w``
+      * buffer ≤ SOC < auto_start   → ramp 0.5 → 1.0 × cap across the band
+      * SOC < buffer (Zone 1/2)     → 0
+    """
+    if battery_soc <= battery_assist_floor_soc:
+        return 0.0
+    if battery_soc >= battery_auto_start_soc:
+        return battery_assist_max_power_w
+    if battery_soc >= battery_buffer_soc:
+        band = max(1.0, battery_auto_start_soc - battery_buffer_soc)
+        ratio = (battery_soc - battery_buffer_soc) / band
+        return battery_assist_max_power_w * (0.5 + 0.5 * ratio)
+    return 0.0
+
+
 class FlowCalculator:
     """Calculates power and energy flows using proportional allocation."""
 
@@ -868,7 +910,14 @@ class FlowCalculator:
             )
 
         # ─── BATTERY_ASSIST ─────────────────────────────────────────
-        # Surplus + redirect + active battery discharge to EV.
+        # Surplus + redirect + battery assist. #501: the assist is the
+        # capped SOC-based POTENTIAL, bounded to the gap between
+        # surplus+redirect and the charger minimum (``min_power_floor_w``
+        # — callers pass it for this strategy too). Assist makes the
+        # min current REACHABLE when solar falls just short; it never
+        # boosts past surplus (that would cycle the battery for no
+        # self-consumption gain). With ``min_power_floor_w`` unset the
+        # full potential applies (legacy callers/tests).
         if strategy == EVBudgetStrategy.BATTERY_ASSIST:
             redirect = self._calculate_battery_redirect(
                 power.battery_charge_power, battery_soc,
@@ -879,6 +928,9 @@ class FlowCalculator:
                 battery_auto_start_soc, battery_buffer_soc,
                 battery_assist_floor_soc, battery_assist_max_power_w,
             )
+            if min_power_floor_w > 0:
+                gap_w = max(0.0, min_power_floor_w - (raw_surplus + redirect))
+                assist = min(assist, gap_w)
             net_w = raw_surplus + redirect + assist
             return EVBudget(
                 strategy=strategy,
@@ -937,33 +989,23 @@ class FlowCalculator:
         battery_assist_floor_soc: float,
         battery_assist_max_power_w: float,
     ) -> float:
-        """How much battery discharge to attribute to EV in battery_assist mode.
+        """How much battery power to attribute to EV in battery_assist mode.
 
-        Mirrors the legacy formula from `_calculate_solar_ev_budget` in
-        ev_control.py (the only place this lived before unification):
-
-        - SOC below assist floor: 0 (the battery shouldn't assist).
-        - Battery already discharging (>= 100 W): use measured value.
-        - Battery not yet discharging:
-            - Zone 4 (SOC >= auto_start_soc): full assist.
-            - Zone 3 (SOC >= buffer_soc):
-                proportional ramp 0.5 → 1.0 across the [buffer, auto_start]
-                band.
-            - Zone 2 (SOC < buffer_soc): 0 (shouldn't reach here — the
-                strategy decision should have chosen solar_only — but
-                guard anyway).
+        #501: delegates to the shared module-level
+        :func:`battery_assist_potential_w` — the SOC-based POTENTIAL,
+        capped by the user's ``battery_assist_max_power``. The legacy
+        ``measured discharge ≥ 100 W → return measured`` branch is
+        gone: it returned the battery's TOTAL discharge (including the
+        house's share) uncapped, which misattributed home consumption
+        to the EV budget and ratcheted the commanded current upward on
+        every home-load spike. ``power`` stays in the signature for
+        call-site compatibility (and future per-battery splits).
         """
-        if battery_soc <= battery_assist_floor_soc:
-            return 0.0
-
-        measured_discharge = max(0.0, power.battery_discharge_power)
-        if measured_discharge >= 100:
-            return measured_discharge
-
-        if battery_soc >= battery_auto_start_soc:
-            return battery_assist_max_power_w
-        if battery_soc >= battery_buffer_soc:
-            band = max(1.0, battery_auto_start_soc - battery_buffer_soc)
-            ratio = (battery_soc - battery_buffer_soc) / band
-            return battery_assist_max_power_w * (0.5 + 0.5 * ratio)
-        return 0.0
+        del power  # #501 — measured discharge intentionally unused
+        return battery_assist_potential_w(
+            battery_soc,
+            battery_assist_floor_soc,
+            battery_buffer_soc,
+            battery_auto_start_soc,
+            battery_assist_max_power_w,
+        )

--- a/docs/EV_CHARGING_LOGIC.md
+++ b/docs/EV_CHARGING_LOGIC.md
@@ -13,7 +13,7 @@
 > |---|---|---|
 > | **Solar only** | Pure surplus, never grid | Solar maximalist |
 > | **Solar + cheapest hours** | Surplus by day, grid only in the cheapest tariff windows (hidden if no dynamic tariff configured) | Dynamic-tariff users |
-> | **Min + Solar** (default) | Guarantee Min from grid/night top-up, solar adds up to Max. Zone-adaptive during the day — Min comes from night charging, not forced grid pull at noon. | Daily commuter needing a baseline |
+> | **Min + Solar** (default) | Guarantee Min from grid/night top-up, solar adds up to Max. Zone-adaptive during the day — Min comes from night charging, not forced grid pull at noon. Since #501 the daytime path is self-consumption-maximizing: solar surplus first, battery assist only up to the charger minimum and within your *Battery assist floor SoC* / *max power* limits, and grid only when the remaining Min could no longer be delivered by tonight's window. | Daily commuter needing a baseline |
 > | **Always (max)** | Charge at maximum regardless of source | "Just charge the car" / strict legacy-``minpv`` behaviour |
 > | **Off** | No charging | Disabled |
 >

--- a/docs/adr/0010-evcc-patterns-pilot-state-commit-then-measure.md
+++ b/docs/adr/0010-evcc-patterns-pilot-state-commit-then-measure.md
@@ -1,6 +1,18 @@
 # ADR 0010 — EV control trusts the EVSE pilot state machine and commits before measuring
 
 **Status:** Proposed (2026-06-05) · informs issues #438, #439, and a new per-vehicle min-current issue
+**Amended (2026-06-11, #501):** Pattern 1's *unconditional* commit
+overshot. In PROD it caused sustained (not one-cycle) grid import and
+battery drain on cloudy Zone-3/4 afternoons — including after the
+daily Min was already met. The commit-then-measure offer is now
+**need-gated**: it engages only when the remaining Min exceeds what
+tonight's window can deliver at max current
+(`ChargerView.night_deliverable_kwh`). The non-gating half of the
+pattern stands unchanged — the assist budget is never gated on
+currently-flowing discharge (the #439 chicken-and-egg); it is the
+capped SOC-based potential (`battery_assist_potential_w`), bounded to
+the surplus→min gap so assist makes the minimum *reachable* rather
+than boosting past surplus.
 
 ## Context
 

--- a/tests/scenarios/2026-06-02_min_plus_solar_zone3_day.yaml
+++ b/tests/scenarios/2026-06-02_min_plus_solar_zone3_day.yaml
@@ -3,21 +3,24 @@ name: "2026-06-02 min_plus_solar day Zone 3 — battery-assist enters"
 coverage:
   - mode: min_plus_solar
     regime: zone3_day_battery_assist
-    issue: "#282 Phase B/D — battery_assist regime"
+    issue: "#282 Phase B/D — battery_assist regime; #501 capped assist"
 
 description: |
   Zone 3 (SOC between buffer=70 and auto_start=90) + day mode is
   the BATTERY_ASSIST regime for min_plus_solar / solar_plus_cheap /
-  always_max. The budget is ``surplus + battery_discharge`` so the
-  battery can bridge the gap between modest surplus and EV demand.
+  always_max. Since #501 the budget is ``surplus + the capped
+  SOC-based assist POTENTIAL`` (ramp 0.5→1.0 × battery_assist_max
+  across the [buffer, auto_start] band) — NOT the battery's measured
+  total discharge, which included the house's share and ratcheted
+  the commanded current on home-load spikes.
 
-  Pre-#358 the Zone 3 transition was guarded by a forecast check
-  (legacy ``_zone_based_strategy`` line 2742-2750). Post-#358
-  decide.py's ``battery_assist_budget_w`` treats Zone 3 and Zone 4
-  the same way (the "deferred to Step 5" TODO in decide.py:109).
-  This scenario pins the current behaviour so a future Step 5
-  re-introduction of the forecast gate doesn't silently change it
-  without notice.
+  With real surplus (2.5 kW) plus the Zone-3 potential
+  (0.625 × 4500 ≈ 2.8 kW) the budget clears the 6 A charger min and
+  the EV charges — pinning that the capped formula still engages the
+  regime when there is genuinely spare energy. (The pre-#501 variant
+  of this scenario had ZERO surplus — home ate all solar — and relied
+  on the unconditional min floor; post-#501 that correctly idles, see
+  2026-06-11_min_plus_solar_cloudy_no_grid.yaml.)
 
 config:
   battery_capacity_kwh: 15.0
@@ -38,14 +41,14 @@ config:
 
 cycle_seconds: 30
 
-# Zone 3 SOC (75), modest solar surplus, battery actively
-# discharging at 5 kW. battery_assist_budget_w should compute
-# surplus + battery_discharge >= charger min → CHARGE.
+# Zone 3 SOC (75), real surplus: solar 6 kW, home 3.5 kW (derived
+# from 2.5 kW export), battery idle. surplus 2500 W + Zone-3 assist
+# potential 2812 W = 5312 W ≥ charger min (4140 W) → CHARGE.
 timeline:
   - t: 0
-    solar_power: 2000
-    grid_power: 2000         # +ve = export
-    battery_power: -5000     # -ve = discharging at 5 kW
+    solar_power: 6000
+    grid_power: 2500         # +ve = export
+    battery_power: 0
     battery_soc: 75
     ev_power: 0              # not yet drawing
     ev_connected: true

--- a/tests/scenarios/2026-06-02_zone_boundary_buffer_soc.yaml
+++ b/tests/scenarios/2026-06-02_zone_boundary_buffer_soc.yaml
@@ -21,9 +21,13 @@ description: |
   This scenario walks the SOC up from 65 to 75 — through the
   exact buffer_soc=70 threshold — and asserts that the resulting
   strategy is internally consistent. With min_plus_solar mode +
-  is_night=false:
-    * Zone 2 (SOC < 70) → solar_only branch (Z2 strategy)
-    * Zone 3 (70 ≤ SOC < 90) → battery_assist branch
+  is_night=false and a real 2.5 kW surplus (#501: the assist
+  budget is the capped SOC potential, so the Zone-3 cycles need
+  surplus + potential ≥ charger min to charge):
+    * Zone 2 (SOC < 70) → solar_only branch (surplus alone is
+      below the 6 A min → idle)
+    * Zone 3 (70 ≤ SOC < 90) → battery_assist branch (surplus +
+      capped potential clears the min → charge)
   The transition cycle (SOC=70) should land in Zone 3
   (buffer_soc is the FLOOR of Zone 3, inclusive).
 
@@ -47,13 +51,14 @@ config:
 cycle_seconds: 30
 
 # Walk SOC from 65 (Zone 2) through 70 (boundary) up to 75
-# (Zone 3 proper). Battery actively discharging to power EV in
-# Zone 3 so the budget clears charger min.
+# (Zone 3 proper). Real surplus (solar 6 kW, home 3.5 kW) so the
+# Zone-3 budget (surplus + capped assist potential) clears the
+# charger min while Zone 2 (surplus only, 2.5 kW < 4.14 kW) idles.
 timeline:
   - t: 0
-    solar_power: 2000
-    grid_power: 2000
-    battery_power: -5000
+    solar_power: 6000
+    grid_power: 2500
+    battery_power: 0
     battery_soc: 65
     ev_power: 0
     ev_connected: true

--- a/tests/scenarios/2026-06-11_min_plus_solar_cloudy_no_grid.yaml
+++ b/tests/scenarios/2026-06-11_min_plus_solar_cloudy_no_grid.yaml
@@ -1,0 +1,67 @@
+name: "2026-06-11 min_plus_solar cloudy day — no forced grid/battery pull (#501)"
+
+coverage:
+  - mode: min_plus_solar
+    regime: zone3_day_battery_assist
+    issue: "#501 — need-gated day floor, self-consumption-maximizing"
+
+description: |
+  The user report behind #501: on a cloudy afternoon with the home
+  battery in Zone 3 (70-90%), pre-#501 min_plus_solar commanded the
+  unconditional 6 A floor (#439 commit-then-measure) — grinding the
+  battery into the EV with sustained grid backfill, even though the
+  daily Min was comfortably deliverable by the night window.
+
+  Post-#501 the floor is need-gated: with a 7 kWh remaining Min and
+  a night window that can deliver ~26 kWh at max current, daytime
+  stays self-consumption-only. Zero surplus (home exceeds solar) +
+  the capped Zone-3 assist potential (0.625 × 4500 ≈ 2.8 kW) is
+  below the 6 A charger min → the EV idles. No grid import, no
+  battery drain.
+
+  HARNESS NOTE: the scenario runner mocks ``coord.time_manager``, so
+  ``_night_deliverable_kwh`` hits its except-guard and returns
+  ``inf`` — i.e. this scenario exercises the ``floor_needed = False``
+  path because ``remaining (7) > inf`` is always False, NOT because
+  of the 26 kWh figure above. To write a scenario that exercises the
+  floor-ENGAGES path (``night_deliverable < remaining``), give the
+  harness a real ``get_night_window`` stub first — otherwise the
+  floor never engages here regardless of ``daily_ev_target`` and the
+  assertion would pass vacuously.
+
+config:
+  battery_capacity_kwh: 15.0
+  battery_buffer_soc: 70
+  battery_auto_start_soc: 90
+  battery_priority_soc: 30
+  battery_assist_floor_soc: 60
+  battery_assist_max_power: 4500
+  ev_min_current: 6
+  ev_max_current: 16
+  ev_phases: 3
+  ev_voltage: 230
+  daily_ev_target: 7.0
+  ev_chargers:
+    - id: "ev_charger"
+      charge_mode: "min_plus_solar"
+      daily_ev_target: 7.0
+
+cycle_seconds: 30
+
+# Cloudy: 300 W solar, home drawing 800 W (the difference imports),
+# battery holding at 75% (Zone 3). EV plugged in, daily Min NOT yet
+# met — and it must still idle.
+timeline:
+  - t: 0
+    solar_power: 300
+    grid_power: -500         # -ve = import (home draws beyond solar)
+    battery_power: 0
+    battery_soc: 75
+    ev_power: 0
+    ev_connected: true
+
+  - t: 60
+  - t: 120
+
+expect:
+  strategy_substring: "idle"

--- a/tests/test_440_per_vehicle_min_current.py
+++ b/tests/test_440_per_vehicle_min_current.py
@@ -105,8 +105,15 @@ class TestEffectiveMinAmpsHelper:
 
 
 def _view(*, is_night=False, connected=True, soc=95, target_kwh=14.0,
-          ev_min=6, vehicle_min=None):
-    """Build a minimal ChargerView for the night/day branches."""
+          ev_min=6, vehicle_min=None, night_deliverable_kwh=float("inf")):
+    """Build a minimal ChargerView for the night/day branches.
+
+    ``night_deliverable_kwh`` defaults to ``inf`` (matching the
+    ChargerView default = "the night window can cover any Min").
+    Post-#501 the daytime Zone 3/4 floor is need-gated, so day-branch
+    tests that want the floor to engage must pass a value below
+    ``target_kwh``.
+    """
     from custom_components.solar_energy_management.coordinator.charger_types import (
         FleetContext, ChargerView, ChargerPower, ChargerEnergy,
     )
@@ -130,6 +137,7 @@ def _view(*, is_night=False, connected=True, soc=95, target_kwh=14.0,
         power=power, energy=energy, mode="min_plus_solar",
         config=cfg, fleet=fleet,
         target_kwh=target_kwh, deadline_amps=0,
+        night_deliverable_kwh=night_deliverable_kwh,
     )
 
 
@@ -157,11 +165,35 @@ def test_min_plus_solar_night_uses_loadpoint_min_when_no_vehicle_override():
 
 
 def test_min_plus_solar_day_zone4_uses_vehicle_min():
-    """Daytime Zone 4 commit-then-measure (#439) — same effective floor
-    applies on the day branch."""
+    """Daytime Zone 4 — when the need-gated floor engages (#501: the
+    night window can no longer cover the remaining Min), it commits at
+    the effective per-vehicle floor (10 A), not the loadpoint min (6 A).
+    The #440 invariant (vehicle_min wins) is preserved under #501's
+    gating; the gate is exercised by ``night_deliverable_kwh < target``.
+    """
     from custom_components.solar_energy_management.coordinator.decide import (
         MinPlusSolarMode,
     )
-    view = _view(is_night=False, soc=95, ev_min=6, vehicle_min=10)
+    view = _view(is_night=False, soc=95, ev_min=6, vehicle_min=10,
+                 target_kwh=14.0, night_deliverable_kwh=0.0)
     decision = MinPlusSolarMode().decide(view)
     assert decision.commanded_amps == 10
+
+
+def test_min_plus_solar_day_zone4_idles_when_min_covered_by_night():
+    """#501 — with the Min covered by the night window
+    (``night_deliverable_kwh >= target``), daytime Zone 4 does NOT
+    force the floor: zero solar surplus → idle, not a grid-backfilled
+    6/10 A floor. Pins the self-consumption-maximizing behavior."""
+    from custom_components.solar_energy_management.coordinator.decide import (
+        MinPlusSolarMode,
+    )
+    from custom_components.solar_energy_management.coordinator.charger_types import (
+        ChargerIntent,
+    )
+    view = _view(is_night=False, soc=95, ev_min=6, vehicle_min=10,
+                 target_kwh=14.0)  # night_deliverable defaults to inf
+    decision = MinPlusSolarMode().decide(view)
+    assert decision.intent is ChargerIntent.IDLE, (
+        f"Min covered by night → must idle, not floor; got {decision.intent}"
+    )

--- a/tests/test_canonical_ev_budget.py
+++ b/tests/test_canonical_ev_budget.py
@@ -180,11 +180,17 @@ class TestSolarOnly:
 
 
 # ──────────────────────────────────────────────────────────────────────
-# BATTERY_ASSIST — Zone 4. Surplus + redirect + actual discharge.
+# BATTERY_ASSIST — Zone 3/4. Surplus + redirect + capped SOC potential
+# (#501: never the measured discharge).
 # ──────────────────────────────────────────────────────────────────────
 
 class TestBatteryAssist:
-    def test_uses_measured_discharge_when_battery_already_discharging(self):
+    def test_measured_discharge_is_ignored_501(self):
+        """#501: the assist is the SOC-based POTENTIAL, never the
+        measured total discharge. Pre-#501 this returned the raw
+        3000 W discharge — which included the house's share and
+        ratcheted the EV budget on home-load spikes, bypassing the
+        battery_assist_max_power cap."""
         fc = FlowCalculator()
         b = fc.calculate_canonical_ev_budget(
             _power(solar=1000, home=500, batt_discharge=3000, batt_soc=75),
@@ -193,11 +199,37 @@ class TestBatteryAssist:
         )
         # raw_surplus = max(0, 1000 - 500 - 0) = 500
         # redirect = 0 (battery not charging)
-        # assist = measured discharge = 3000
+        # assist = SOC potential: 4500 * (0.5 + 0.5*(75-70)/20) = 2812.5
+        # (no min_power_floor_w passed → full potential, legacy callers)
         assert b.solar_surplus == 500
         assert b.battery_redirect == 0
-        assert b.battery_assist == 3000
-        assert b.net_w == 3500
+        assert b.battery_assist == pytest.approx(2812.5, abs=1)
+        assert b.net_w == pytest.approx(3312.5, abs=1)
+
+    def test_assist_tops_up_to_min_power_floor_only_501(self):
+        """#501: with min_power_floor_w passed (the coordinator does
+        for BATTERY_ASSIST), the assist fills only the surplus→min
+        gap — it never boosts past surplus (battery cycling for no
+        self-consumption gain)."""
+        fc = FlowCalculator()
+        # Sunny: surplus 7500 already > floor → assist contributes 0
+        b = fc.calculate_canonical_ev_budget(
+            _power(solar=8000, home=500, batt_soc=95),
+            strategy=EVBudgetStrategy.BATTERY_ASSIST,
+            battery_soc=95,
+            min_power_floor_w=4140.0,
+        )
+        assert b.battery_assist == 0
+        assert b.net_w == 7500
+        # Cloudy: surplus 0 → assist fills exactly the floor gap
+        b2 = fc.calculate_canonical_ev_budget(
+            _power(solar=300, home=800, batt_soc=95),
+            strategy=EVBudgetStrategy.BATTERY_ASSIST,
+            battery_soc=95,
+            min_power_floor_w=4140.0,
+        )
+        assert b2.battery_assist == pytest.approx(4140, abs=1)
+        assert b2.net_w == pytest.approx(4140, abs=1)
 
     def test_estimates_assist_proportionally_in_zone3_band(self):
         """SOC = 80, buffer=70, auto_start=90.

--- a/tests/test_decide.py
+++ b/tests/test_decide.py
@@ -47,6 +47,8 @@ def _view(
     tariff_level: str | None = None,
     target_kwh: float | None = None,
     deadline_amps: int = 0,
+    night_deliverable_kwh: float = float("inf"),
+    battery_assist_max_power_w: float = 4500.0,
     config: dict | None = None,
 ) -> ChargerView:
     return ChargerView(
@@ -64,9 +66,11 @@ def _view(
             battery_discharge_w=battery_discharge_w,
             battery_soc=battery_soc,
             is_night=is_night, tariff_level=tariff_level,
+            battery_assist_max_power_w=battery_assist_max_power_w,
         ),
         target_kwh=target_kwh,
         deadline_amps=deadline_amps,
+        night_deliverable_kwh=night_deliverable_kwh,
     )
 
 
@@ -229,8 +233,10 @@ class TestMinPlusSolarMode:
 
 class TestMinPlusSolarZoneAssist:
     """min_plus_solar day-path uses Zone-aware battery assist
-    (Zone 4 = drain battery; Zone 3 = use current discharge;
-    Zone 2 = pure solar; Zone 1 = idle).
+    (Zone 3/4 = surplus + capped SOC-based assist potential (#501);
+    Zone 2 = pure solar; Zone 1 = idle). The min-current floor is
+    need-gated: it engages only when the remaining Min exceeds what
+    tonight's window can deliver.
     """
 
     def test_zone_4_battery_assist_charges_from_battery(self):
@@ -275,6 +281,96 @@ class TestMinPlusSolarZoneAssist:
         ))
         assert d.intent is ChargerIntent.IDLE
         assert "Zone 1" in d.reason
+
+
+class TestMinPlusSolarSelfMax:
+    """#501 — daytime min_plus_solar is self-consumption-maximizing.
+
+    The Zone 3/4 min-current floor is need-gated (engages only when
+    the night window can't deliver the remaining Min) and the assist
+    budget is the capped SOC-based POTENTIAL — never the battery's
+    measured total discharge (which included the house's share and
+    ratcheted the commanded current on home-load spikes).
+    """
+
+    def test_cloudy_zone3_no_floor_idles(self):
+        """Cloudy day, Zone 3, Min comfortably covered by tonight's
+        window → NO forced 6 A; the charger idles (pre-#501 it pulled
+        ≥4.1 kW from battery+grid all afternoon)."""
+        d = decide(_view(
+            mode="min_plus_solar",
+            solar_w=300, home_w=800, battery_soc=75,
+            target_kwh=7.0, night_deliverable_kwh=26.0,
+        ))
+        # budget = surplus(0) + assist_potential(75) = 0.625*4500 = 2812 W < 6 A
+        assert d.intent is ChargerIntent.IDLE
+        assert "night window" in d.reason
+
+    def test_floor_engages_when_night_cannot_cover(self):
+        """Remaining Min exceeds the night window's deliverable —
+        the commit-then-measure floor (#439/ADR 0010) engages."""
+        d = decide(_view(
+            mode="min_plus_solar",
+            solar_w=300, home_w=800, battery_soc=75,
+            target_kwh=30.0, night_deliverable_kwh=12.0,
+        ))
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+        assert d.commanded_amps == 6
+        assert "floor engaged" in d.reason
+
+    def test_no_floor_after_min_met(self):
+        """Min already reached today → never force the floor, even if
+        night_deliverable is tiny ('Up to Full never forces grid')."""
+        d = decide(_view(
+            mode="min_plus_solar",
+            solar_w=300, home_w=800, battery_soc=75,
+            target_kwh=0.05, night_deliverable_kwh=0.0,
+        ))
+        assert d.intent is ChargerIntent.IDLE
+
+    def test_home_load_spike_does_not_ratchet_amps(self):
+        """Regression for the misattribution ratchet: the battery
+        covering a HOME load spike must not inflate the EV budget.
+        Same solar/SOC, discharge jumps 0 → 6 kW (house turned on the
+        oven) → commanded amps unchanged."""
+        base = decide(_view(
+            mode="min_plus_solar",
+            solar_w=6000, home_w=500, battery_soc=80,
+            battery_discharge_w=0.0,
+        ))
+        spike = decide(_view(
+            mode="min_plus_solar",
+            solar_w=6000, home_w=500, battery_soc=80,
+            battery_discharge_w=6000.0,
+        ))
+        assert base.intent is ChargerIntent.CHARGE_AT_AMPS
+        assert spike.commanded_amps == base.commanded_amps
+
+    def test_assist_capped_at_configured_max(self):
+        """Zone 4, no solar: the assist budget is the configured
+        battery_assist_max_power, not the battery's nameplate."""
+        d = decide(_view(
+            mode="min_plus_solar",
+            solar_w=0, home_w=500, battery_soc=95,
+            battery_assist_max_power_w=3000.0,
+            target_kwh=30.0, night_deliverable_kwh=12.0,
+        ))
+        # potential = 3000 W → 4 A, floor raises to 6 A (floor engaged);
+        # budget itself must reflect the cap
+        assert d.budget_w == pytest.approx(3000.0, abs=1)
+
+    def test_zone4_assist_potential_charges_without_flowing_discharge(self):
+        """#439 stays fixed: battery NOT yet discharging, Zone 4 →
+        the POTENTIAL still funds the budget and charging starts
+        (no chicken-and-egg gate on measured discharge)."""
+        d = decide(_view(
+            mode="min_plus_solar",
+            solar_w=0, home_w=500, battery_soc=95,
+            battery_discharge_w=0.0,
+        ))
+        # potential = 4500 W → 6 A
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+        assert d.commanded_amps == 6
 
 
 class TestSolarPlusCheapMode:


### PR DESCRIPTION
## What & why

Daytime `min_plus_solar` in battery **Zone 3/4** was draining the home battery into the EV and importing from the grid when it should maximize self-consumption (user review, 2026-06-11). A cloudy afternoon at 70–90% SOC got ground into the car with sustained grid backfill — even after the daily Min was already met.

Closes the algorithmic half of #501 (Refs #501; closes when promoted to `main`).

## The fix (3 coupled changes; amends ADR 0010 pattern 1)

1. **Need-gated daytime floor** — the Zone-3/4 min-current floor now engages only when the remaining daily Min exceeds what tonight's window can deliver at max current (new per-charger `ChargerView.night_deliverable_kwh`, computed from the night-window start → that charger's Charge-by deadline). Otherwise daytime is pure surplus + capped assist, and idles below the charger minimum. Restores the documented *"Min comes from the night top-up, not a forced grid pull at noon"*; `always_max` stays the "just charge" escape hatch.
2. **One shared, capped assist formula** — `decide.battery_assist_budget_w` and `flow_calculator._calculate_battery_assist_w` had diverged (ADR 0002 regression). Both now use the same SOC-based **potential** (`battery_assist_potential_w`): capped by `battery_assist_max_power`, zeroed below the assist-floor SOC, bounded to the surplus→min gap.
3. **Measured-discharge branch removed from both** — total battery discharge includes the house's share, so a home-load spike inflated the EV budget and ratcheted commanded current upward. Using *potential* (never gated on currently-flowing discharge) keeps #439's chicken-and-egg structurally fixed.

Also: `EV_CHARGING_LOGIC.md` mode table corrected; ADR 0010 note added.

## Verification

- **Full suite: 3559 passed, 8 skipped** (py3.12). New: `test_440` updated to exercise the need-gated floor (preserves the per-vehicle-min invariant) + a new test pinning "idle when Min covered by night"; new scenario `2026-06-11_min_plus_solar_cloudy_no_grid.yaml`.
- **Reviewer (`ruflo-core:reviewer`): no critical issues.** Applied its flagged fixes — renamed `FleetContext.battery_floor_soc` → `battery_assist_floor_soc` (matches config key + param), corrected the `battery_assist_budget_w` docstring, and added a harness caveat to the scenario YAML so the floor-engages path can't be tested vacuously.
- **HA-TEST (code-only deploy):** coordinator runs clean (`success: True`), `night_deliverable_kwh` computes live without crashing, 0 SEM errors. (Zone 3/4 not force-exercisable live — mock battery reads SOC 0% = Zone 1 — but covered by unit + scenario tests.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
