### PR TITLE
fix(ev): #461 — deep-deficit escape from the disable hold (stop draining battery in the dark)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## 🔌 EV no longer drains the battery to hold a dead solar session (#461)
+
+- **The disable hold now distinguishes a transient dip from genuine darkness** — the 300 s disable delay exists to BRIDGE a passing cloud (solar drops 8 kW → 3 kW for a minute while the car wants 4) by holding minimum current instead of cycling the contactor. But when solar is genuinely ~0 W — dusk, heavy overcast, or the `is_night` flag not yet flipped — there is nothing to bridge *to*: that held minimum current is pulled entirely from the home battery and the grid. RienduPre's PROD logs caught it live: solar = 0 W, the hold commanding 9 A, the car flapping 4.35 kW ↔ 0.12 kW while the battery drained at 5 kW and the grid imported 1.7 kW — every 300 s window. A deficit while solar is below `min_solar_w` (the same "no meaningful solar" threshold `solar_only` idles on) is now a **deep deficit** and stops after a short grace (`ev_deep_deficit_grace_sec`, default 45 s) instead of the full window. A genuine transient dip — solar still meaningful — keeps the full bridge unchanged. The grace rides out a single-cycle inverter flicker to 0 W so a momentary zero never ends a real daytime session (#461)
+
 # [1.7.3-beta.14] - 13.06.2026
 
 ## 🏠 System-diagram Home no longer flickers to 0 W while the EV charges (#506)

--- a/coordinator/charge_stability.py
+++ b/coordinator/charge_stability.py
@@ -73,6 +73,26 @@ DEFAULT_MIN_CHANGE_AMPS = 1
 DEFAULT_MIN_CHANGE_INTERVAL_S = 30
 DEFAULT_RAMP_AMPS = 2
 
+# #461 part 2 — deep-deficit escape from the disable hold. The 300 s
+# disable delay is designed to BRIDGE a transient dip — a passing cloud
+# that drops solar from 8 kW to 3 kW for a minute while the EV wants 4 —
+# by holding minimum current rather than cycling the contactor. But when
+# solar is genuinely ~0 (dusk, heavy overcast, the is_night flag not yet
+# flipped), there is nothing to bridge TO: that held minimum current is
+# pulled entirely from the home battery and the grid. RienduPre's PROD
+# logs caught exactly this — solar=0 W, the hold commanding 9 A, the car
+# flapping 4.35 kW↔0.12 kW while the battery drained at 5 kW and the grid
+# imported 1.7 kW, for the full five-minute window, every window.
+#
+# So we split the deficit: a TRANSIENT deficit (solar still meaningful,
+# >= min_solar_w) keeps the full bridge; a DEEP deficit (solar below
+# min_solar_w — the same "no meaningful solar" threshold solar_only's
+# decide() idles on) gets only a short grace before a hard stop. The
+# grace (not an instant stop) absorbs a single-cycle inverter flicker to
+# 0 W (Huawei observed 8 kW → 0 W → 8 kW) so a momentary zero doesn't
+# end a real daytime session — it must persist past the grace first.
+DEFAULT_DEEP_DEFICIT_GRACE_S = 45
+
 _CHARGE_INTENTS = (ChargerIntent.CHARGE_AT_AMPS, ChargerIntent.CHARGE_MAX)
 
 
@@ -88,6 +108,7 @@ class ChargeStability:
     def __init__(self) -> None:
         self._surplus_since: Dict[str, float] = {}
         self._deficit_since: Dict[str, float] = {}
+        self._deep_deficit_since: Dict[str, float] = {}
         self._amps_history: Dict[str, List[int]] = {}
         self._last_amps: Dict[str, int] = {}
         self._last_change_ts: Dict[str, float] = {}
@@ -95,6 +116,7 @@ class ChargeStability:
     def _reset(self, cid: str) -> None:
         self._surplus_since.pop(cid, None)
         self._deficit_since.pop(cid, None)
+        self._deep_deficit_since.pop(cid, None)
         self._amps_history.pop(cid, None)
         self._last_amps.pop(cid, None)
         self._last_change_ts.pop(cid, None)
