### PR TITLE
fix(forecast_tracker): #416 — EMA-smooth the live dampening signal + correct sun window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## 🔮 Forecast dampening: morning jitter smoothed + correct sun window (#416)
+
+Closes the two remaining sub-findings of the #416 forecast-correction audit (the other three — shrinkage naming, telemetry surface, write-time weather snapshot — shipped earlier and are soak-verified on PROD).
+
+- **The live dampening signal is EMA-smoothed (τ ≈ 5 min)** — at 7–9 AM the expected-production fraction is tiny, so the normalized live ratio amplified the actual-sensor noise floor (cloud transits, inverter sampling) into large cycle-to-cycle swings of `forecast_dampening_factor`. The blend now consumes a time-based EMA of the ratio; genuine weather trends still pass with little lag. Raw and smoothed values are both on the sensor's diagnostic attributes (`normalized_ratio` / `smoothed_ratio`) (#416)
+- **`_get_sun_hours` no longer mixes tomorrow's sunrise with today's sunset** — `next_rising`/`next_setting` are NEXT events; tomorrow-dated ones now roll back a day, fixing the skewed daylight window (~1 min average, worse near solstices/high latitudes) (#416)
+
 ## 🧭 Sign-detection locks survive restarts (#476)
 
 The grid/battery sign autodetect locks were RAM-only — every reload re-learned the sign from possibly ambiguous low-power samples, and three bad votes right after a reboot could lock the WRONG sign until the next reload (the 2026-06-11 PROD flip).

--- a/coordinator/forecast_tracker.py
+++ b/coordinator/forecast_tracker.py
@@ -13,9 +13,10 @@ The correction factor is a simple but effective approach:
 from __future__ import annotations
 
 import logging
+import math
 from collections import deque
 from dataclasses import dataclass, field
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Dict, List, Optional
 
 from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
@@ -31,6 +32,12 @@ MIN_FORECAST_KWH = 0.5
 
 # Real-time dampening: hours of solar production before fully trusting live data
 CONFIDENCE_RAMP_HOURS = 3.0
+# #416 sub#2 — time-constant (seconds) of the EMA applied to the live
+# normalized ratio before it enters the dampening blend. ~5 minutes:
+# cycle-to-cycle sensor noise (cloud transits, inverter sampling) is
+# damped away, while genuine weather trends (tens of minutes) pass
+# through with little lag.
+LIVE_RATIO_EMA_TAU_S = 300.0
 
 # Outlier detection: cap actual at this multiple of forecast
 MAX_ACTUAL_RATIO = 2.0  # Cap outlier days at 2× forecast (was 3.0)
@@ -90,6 +97,11 @@ class ForecastTracker:
         self._dampening_snapshot: Optional[float] = None
         self._snapshot_confidence: Optional[float] = None
         self._snapshot_live_ratio: Optional[float] = None
+        # #416 sub#2 — intraday EMA over the normalized live ratio.
+        # Reset at day rollover; not persisted (re-seeds within ~τ
+        # after a mid-day restart).
+        self._smoothed_normalized_ratio: Optional[float] = None
+        self._smoothed_ratio_ts: Optional[float] = None
         # #416 follow-up (2026-06-06): snapshot of ``_weather_today``
         # captured during the same confident mid-day cycle that updates
         # ``_dampening_snapshot``. The day-rollover write needs to
@@ -124,6 +136,21 @@ class ForecastTracker:
                         # Convert to local time hours
                         local_rise = rise.astimezone(dt_util.DEFAULT_TIME_ZONE)
                         local_sett = sett.astimezone(dt_util.DEFAULT_TIME_ZONE)
+                        # #416 sub#3 — ``next_rising``/``next_setting``
+                        # are the NEXT events: during the day
+                        # next_rising is tomorrow's sunrise, and after
+                        # sunset next_setting is tomorrow's too. Mixing
+                        # tomorrow-rise with today-set skews the
+                        # daylight window (~1 min average, worse near
+                        # solstices / high latitudes). Roll any
+                        # tomorrow-dated event back one day — the day-
+                        # over-day drift (≲2 min) is far below the
+                        # sine-curve model's own error.
+                        local_today = dt_util.now().date()
+                        if local_rise.date() > local_today:
+                            local_rise -= timedelta(days=1)
+                        if local_sett.date() > local_today:
+                            local_sett -= timedelta(days=1)
                         return (
                             local_rise.hour + local_rise.minute / 60.0,
                             local_sett.hour + local_sett.minute / 60.0,
@@ -154,6 +181,8 @@ class ForecastTracker:
             self._snapshot_confidence = None
             self._snapshot_live_ratio = None
             self._weather_snapshot = None
+            self._smoothed_normalized_ratio = None
+            self._smoothed_ratio_ts = None
 
         # Update today's values
         self._today_date = today
@@ -525,8 +554,32 @@ class ForecastTracker:
         live_ratio = self._today_actual / self._today_forecast
         normalized_ratio = live_ratio / expected_fraction if expected_fraction > 0.01 else 1.0
 
+        # #416 sub#2 — time-based EMA over the normalized ratio. At
+        # 7-9 AM ``expected_fraction`` is tiny, so the division above
+        # amplifies the actual-sensor noise floor (cloud transits,
+        # inverter sampling) into large cycle-to-cycle dampening
+        # swings. The EMA (τ = LIVE_RATIO_EMA_TAU_S) damps that jitter;
+        # genuine weather trends (tens of minutes) pass with little
+        # lag. Raw ``normalized_ratio`` stays on the diagnostics
+        # surface; only the blend consumes the smoothed value.
+        now_ts = now.timestamp()
+        if (
+            self._smoothed_normalized_ratio is None
+            or self._smoothed_ratio_ts is None
+            or now_ts < self._smoothed_ratio_ts
+        ):
+            self._smoothed_normalized_ratio = normalized_ratio
+        else:
+            dt_s = max(0.0, now_ts - self._smoothed_ratio_ts)
+            alpha = 1.0 - math.exp(-dt_s / LIVE_RATIO_EMA_TAU_S)
+            self._smoothed_normalized_ratio += alpha * (
+                normalized_ratio - self._smoothed_normalized_ratio
+            )
+        self._smoothed_ratio_ts = now_ts
+        smoothed_ratio = self._smoothed_normalized_ratio
+
         # Blend: historical correction × (1 - confidence) + live ratio × confidence
-        blended = (1 - confidence) * self._correction_factor + confidence * normalized_ratio
+        blended = (1 - confidence) * self._correction_factor + confidence * smoothed_ratio
         clamped = max(0.5, min(1.5, blended))
 
         if clamped != blended:
@@ -586,6 +639,13 @@ class ForecastTracker:
             "forecast_dampening_confidence": self._last_confidence,
             "forecast_dampening_live_ratio": self._last_live_ratio,
             "forecast_dampening_normalized_ratio": self._last_normalized_ratio,
+            # #416 sub#2 — the EMA-smoothed value that actually enters
+            # the blend (raw normalized_ratio above is the unsmoothed
+            # diagnostic). None until the first blended_live cycle.
+            "forecast_dampening_smoothed_ratio": (
+                round(self._smoothed_normalized_ratio, 4)
+                if self._smoothed_normalized_ratio is not None else None
+            ),
             "forecast_dampening_pre_clamp": self._last_blended_pre_clamp,
         }
 

--- a/sensor.py
+++ b/sensor.py
@@ -2296,6 +2296,7 @@ class SEMSolarSensor(CoordinatorEntity, RestoreSensor):
                 "confidence": d.get("forecast_dampening_confidence"),
                 "live_ratio": d.get("forecast_dampening_live_ratio"),
                 "normalized_ratio": d.get("forecast_dampening_normalized_ratio"),
+                "smoothed_ratio": d.get("forecast_dampening_smoothed_ratio"),
                 "pre_clamp": d.get("forecast_dampening_pre_clamp"),
                 "correction_factor_historical": d.get("forecast_correction_factor"),
             })

