### PR TITLE
fix(heat-pump/hot-water): #508 phase 1 — surplus activation + relay-failure safety + legionella driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## 🔥 Heat pump / hot water: surplus activation actually fires + relay-failure safety (#508)
+
+First phase of wiring the dedicated heat-pump and hot-water controllers into the surplus pipeline they were bypassing.
+
+- **They actually activate on solar surplus now** — both controllers defaulted to `PEAK_ONLY`, and the surplus controller never proactively turns on a non-`SURPLUS` device, so surplus boosting was silently inert. Both now default to `SURPLUS` (still overridable via `set_device_control_mapping`) (#508)
+- **A failed SG-Ready relay write no longer credits phantom power** — the heat pump used to mark itself `ACTIVE` and deduct `rated_power` from the surplus pool even when the relay call failed, starving the EV/battery of watts that weren't being drawn. It now returns 0 W and reports `ERROR`; a partial (relay2) failure restores relay1 to its prior state instead of leaving a stray curtail signal (#508)
+- **Legionella prevention runs** — `check_legionella_cycle()` had no production caller (the disinfection cycle never ran, `hours_since_legionella` was pinned at 999). It's now driven every cycle, and the last-cycle timestamp persists across restarts so a reboot doesn't force a disinfection run (#508)
+- **Heat-pump compressor anti-cycling** — `min_on`/`min_off` guards (10 min run / 5 min rest) so a 10 s coordinator cycle can't short-cycle the compressor (#508)
+- Follow-up phase (tracked in #508): route them through the load-manager dual-sync for peak shedding, and feed the true house surplus rather than the EV budget
+
+
 # [1.7.3-beta.14] - 13.06.2026
 
 ## 🏠 System-diagram Home no longer flickers to 0 W while the EV charges (#506)

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1023,6 +1023,26 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 self._storage.get_sign_state()
             )
 
+            # Restore the legionella timestamp (#508 I2). With the cycle
+            # now driven every coordinator tick (#508 C1), a None
+            # timestamp reads as "overdue" and would force a disinfection
+            # run on every restart. Restore the persisted time; on a
+            # fresh install (no stored time) seed to NOW so the first
+            # cycle is ~interval_hours away, not immediate.
+            hw_dev = self._surplus_controller._devices.get("hot_water") \
+                if hasattr(self, "_surplus_controller") else None
+            if hw_dev is not None and hasattr(hw_dev, "record_legionella_cycle"):
+                stored_leg = self._storage.get_legionella_time()
+                if stored_leg:
+                    try:
+                        hw_dev.record_legionella_cycle(
+                            dt_util.parse_datetime(stored_leg)
+                        )
+                    except (ValueError, TypeError):
+                        hw_dev.record_legionella_cycle(dt_util.now())
+                else:
+                    hw_dev.record_legionella_cycle(dt_util.now())
+
             # Restore per-charger daily EV energy. It was in-memory only, so it reset to
             # 0 on every restart while the global daily_ev persisted — desyncing the
             # per-charger daily sensor AND (worse) the per-charger night-charge remaining,
@@ -2072,6 +2092,15 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 self._storage.set_sign_state(
                     self._sensor_reader.export_sign_state()
                 )
+                # Persist the legionella timestamp (#508 I2).
+                _hw = self._surplus_controller._devices.get("hot_water") \
+                    if hasattr(self, "_surplus_controller") else None
+                _leg_t = getattr(_hw, "_last_legionella_time", None) if _hw else None
+                if _leg_t is not None:
+                    try:
+                        self._storage.set_legionella_time(_leg_t.isoformat())
+                    except (AttributeError, ValueError):
+                        pass
                 await self._storage.async_save_energy_delayed()
 
             self._initial_update_done = True
@@ -2918,6 +2947,16 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         hw_hours_since_leg: Optional[float] = None
         hw_leg_active: bool = False
         if hw_controller is not None:
+            # #508 C1 — drive the legionella state machine every cycle.
+            # check_legionella_cycle() had no production caller, so the
+            # disinfection cycle never ran and hours_since_legionella was
+            # pinned at the 999 sentinel forever. Running it each cycle
+            # advances the hold-timer and fires completion correctly.
+            if hasattr(hw_controller, "check_legionella_cycle"):
+                try:
+                    await hw_controller.check_legionella_cycle()
+                except Exception as e:  # noqa: BLE001 — never break the cycle
+                    _LOGGER.debug("Legionella cycle check failed: %s", e)
             try:
                 t = hw_controller.get_current_temperature() if hasattr(hw_controller, "get_current_temperature") else None
                 hw_current_temp = float(t) if t is not None else None

--- a/coordinator/storage.py
+++ b/coordinator/storage.py
@@ -320,6 +320,18 @@ class SEMStorage:
         """Persist sign-detection lock state."""
         self._energy_data["sign_state"] = state
 
+    # Legionella timestamp persistence (#508 I2) — without this, driving
+    # the legionella cycle (#508 C1) would force a disinfection run on
+    # every restart, since a None timestamp reads as "overdue".
+    def get_legionella_time(self) -> Optional[str]:
+        """Get the persisted last-legionella ISO timestamp, or None."""
+        return self._energy_data.get("legionella_last_time")
+
+    def set_legionella_time(self, iso_ts: Optional[str]) -> None:
+        """Persist the last-legionella ISO timestamp."""
+        if iso_ts:
+            self._energy_data["legionella_last_time"] = iso_ts
+
     def add_session_to_history(self, session: Dict[str, Any]) -> None:
         """Append a completed session to bounded history (max 90 entries)."""
         state = self.get_ev_intelligence_state()

--- a/devices/heat_pump_controller.py
+++ b/devices/heat_pump_controller.py
@@ -112,6 +112,20 @@ class HeatPumpController(SetpointDevice):
         self._last_temperature_reading_path: str = "uninitialized"
         self._last_offpeak_path: str = "uninitialized"
 
+        # #508 — the heat pump exists to soak up solar surplus, so it
+        # must be a SURPLUS-mode device. The base default is PEAK_ONLY,
+        # and SurplusController.update() never proactively activates a
+        # non-SURPLUS device — so without this the controller registered
+        # but never turned on. A user can still override to peak_only/off
+        # via set_device_control_mapping.
+        from .base import DeviceControlMode
+        self.control_mode = DeviceControlMode.SURPLUS
+        # #508 W1 — compressor anti-cycling. On a 10 s coordinator cycle
+        # the activate→deactivate path could otherwise short-cycle the
+        # compressor. can_activate()/can_deactivate() enforce these.
+        self.min_on_seconds = 600   # 10 min minimum run
+        self.min_off_seconds = 300  # 5 min compressor rest
+
     @property
     def sg_ready_state(self) -> SGReadyState:
         return self._hp_status.sg_ready_state
@@ -152,12 +166,24 @@ class HeatPumpController(SetpointDevice):
             target_state = SGReadyState.BOOST
             self._last_activation_path = "boost"
 
-        await self._set_sg_ready_state(target_state)
+        relay_ok = await self._set_sg_ready_state(target_state)
+        if not relay_ok:
+            # #508 C3: a relay write failed — the pump is NOT in the
+            # requested SG-Ready state. Do not mark ACTIVE and do not
+            # credit rated_power to the surplus pool (that power isn't
+            # being drawn). Surface ERROR so the diagnostics show it.
+            self._status.state = DeviceState.ERROR
+            self._last_activation_path += "+relay_failed"
+            _LOGGER.warning(
+                "Heat pump activation aborted: SG-Ready relay write failed "
+                "(%s) — not crediting %.0fW to surplus",
+                self._last_relay_path, self.rated_power,
+            )
+            return 0.0
+
         if self.climate_entity_id:
             self._last_activation_path += "+climate"
-
-        # Also boost temperature setpoint if climate entity configured
-        if self.climate_entity_id:
+            # Also boost temperature setpoint if climate entity configured
             await super().activate(available_watts)
 
         self._status.state = DeviceState.ACTIVE
@@ -216,17 +242,24 @@ class HeatPumpController(SetpointDevice):
         self._last_deactivation_path = "unblocked"
         _LOGGER.info("Heat pump unblocked")
 
-    async def _set_sg_ready_state(self, state: SGReadyState) -> None:
+    async def _set_sg_ready_state(self, state: SGReadyState) -> bool:
         """Set SG-Ready state via relay entities.
+
+        Returns ``True`` when the requested state was applied (or there
+        are no relays to apply — climate-only installs), ``False`` when a
+        physical relay write FAILED. #508 C3: the caller must not credit
+        ``rated_power`` to the surplus pool when this returns False — the
+        pump did not enter the requested state.
 
         Records the relay branch on ``self._last_relay_path`` (#421):
         ``both_relays`` / ``relay1_only`` / ``relay2_only`` /
         ``no_relays_configured`` / ``relay1_failed`` / ``relay2_failed``.
-        The ``no_relays_configured`` path is the silent-failure surface
-        — SG-Ready state mutates internally but no physical relay
-        actuates. The audit's biggest finding.
+        ``no_relays_configured`` is the climate-only path (#437) — a
+        valid success, the climate setpoint is the actuation.
         """
         relay1_on, relay2_on = SG_READY_RELAY_MAP[state]
+        # Prior relay1 value (for restore on a partial relay2 failure, I3).
+        prev_relay1_on, _ = SG_READY_RELAY_MAP[self._hp_status.sg_ready_state]
         relay1_called = False
 
         if self.relay1_entity_id:
@@ -241,7 +274,7 @@ class HeatPumpController(SetpointDevice):
             except Exception as e:
                 _LOGGER.error("Failed to set SG-Ready relay 1: %s", e)
                 self._last_relay_path = "relay1_failed"
-                return
+                return False
 
         if self.relay2_entity_id:
             service = "turn_on" if relay2_on else "turn_off"
@@ -258,7 +291,21 @@ class HeatPumpController(SetpointDevice):
             except Exception as e:
                 _LOGGER.error("Failed to set SG-Ready relay 2: %s", e)
                 self._last_relay_path = "relay2_failed"
-                return
+                # I3: relay1 already moved but relay2 didn't — the (r1,r2)
+                # pair is now inconsistent (e.g. could read as BLOCKED).
+                # Best-effort restore relay1 to its prior value so we
+                # leave a coherent prior state, not a curtail signal.
+                if relay1_called and relay1_on != prev_relay1_on:
+                    try:
+                        restore = "turn_on" if prev_relay1_on else "turn_off"
+                        await self.hass.services.async_call(
+                            "homeassistant", restore,
+                            {"entity_id": self.relay1_entity_id},
+                            blocking=True,
+                        )
+                    except Exception:  # noqa: BLE001 — best effort
+                        pass
+                return False
         elif relay1_called:
             self._last_relay_path = "relay1_only"
         else:
@@ -266,6 +313,7 @@ class HeatPumpController(SetpointDevice):
 
         self._hp_status.sg_ready_state = state
         _LOGGER.debug("SG-Ready state set to %s", state.name)
+        return True
 
     def get_current_temperature(self) -> Optional[float]:
         """Read current temperature from sensor.

--- a/devices/hot_water_controller.py
+++ b/devices/hot_water_controller.py
@@ -108,6 +108,14 @@ class HotWaterController(SwitchDevice):
         self._last_deactivation_path: str = "uninitialized"
         self._last_temperature_reading: Optional[float] = None
 
+        # #508 — hot water exists to soak up solar surplus, so it must be
+        # a SURPLUS-mode device. The base default is PEAK_ONLY, and
+        # SurplusController.update() never proactively activates a
+        # non-SURPLUS device — so without this the controller registered
+        # but never turned on. Overridable via set_device_control_mapping.
+        from .base import DeviceControlMode
+        self.control_mode = DeviceControlMode.SURPLUS
+
     @property
     def entity_domain(self) -> Optional[str]:
         """Return the entity domain (water_heater, climate, or switch)."""

--- a/tests/test_508_heatpump_hotwater_wiring.py
+++ b/tests/test_508_heatpump_hotwater_wiring.py
@@ -1,0 +1,139 @@
+"""#508 — heat-pump / hot-water surplus wiring + relay-failure handling.
+
+The dedicated controllers were registered straight onto the surplus
+controller and skipped the dual-sync the EV / Energy-Dashboard devices
+get. Two consequences pinned here:
+
+1. They defaulted to ``PEAK_ONLY``, so ``SurplusController.update()``
+   never proactively activated them — surplus boosting was inert.
+   (The old tests masked this by using generic ``SwitchDevice`` objects
+   with ``control_mode = SURPLUS`` set by hand.)
+2. The heat pump credited ``rated_power`` to the surplus pool even when
+   the SG-Ready relay write FAILED.
+
+Also: heat-pump compressor anti-cycling (``min_on/off_seconds``), the
+relay2-failure relay1 restore, and the legionella-timestamp storage
+round-trip.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.devices.base import (
+    DeviceControlMode, DeviceState,
+)
+from custom_components.solar_energy_management.devices.heat_pump_controller import (
+    HeatPumpController, SGReadyState,
+)
+from custom_components.solar_energy_management.devices.hot_water_controller import (
+    HotWaterController,
+)
+
+
+def _hass():
+    h = MagicMock()
+    h.services = MagicMock()
+    h.services.async_call = AsyncMock()
+    h.states = MagicMock()
+    h.states.get = MagicMock(return_value=None)
+    return h
+
+
+# ── C2: real controllers default to SURPLUS ──────────────────────────
+
+def test_heat_pump_defaults_to_surplus_mode():
+    hp = HeatPumpController(
+        hass=_hass(), relay1_entity_id="switch.r1", relay2_entity_id="switch.r2",
+    )
+    assert hp.control_mode == DeviceControlMode.SURPLUS, (
+        "heat pump must be SURPLUS or SurplusController never activates it"
+    )
+
+
+def test_hot_water_defaults_to_surplus_mode():
+    hw = HotWaterController(hass=_hass(), entity_id="switch.boiler")
+    assert hw.control_mode == DeviceControlMode.SURPLUS
+
+
+# ── W1: compressor anti-cycling on the heat pump ─────────────────────
+
+def test_heat_pump_has_anticycling_guards():
+    hp = HeatPumpController(hass=_hass(), relay1_entity_id="switch.r1",
+                            relay2_entity_id="switch.r2")
+    assert hp.min_on_seconds >= 300
+    assert hp.min_off_seconds >= 180
+    # The base can_activate/can_deactivate consult these (SetpointDevice
+    # does not override them).
+    assert hasattr(hp, "can_activate") and hasattr(hp, "can_deactivate")
+
+
+# ── C3: relay-write failure must NOT credit rated_power ──────────────
+
+@pytest.mark.asyncio
+async def test_relay_failure_returns_zero_and_marks_error():
+    hass = _hass()
+    # relay1 write raises.
+    hass.services.async_call = AsyncMock(side_effect=RuntimeError("relay down"))
+    hp = HeatPumpController(hass=hass, rated_power=2000,
+                            relay1_entity_id="switch.r1", relay2_entity_id="switch.r2")
+    consumed = await hp.activate(3000)
+    assert consumed == 0.0, "relay failure must credit 0 W, not rated_power"
+    assert hp._status.state == DeviceState.ERROR
+    assert "relay_failed" in hp._last_activation_path
+
+
+@pytest.mark.asyncio
+async def test_relay_success_credits_rated_power():
+    hass = _hass()  # async_call succeeds
+    hp = HeatPumpController(hass=hass, rated_power=2000,
+                            relay1_entity_id="switch.r1", relay2_entity_id="switch.r2")
+    consumed = await hp.activate(3000)
+    assert consumed == 2000.0
+    assert hp._status.state == DeviceState.ACTIVE
+
+
+# ── I3: relay2 failure restores relay1 to its prior value ────────────
+
+@pytest.mark.asyncio
+async def test_relay2_failure_restores_relay1():
+    hass = _hass()
+    calls = []
+
+    async def _call(domain, service, data, blocking=False):
+        calls.append((data.get("entity_id"), service))
+        # Fail only on relay2 writes.
+        if data.get("entity_id") == "switch.r2":
+            raise RuntimeError("relay2 down")
+
+    hass.services.async_call = AsyncMock(side_effect=_call)
+    hp = HeatPumpController(hass=hass, relay1_entity_id="switch.r1",
+                            relay2_entity_id="switch.r2")
+    # Prior state NORMAL = (relay1 off, relay2 on). Move to BOOST = (on, off):
+    # relay1 flips on, then relay2 fails → relay1 must be restored to off.
+    hp._hp_status.sg_ready_state = SGReadyState.NORMAL
+    ok = await hp._set_sg_ready_state(SGReadyState.BOOST)
+    assert ok is False
+    assert hp._last_relay_path == "relay2_failed"
+    # Last relay1 write must be the restore (turn_off back to NORMAL's off).
+    r1_calls = [c for c in calls if c[0] == "switch.r1"]
+    assert r1_calls[-1] == ("switch.r1", "turn_off"), (
+        f"relay1 should be restored to its prior (off) value; got {r1_calls}"
+    )
+
+
+# ── I2: legionella timestamp storage round-trip ──────────────────────
+
+def test_storage_legionella_time_roundtrip():
+    from custom_components.solar_energy_management.coordinator.storage import (
+        SEMStorage,
+    )
+    s = SEMStorage.__new__(SEMStorage)
+    s._energy_data = {}
+    assert s.get_legionella_time() is None
+    s.set_legionella_time("2026-06-13T10:00:00+00:00")
+    assert s.get_legionella_time() == "2026-06-13T10:00:00+00:00"
+    # None is a no-op (doesn't clobber a stored value).
+    s.set_legionella_time(None)
+    assert s.get_legionella_time() == "2026-06-13T10:00:00+00:00"


### PR DESCRIPTION
## What & why

Phase 1 of #508. SEM's dedicated `HeatPumpController`/`HotWaterController` register straight onto the surplus controller and **skip the `UnifiedDeviceRegistry` dual-sync** the EV and Energy-Dashboard devices get. This PR fixes the controller-internal + surplus-activation gaps; the load-management + true-surplus wiring is phase 2 (tracked in #508).

Reviewed against evcc's heating model (heating-as-loadpoint, SG-Ready Boost/Dim, **measure-don't-assume**).

## Fixes

- **Surplus boosting actually fires.** Both controllers defaulted to `PEAK_ONLY`, and `SurplusController.update()` never proactively activates a non-`SURPLUS` device (`surplus_controller.py:367`) — so the whole point of these controllers was inert in production. Both now default to `SURPLUS` (overridable via `set_device_control_mapping`). *The old tests masked this by using generic `SwitchDevice`s with `control_mode = SURPLUS` set by hand — the new tests exercise the real controllers.*
- **Relay-failure no longer credits phantom power (C3).** `activate()` gates on `_set_sg_ready_state()` success: a failed SG-Ready relay write returns **0 W** and marks `ERROR` instead of marking `ACTIVE` and deducting `rated_power` from the surplus pool (starving the EV/battery of watts that aren't flowing). A partial relay2 failure restores relay1 to its prior value (I3).
- **Legionella prevention runs (C1).** `check_legionella_cycle()` had **zero production callers** — disinfection never ran and `hours_since_legionella` was pinned at 999. Now driven every cycle; `_last_legionella_time` persists across restarts so a reboot doesn't force a cycle (I2). (The broken-sensor and temp-cutoff cases — W6 — were already mitigated in the existing code.)
- **Compressor anti-cycling (W1).** Heat pump now sets `min_on=600s` / `min_off=300s` (it's a `SetpointDevice`, which uses the base guard; hot water already had this via `SwitchDevice`).

## Phase 2 (next PR, same issue)
- Load-manager dual-sync so HP/HW are **peak-shed / throttled** when grid import nears the limit (W2).
- Feed the **true house surplus** (feed-in + own draw, evcc-style — feedback-free) instead of the EV budget (W7).

## Verification
- 7 new tests in `test_508_heatpump_hotwater_wiring.py` (real-controller SURPLUS default, anti-cycling guards, relay-failure → 0 W + ERROR, relay-success → rated_power, relay2-failure relay1 restore, legionella storage round-trip).
- Full suite **3589 passed / 8 skipped**. Not configured on any PROD today, so no live impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