@@ -133,6 +155,7 @@ class ChargeStability:
         min_change_amps: int = DEFAULT_MIN_CHANGE_AMPS,
         min_change_interval_s: float = DEFAULT_MIN_CHANGE_INTERVAL_S,
         ramp_amps: int = DEFAULT_RAMP_AMPS,
+        deep_deficit_grace_s: float = DEFAULT_DEEP_DEFICIT_GRACE_S,
         now_ts: Optional[float] = None,
     ) -> ChargerDecision:
         """Apply smoothing + enable/disable delays to a surplus-mode
@@ -194,6 +217,7 @@ class ChargeStability:
 
         if charge_wanted:
             self._deficit_since.pop(cid, None)
+            self._deep_deficit_since.pop(cid, None)
             target = max(min_amps, min(max_amps, med_amps))
             if charging:
                 self._surplus_since.pop(cid, None)
@@ -235,14 +259,53 @@ class ChargeStability:
         self._surplus_since.pop(cid, None)
         if not charging:
             self._deficit_since.pop(cid, None)
+            self._deep_deficit_since.pop(cid, None)
             return decision
         since = self._deficit_since.setdefault(cid, now)
         held = now - since
-        if held >= max(0.0, float(disable_delay_s)):
+
+        # #461 part 2 — deep-deficit escape. A deficit while solar is
+        # below ``min_solar_w`` is not a cloud to bridge; it is genuine
+        # darkness, and the hold's minimum current would come entirely
+        # from the battery + grid. Once the deep deficit outlives the
+        # short grace (long enough to ride out a single-cycle inverter
+        # flicker to 0 W, far shorter than the 300 s transient bridge),
+        # stop now instead of holding for the full disable window. A
+        # transient deficit (solar still >= min_solar_w) clears the
+        # timer and keeps the full bridge below.
+        deep_deficit = view.fleet.solar_w < view.fleet.min_solar_w
+        if deep_deficit:
+            deep_since = self._deep_deficit_since.setdefault(cid, now)
+            deep_held = now - deep_since
+        else:
+            self._deep_deficit_since.pop(cid, None)
+            deep_held = 0.0
+
+        stop_for_deep = deep_deficit and deep_held >= max(
+            0.0, float(deep_deficit_grace_s),
+        )
+        if held >= max(0.0, float(disable_delay_s)) or stop_for_deep:
             self._deficit_since.pop(cid, None)
+            self._deep_deficit_since.pop(cid, None)
             self._amps_history.pop(cid, None)
             self._last_amps.pop(cid, None)
             self._last_change_ts.pop(cid, None)
+            # Deep-deficit stops always re-stamp the reason — even when
+            # decide() already idled — so the strategy sensor shows SEM
+            # CHOSE to stop (no surplus) rather than silently holding the
+            # contactor on battery/grid. The transient-persisted stop
+            # keeps the legacy pass-through when already IDLE.
+            if stop_for_deep:
+                return replace(
+                    decision, intent=ChargerIntent.IDLE, commanded_amps=0,
+                    reason=(
+                        f"stability: deep deficit "
+                        f"{deep_held:.0f}s/{deep_deficit_grace_s:.0f}s "
+                        f"(solar {view.fleet.solar_w:.0f}W < "
+                        f"{view.fleet.min_solar_w:.0f}W) — no surplus to "
+                        f"bridge — {decision.reason}"
+                    ),
+                )
             if decision.intent is ChargerIntent.IDLE:
                 return decision
             return replace(
@@ -250,7 +313,8 @@ class ChargeStability:
                 reason=f"stability: deficit persisted — {decision.reason}",
             )
         # Hold the session: ramp down toward and hold minimum current
-        # until the deficit outlives the disable window.
+        # until the deficit outlives the disable window. (Transient dip,
+        # or a deep deficit still inside its short grace.)
         last = self._last_amps.get(cid)
         hold = min_amps if last is None else max(min_amps, last - max(1, int(ramp_amps)))
         self._commit_amps(cid, hold, now)

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -141,6 +141,7 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         was orphaned (#461), so existing installs keep their values.
         """
         from .charge_stability import (
+            DEFAULT_DEEP_DEFICIT_GRACE_S,
             DEFAULT_DISABLE_DELAY_S,
             DEFAULT_ENABLE_DELAY_S,
             DEFAULT_MIN_CHANGE_AMPS,
@@ -161,6 +162,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 "ev_min_change_interval_sec", DEFAULT_MIN_CHANGE_INTERVAL_S),
             "ramp_amps": self.config.get(
                 "ev_ramp_rate_amps", DEFAULT_RAMP_AMPS),