--- a/tests/test_416_dampening_smoothing.py
+++ b/tests/test_416_dampening_smoothing.py
@@ -1,0 +1,192 @@
+"""#416 sub#2 + sub#3 — live-signal EMA smoothing + correct sun hours.
+
+Sub#2: at 7-9 AM ``expected_fraction`` is tiny, so the normalized live
+ratio amplifies the actual-sensor noise floor into large cycle-to-cycle
+dampening swings (no smoothing existed). An EMA (τ = 300 s) over the
+normalized ratio now feeds the blend; the raw value stays diagnostic.
+
+Sub#3: ``next_rising``/``next_setting`` are NEXT events — during the
+day next_rising is tomorrow's sunrise. Mixing tomorrow-rise with
+today-set skewed the daylight window. Tomorrow-dated events now roll
+back one day.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.forecast_tracker import (
+    ForecastTracker,
+    LIVE_RATIO_EMA_TAU_S,
+)
+
+TZ = timezone.utc
+
+
+def _dt(hour, minute=0, day=18):
+    return datetime(2026, 4, day, hour, minute, tzinfo=TZ)
+
+
+def _tracker():
+    t = ForecastTracker()
+    t._hass = None
+    t._today_date = "2026-04-18"
+    t._today_forecast = 30.0
+    t._correction_factor = 1.0
+    return t
+
+
+def _run_cycle(t, now, actual_kwh):
+    """Drive one _calculate_dampening_factor cycle at a frozen time."""
+    t._today_actual = actual_kwh
+    with patch(
+        "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
+    ) as mock_dt:
+        mock_dt.now.return_value = now
+        mock_dt.DEFAULT_TIME_ZONE = TZ
+        return t._calculate_dampening_factor()
+
+
+# ── Sub#2: EMA damps cycle-to-cycle jitter ───────────────────────────
+
+def test_morning_jitter_is_damped():
+    """Two cycles 10 s apart with a 25% jump in normalized ratio: the
+    published dampening moves only a fraction of the raw swing
+    (alpha = 1 - exp(-10/300) ≈ 0.033)."""
+    t = _tracker()
+    # 10:00 — well past the early-morning floor for a 30 kWh day.
+    d1 = _run_cycle(t, _dt(10, 0), actual_kwh=6.0)
+    s1 = t._smoothed_normalized_ratio
+    # 10 s later the sensor jumps 25% (cloud-transit noise).
+    d2 = _run_cycle(t, _dt(10, 0).replace(second=10), actual_kwh=7.5)
+    s2 = t._smoothed_normalized_ratio
+    raw2 = t._last_normalized_ratio
+
+    # The raw ratio moved ~25%; the smoothed value moved ≲5% of that gap.
+    assert raw2 > s1 * 1.2
+    alpha_10s = 1 - pytest.approx(0.9672, abs=0.001).expected  # ≈ 0.033
+    assert s2 - s1 == pytest.approx((raw2 - s1) * alpha_10s, rel=0.05)
+    # And the published factor barely moved between the two cycles.
+    assert abs(d2 - d1) < 0.05
+
+
+def test_smoothed_converges_to_steady_signal():
+    """A steady ratio converges: after >> τ the smoothed value equals
+    the raw value and the blend behaves exactly as pre-#416."""
+    t = _tracker()
+    _run_cycle(t, _dt(10, 0), actual_kwh=6.0)
+    # 30 minutes later (6×τ), same conditions → converged.
+    d = _run_cycle(t, _dt(10, 30), actual_kwh=6.9)
+    assert t._smoothed_normalized_ratio == pytest.approx(
+        t._last_normalized_ratio, rel=0.02
+    )
+    assert d == pytest.approx(t._last_blended_pre_clamp, abs=0.51)  # clamp window
+
+
+def test_ema_seeds_on_first_blended_cycle():
+    t = _tracker()
+    assert t._smoothed_normalized_ratio is None
+    _run_cycle(t, _dt(12, 0), actual_kwh=15.0)
+    # _last_normalized_ratio is rounded to 4dp; the EMA seed isn't.
+    assert t._smoothed_normalized_ratio == pytest.approx(
+        t._last_normalized_ratio, abs=1e-4
+    )
+
+
+def test_ema_resets_at_day_rollover():
+    t = _tracker()
+    _run_cycle(t, _dt(12, 0), actual_kwh=15.0)
+    assert t._smoothed_normalized_ratio is not None
+    with patch(
+        "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
+    ) as mock_dt:
+        mock_dt.now.return_value = _dt(0, 5, day=19)
+        mock_dt.DEFAULT_TIME_ZONE = TZ
+        t.update(forecast_today_kwh=25.0, actual_solar_kwh=0.0)
+    assert t._smoothed_normalized_ratio is None
+    assert t._smoothed_ratio_ts is None
+
+
+def test_clock_rewind_reseeds_instead_of_negative_alpha():
+    """now_ts earlier than the stored ts (clock adjust / test reuse)
+    re-seeds rather than computing exp() of a positive number."""
+    t = _tracker()
+    _run_cycle(t, _dt(12, 0), actual_kwh=15.0)
+    before = t._smoothed_normalized_ratio
+    _run_cycle(t, _dt(11, 0), actual_kwh=20.0)  # clock went backwards
+    assert t._smoothed_normalized_ratio == pytest.approx(
+        t._last_normalized_ratio, abs=1e-4
+    )
+    assert t._smoothed_normalized_ratio != before
+
+
+# ── Sub#3: sun hours roll tomorrow's events back to today ────────────
+
+def _sun_state(next_rising, next_setting):
+    sun = MagicMock()
+    sun.attributes = {
+        "next_rising": next_rising.isoformat(),
+        "next_setting": next_setting.isoformat(),
+    }
+    return sun
+
+
+def test_sun_hours_daytime_uses_todays_sunrise():
+    """At noon, next_rising is TOMORROW 06:12 — the old code mixed it
+    with today's 20:00 sunset. Now it rolls back to today."""
+    hass = MagicMock()
+    hass.states.get.return_value = _sun_state(
+        next_rising=_dt(6, 12, day=19),   # tomorrow morning
+        next_setting=_dt(20, 0, day=18),  # today evening
+    )
+    t = ForecastTracker()
+    t._hass = hass
+    with patch(
+        "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
+    ) as mock_dt:
+        mock_dt.now.return_value = _dt(12, 0, day=18)
+        mock_dt.DEFAULT_TIME_ZONE = TZ
+        rise, sett = t._get_sun_hours()
+    assert rise == pytest.approx(6.2)
+    assert sett == pytest.approx(20.0)
+
+
+def test_sun_hours_after_sunset_rolls_both_back():
+    """At 22:00 both next events are tomorrow's — both roll back so the
+    window still describes TODAY."""
+    hass = MagicMock()
+    hass.states.get.return_value = _sun_state(
+        next_rising=_dt(6, 12, day=19),
+        next_setting=_dt(20, 2, day=19),
+    )
+    t = ForecastTracker()
+    t._hass = hass
+    with patch(
+        "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
+    ) as mock_dt:
+        mock_dt.now.return_value = _dt(22, 0, day=18)
+        mock_dt.DEFAULT_TIME_ZONE = TZ
+        rise, sett = t._get_sun_hours()
+    assert rise == pytest.approx(6.2)
+    assert sett == pytest.approx(20.0, abs=0.05)
+
+
+def test_sun_hours_pre_sunrise_unchanged():
+    """Before sunrise both next events are today's — no rollback."""
+    hass = MagicMock()
+    hass.states.get.return_value = _sun_state(
+        next_rising=_dt(6, 12, day=18),
+        next_setting=_dt(20, 0, day=18),
+    )
+    t = ForecastTracker()
+    t._hass = hass
+    with patch(
+        "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
+    ) as mock_dt:
+        mock_dt.now.return_value = _dt(4, 0, day=18)
+        mock_dt.DEFAULT_TIME_ZONE = TZ
+        rise, sett = t._get_sun_hours()
+    assert rise == pytest.approx(6.2)
+    assert sett == pytest.approx(20.0)