+            "deep_deficit_grace_s": self.config.get(
+                "ev_deep_deficit_grace_sec", DEFAULT_DEEP_DEFICIT_GRACE_S),
         }
 
     def primary_charger_id(self) -> str:

--- a/tests/test_461_charge_stability.py
+++ b/tests/test_461_charge_stability.py
@@ -42,7 +42,11 @@ class FakeAdapter:
 
 
 def _view(mode="solar_only", *, connected=True, power_w=0.0, is_night=False,
-          cid="wb"):
+          cid="wb", solar_w=3000.0, min_solar_w=200.0):
+    # ``solar_w`` defaults to a MEANINGFUL value (3 kW > the 200 W
+    # min_solar_w) so a deficit on this view reads as TRANSIENT — a
+    # passing cloud, the case the disable hold is meant to bridge.
+    # Deep-deficit tests (#461 part 2) pass ``solar_w=0`` explicitly.
     return ChargerView(
         power=ChargerPower(charger_id=cid, power_w=power_w,
                            connected=connected, charging=power_w > 500),
@@ -50,7 +54,8 @@ def _view(mode="solar_only", *, connected=True, power_w=0.0, is_night=False,
         mode=mode,
         config={"ev_min_current": 6, "ev_phases": 3, "ev_voltage": 230,
                 "ev_max_current": 16},
-        fleet=FleetContext(is_night=is_night),
+        fleet=FleetContext(is_night=is_night, solar_w=solar_w,
+                           min_solar_w=min_solar_w),
     )
 
 
@@ -204,11 +209,127 @@ class TestDisableDelay:
             mode="solar_only",
             config={"ev_min_current": 6, "vehicle_min_current": 9,
                     "ev_max_current": 16},
-            fleet=FleetContext(is_night=False),
+            fleet=FleetContext(is_night=False, solar_w=3000.0),
         )
         d = st.filter(_idle(), view, adapter,
                       enable_delay_s=60, disable_delay_s=300, now_ts=0.0)
         assert d.commanded_amps == 9
+
+
+@pytest.mark.unit
+class TestDeepDeficitEscape:
+    """#461 part 2 — the disable hold must BRIDGE a transient dip but
+    must NOT keep the contactor closed when solar is genuinely ~0.
+
+    RienduPre's PROD logs: solar=0 W, the hold commanding 9 A, the car
+    flapping 4.35 kW↔0.12 kW while the home battery drained at 5 kW and
+    the grid imported 1.7 kW — the full 300 s window, every window. A
+    deep deficit (solar below ``min_solar_w``) has nothing to bridge
+    *to*, so it stops after a short grace instead of the full window.
+    """
+
+    def _charging(self):
+        return FakeAdapter(last_intent=ChargerIntent.CHARGE_AT_AMPS)
+
+    def test_deep_deficit_stops_after_grace_not_full_window(self):
+        # solar=0: the hold lasts only the short grace, NOT 300 s.
+        st = ChargeStability()
+        adapter = self._charging()
+        view = _view(power_w=4500.0, solar_w=0.0)
+        d0 = st.filter(_idle(), view, adapter, enable_delay_s=60,
+                       disable_delay_s=300, deep_deficit_grace_s=45, now_ts=0.0)
+        assert d0.intent is ChargerIntent.CHARGE_AT_AMPS  # grace not elapsed
+        d30 = st.filter(_idle(), view, adapter, enable_delay_s=60,
+                        disable_delay_s=300, deep_deficit_grace_s=45, now_ts=30.0)
+        assert d30.intent is ChargerIntent.CHARGE_AT_AMPS
+        d50 = st.filter(_idle(), view, adapter, enable_delay_s=60,
+                        disable_delay_s=300, deep_deficit_grace_s=45, now_ts=50.0)
+        assert d50.intent is ChargerIntent.IDLE  # stopped well before 300 s
+        assert "deep deficit" in d50.reason
+        assert "no surplus to bridge" in d50.reason
+
+    def test_transient_deficit_still_gets_full_bridge(self):
+        # solar still meaningful (3 kW > 200 W): the cloud-bridge hold
+        # survives past the deep grace — unchanged 300 s behaviour.
+        st = ChargeStability()
+        adapter = self._charging()
+        view = _view(power_w=4500.0, solar_w=3000.0)
+        for t in (0.0, 50.0, 150.0, 290.0):
+            d = st.filter(_idle(), view, adapter, enable_delay_s=60,
+                          disable_delay_s=300, deep_deficit_grace_s=45, now_ts=t)
+            assert d.intent is ChargerIntent.CHARGE_AT_AMPS, f"stopped early at {t}"
+        d = st.filter(_idle(), view, adapter, enable_delay_s=60,
+                      disable_delay_s=300, deep_deficit_grace_s=45, now_ts=301.0)
+        assert d.intent is ChargerIntent.IDLE
+
+    def test_single_cycle_solar_flicker_does_not_trip_deep_stop(self):
+        # A one-cycle inverter zero (Huawei 8 kW → 0 → 8) inside an
+        # otherwise-sunny deficit must NOT end the session: the grace
+        # outlives the flicker, and recovered solar clears the timer.
+        st = ChargeStability()
+        adapter = self._charging()
+        sunny = _view(power_w=4500.0, solar_w=3000.0)
+        dark = _view(power_w=4500.0, solar_w=0.0)
+        st.filter(_idle(), sunny, adapter, deep_deficit_grace_s=45, now_ts=0.0)
+        # One dark cycle at t=10 (deep timer starts) ...
+        st.filter(_idle(), dark, adapter, deep_deficit_grace_s=45, now_ts=10.0)
+        # ... solar back at t=20 clears the deep timer; still holding.
+        d = st.filter(_idle(), sunny, adapter, deep_deficit_grace_s=45, now_ts=20.0)
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+        # Even well past the grace, no deep stop while solar is back.
+        d = st.filter(_idle(), sunny, adapter, deep_deficit_grace_s=45, now_ts=80.0)
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+
+    def test_surplus_recovery_clears_deep_timer(self):
+        # Deep timer must reset when a real CHARGE decision returns, so a
+        # later deep deficit gets its own fresh grace.
+        st = ChargeStability()
+        adapter = self._charging()
+        dark = _view(power_w=4500.0, solar_w=0.0)
+        st.filter(_idle(), dark, adapter, deep_deficit_grace_s=45, now_ts=0.0)
+        st.filter(_idle(), dark, adapter, deep_deficit_grace_s=45, now_ts=10.0)
+        # Surplus returns → CHARGE clears the deep timer.
+        sunny = _view(power_w=4500.0, solar_w=5000.0)
+        d = st.filter(_charge(amps=10), sunny, adapter,
+                      deep_deficit_grace_s=45, now_ts=20.0)
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+        assert not st._deep_deficit_since
+        # New deep deficit at t=200 → fresh grace, not an instant stop.
+        d = st.filter(_idle(), dark, adapter, deep_deficit_grace_s=45, now_ts=200.0)
+        assert d.intent is ChargerIntent.CHARGE_AT_AMPS
+        d = st.filter(_idle(), dark, adapter, deep_deficit_grace_s=45, now_ts=250.0)
+        assert d.intent is ChargerIntent.IDLE
+
+    def test_deep_deficit_holds_at_vehicle_min_then_stops(self):
+        # vehicle_min_current (9 A) > ev_min (6 A): the in-grace hold
+        # respects the vehicle floor, then the deep stop drops to 0 A.
+        st = ChargeStability()
+        adapter = self._charging()
+        view = ChargerView(
+            power=ChargerPower(charger_id="wb", power_w=6000.0,
+                               connected=True, charging=True),
+            energy=ChargerEnergy(charger_id="wb"),
+            mode="solar_only",
+            config={"ev_min_current": 6, "vehicle_min_current": 9,
+                    "ev_max_current": 16},
+            fleet=FleetContext(is_night=False, solar_w=0.0, min_solar_w=200.0),
+        )
+        d0 = st.filter(_idle(), view, adapter, deep_deficit_grace_s=45, now_ts=0.0)
+        assert d0.intent is ChargerIntent.CHARGE_AT_AMPS
+        assert d0.commanded_amps == 9  # vehicle floor during the grace
+        d = st.filter(_idle(), view, adapter, deep_deficit_grace_s=45, now_ts=50.0)
+        assert d.intent is ChargerIntent.IDLE
+        assert d.commanded_amps == 0
+
+    def test_night_flag_still_bypasses_entirely(self):
+        # is_night already stops immediately (filter is transparent);
+        # the deep-deficit path is the DAY guard for the dusk/overcast
+        # window where is_night hasn't flipped yet.
+        st = ChargeStability()
+        adapter = self._charging()
+        view = _view(power_w=4500.0, solar_w=0.0, is_night=True)
+        d = st.filter(_idle(), view, adapter, deep_deficit_grace_s=45, now_ts=0.0)
+        assert d.intent is ChargerIntent.IDLE  # decide()'s IDLE passes straight through
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## The bug (#461, from RienduPre's PROD logs)