--- a/tests/test_calculation_audit.py
+++ b/tests/test_calculation_audit.py
@@ -533,6 +533,11 @@ class TestForecastSunriseSunsetFromSunEntity:
             "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
         ) as mock_dt:
             mock_dt.DEFAULT_TIME_ZONE = timezone.utc
+            # #416 sub#3 — _get_sun_hours reads now().date() to roll
+            # tomorrow-dated next_* events back to today.
+            mock_dt.now.return_value = datetime(
+                2026, 5, 15, 4, 0, tzinfo=timezone.utc
+            )
             tracker.set_hass(hass)
             rise, sett = tracker._get_sun_hours()
 
@@ -581,6 +586,9 @@ class TestForecastSunriseSunsetFromSunEntity:
             "custom_components.solar_energy_management.coordinator.forecast_tracker.dt_util"
         ) as mock_dt:
             mock_dt.DEFAULT_TIME_ZONE = timezone.utc
+            mock_dt.now.return_value = datetime(
+                2026, 1, 15, 4, 0, tzinfo=timezone.utc
+            )
             tracker.set_hass(hass)
             rise, sett = tracker._get_sun_hours()
 

--- a/tests/test_forecast_tracker.py
+++ b/tests/test_forecast_tracker.py
@@ -29,6 +29,10 @@ def _freeze_dt(year=2026, month=4, day=18, hour=12, minute=0):
     mock.year = dt.year
     mock.hour = dt.hour
     mock.minute = dt.minute