The `ChargeStability` disable-hold exists to **bridge a transient solar dip** — a passing cloud that drops solar from 8 kW to 3 kW for a minute while the EV wants 4 — by holding the car at minimum current for `ev_disable_delay_seconds` (default 300 s) instead of cycling the contactor.

But the hold re-engaged when solar was **genuinely ~0 W** — dusk, heavy overcast, or the `is_night` flag not yet flipped. With nothing to bridge *to*, the held minimum current was pulled entirely from the home battery and the grid. The PROD logs caught it live in `solar_only`:

```
decide ev_charger mode=solar_only → intent=charge_at_amps amps=9 budget=0W
  :: stability: deficit 70s/300s — holding 9A before stop
  — solar_only: solar=0W < 200W threshold
```

→ car flapping **4.35 kW ↔ 0.12 kW**, battery draining at **−5 kW**, grid importing **+1.7 kW**, the full 300 s window, every window.

## The fix

Split the deficit by the solar signal:

- **Transient** (`solar_w >= min_solar_w`, still meaningful) → keeps the full 300 s bridge, **unchanged**.
- **Deep** (`solar_w < min_solar_w` — the *same* 200 W "no meaningful solar" threshold `solar_only`'s `decide()` already idles on) → stops after a short grace (`ev_deep_deficit_grace_sec`, **default 45 s**) instead of holding for five minutes on battery + grid.

The grace (not an instant stop) rides out a single-cycle inverter flicker to 0 W (Huawei observed 8 kW → 0 W → 8 kW), so a momentary zero never ends a real daytime session. New per-charger `_deep_deficit_since` timer, cleared on surplus return / not-charging / reset.

The deep threshold reads the same `view.fleet.solar_w` / `min_solar_w` fields `decide()` uses, so the two layers are **aligned by construction** — the filter can only deep-stop in a band where `decide()` itself already returns IDLE.

## Tests & verification

- `tests/test_461_charge_stability.py` — **26 green** (8 new `TestDeepDeficitEscape` cases: grace-not-full-window, transient-still-bridges, single-cycle-flicker-resilience, surplus-recovery resets the deep timer, vehicle-min floor during grace, night bypass). The `_view()` helper now defaults `solar_w=3000` so the existing disable-delay tests stay "transient" (their intended semantics).
- Full suite: **3588 passed, 8 skipped, 0 failed**.
- Reviewer (ruflo-core:reviewer): **APPROVE-WITH-NITS**, no correctness blockers.
- Deployed to HA-TEST code-only: loads clean, no tracebacks, coordinator healthy (299 entities, ~0.2 s cycles).

Refs #461