+    # #416 sub#2/#3 — the EMA smoothing reads now().timestamp() and the
+    # sun-hours fix reads now().date(); bind the real datetime's methods.
+    mock.timestamp = dt.timestamp
+    mock.date = dt.date
     return mock
 
 


### PR DESCRIPTION
## What & why

Closes the **two remaining sub-findings of the #416 forecast-correction audit** (sub#1 shrinkage naming, sub#4 telemetry surface, and the write-time weather snapshot shipped earlier and are PROD-soak-verified — see the issue's status table).

### Sub#2 — morning dampening jitter (Refs #416)
At 7–9 AM `expected_fraction` is tiny, so `normalized_ratio = live_ratio / expected_fraction` amplified the actual-sensor noise floor (cloud transits, inverter sampling) into large cycle-to-cycle swings of `forecast_dampening_factor` — there was no smoothing on the live signal. A **time-based EMA (τ = 300 s)** now sits between the ratio and the blend: cycle noise is damped (10 s cycle → α ≈ 0.033), genuine weather trends (tens of minutes) pass with little lag. EMA state is intraday-only — reset at rollover, re-seeds after restarts/clock rewinds. Raw and smoothed values are both diagnostic attributes (`normalized_ratio` / `smoothed_ratio`).

### Sub#3 — sun window mixed days
`next_rising`/`next_setting` are NEXT events: during the day `next_rising` is **tomorrow's** sunrise; after sunset `next_setting` is tomorrow's too. The daylight window mixed days (~1 min average error, worse near solstices/high latitudes). Tomorrow-dated events now roll back one day.

### Finding 5 note (zero-history floor)
Addressed by design + this smoothing: first-day live dampening responds to *today's own* signal (desirable on a genuinely cloudy first day); the EMA + confidence ramp now prevent the noise-driven floor-slamming that made it look erratic on synthetic data.

## Verification

- 8 new tests in `test_416_dampening_smoothing.py` (jitter damping with exact α, convergence to steady signal, seeding, rollover reset, clock-rewind reseed, all three sun-rollback shapes)
- `_freeze_dt` helper + 2 calculation-audit tests gain the `now().timestamp()`/`.date()` bindings the new code reads
- Full suite green (3565→ all forecast + audit suites pass after the helper fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
