### PR TITLE
feat(surplus): #508 phase 2 (true surplus + peak-aware) + #470 priority split

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## ☀️ Heat pump / hot water boost on the TRUE house surplus, and stand down under peak (#508 phase 2)
+
+- **They now see real spare solar, not the EV's budget (W7)** — the surplus controller was fed the EV charging *budget*, so heat pump / hot water effectively competed for the EV's allocation. It now receives the true house surplus: `grid_export + its own active device draw`. The add-back is what makes it stable — without it, every device the controller switches on shrinks the grid export it reads next cycle, so the signal would chase its own tail and the device would flap. With it, the input is the surplus that *would* exist if its devices were off — the right quantity to allocate from. Net effect: discretionary loads boost only on genuine spare solar, after the EV and battery have taken their share (#508)
+- **They back off when the grid-import peak is at risk (W2)** — the load manager and the surplus controller used to fight: the load manager would shed a heat pump to protect the 15-minute peak, then the surplus controller (running later in the same cycle) would see surplus and switch it straight back on. The surplus controller now receives the load manager's peak posture — on `WARNING` it stops *adding* discretionary load; on `SHEDDING` it backs its own devices off one per cycle (gentlest first by reverse priority); on `EMERGENCY` it sheds them all at once. The EV stays owned by the load manager's shed path (#508)
+
+## 🔀 Independent surplus vs shed priority per EV charger (#470)
+
+- **`ev_shed_priority` splits off from `ev_surplus_priority`** — a single number used to drive two unrelated decisions: who gets solar surplus first (cooperative, every cycle) and who gets throttled first when grid import nears the peak limit (emergency). A mixed fleet can't express both — e.g. a long-range EV should charge *first* on surplus (big battery soaks watts) yet shed *first* under peak (range cushion absorbs a throttle). Surplus order stays on `ev_surplus_priority`; shed order moves to the new per-charger `ev_shed_priority`, exposed in the options flow, the setup flow, and as a per-charger number entity. A v12→v13 migration seeds `ev_shed_priority = ev_surplus_priority` for every existing charger, so the decoupling is behaviour-neutral until you deliberately diverge them (#470)
+
 ## 🔥 Heat pump / hot water: surplus activation actually fires + relay-failure safety (#508)
 
 First phase of wiring the dedicated heat-pump and hot-water controllers into the surplus pipeline they were bypassing.

--- a/__init__.py
+++ b/__init__.py
@@ -934,6 +934,55 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> boo
             )
             return False
 
+    if entry.version < 13:
+        # v12 → v13 (#470): split the conflated ``ev_surplus_priority`` into
+        # a surplus-allocation order and a load-shed order. Seed each
+        # charger's ``ev_shed_priority`` from its current
+        # ``ev_surplus_priority`` (legacy alias ``ev_load_priority``) so the
+        # decoupling is behaviour-neutral until the user deliberately
+        # diverges them. Writing the value explicitly (rather than relying
+        # on the runtime fallback) means a later flip of one field is an
+        # obvious, isolated change in the config.
+        try:
+            new_data = {**accumulated_data}
+            new_options = {**accumulated_options}
+            full = {**new_data, **new_options}
+            seeded = 0
+            for bag in (new_data, new_options):
+                chargers = bag.get("ev_chargers")
+                if not isinstance(chargers, list):
+                    continue
+                rebuilt = []
+                for c in chargers:
+                    if isinstance(c, dict) and c.get("ev_shed_priority") is None:
+                        c = dict(c)
+                        src = c.get("ev_surplus_priority")
+                        if src is None:
+                            src = c.get("ev_load_priority")
+                        if src is None:
+                            src = full.get("ev_surplus_priority")
+                        if src is not None:
+                            c["ev_shed_priority"] = int(src)
+                            seeded += 1
+                    rebuilt.append(c)
+                bag["ev_chargers"] = rebuilt
+            hass.config_entries.async_update_entry(
+                entry, data=new_data, options=new_options,
+                version=13, minor_version=1,
+            )
+            accumulated_data, accumulated_options = new_data, new_options
+            if seeded:
+                _LOGGER.info(
+                    "#470: seeded ev_shed_priority from ev_surplus_priority "
+                    "for %d charger(s)", seeded,
+                )
+        except Exception as e:
+            _LOGGER.error(
+                "Migration from v%s to v13 failed — keeping original config: %s",
+                entry.version, e,
+            )
+            return False
+
     _LOGGER.info("Migration to version %s.%s done", entry.version, entry.minor_version)
     return True
 
@@ -1329,6 +1378,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
             ev_service_entity = _cfg("ev_charger_service_entity_id")
             ev_current_entity = _cfg("ev_current_control_entity")
             ev_priority = int(_cfg("ev_surplus_priority", _cfg("ev_load_priority", 3 + idx)))
+            # #470: shed priority is independent of surplus priority. A
+            # mixed fleet wants e.g. the long-range EV to charge FIRST on
+            # surplus (big battery soaks watts) yet shed FIRST under peak
+            # (range cushion absorbs a throttle). ``ev_shed_priority``
+            # carries the load-manager order; it falls back to the surplus
+            # priority so single-charger / homogeneous installs are
+            # behaviour-identical (the v12→v13 migration seeds it
+            # explicitly per charger so flips are deliberate).
+            ev_shed_priority = int(_cfg("ev_shed_priority", ev_priority))
 
             # Also auto-fill sensor reader config from first charger
             if idx == 0:
@@ -1446,7 +1504,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
                 await coordinator._load_manager.register_ev_charger(
                     current_control_entity=ev_current_entity,
                     power_entity=ev_power_entity,
-                    priority=ev_priority,
+                    priority=ev_shed_priority,  # #470: shed order, not surplus order
                     is_critical=False,
                     charger_service=ev_charger_service,
                     charger_id=charger_id,

--- a/config_flow.py
+++ b/config_flow.py
@@ -153,7 +153,7 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     #     ``initial_current`` (decouples from the misleading "night"
     #     prefix — the value is the session-start ramp current, applied
     #     whenever a session begins). Display: "Vehicle Start Amps".
-    VERSION = 12
+    VERSION = 13
 
     @staticmethod
     @callback
@@ -570,6 +570,7 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                         "ev_start_service", "ev_start_service_data",
                         "ev_stop_service", "ev_stop_service_data",
                         "ev_charger_needs_cycle", "ev_surplus_priority",
+                        "ev_shed_priority",
                         # Wallbox-style control path (#384 Part 2 kept). The
                         # other 8 per-charger fields from #390 reverted to
                         # OptionsFlow-only in #397 — they were tunables with
@@ -1046,6 +1047,14 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
                 ),
+                # #470: independent shed order under peak; defaults to the
+                # surplus priority above.
+                vol.Optional(
+                    "ev_shed_priority",
+                    default=5,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
+                ),
                 # Per-charger night charging settings (#193)
                 vol.Optional(
                     "daily_ev_target",
@@ -1206,6 +1215,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     "ev_surplus_priority",
                     default=charger.get("ev_surplus_priority", 5),
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
+                ),
+                # #470: shed order under peak — independent of the surplus
+                # order above. Lower number = charges first on surplus;
+                # higher number = shed first under peak. Defaults to the
+                # surplus priority so they coincide until deliberately split.
+                vol.Optional(
+                    "ev_shed_priority",
+                    default=charger.get(
+                        "ev_shed_priority", charger.get("ev_surplus_priority", 5),
+                    ),
                 ): selector.NumberSelector(
                     selector.NumberSelectorConfig(min=1, max=10, step=1, mode="slider")
                 ),

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -2759,8 +2759,28 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
         # Surplus controller (Phase 0.2)
         surplus_data = SurplusControlData()
         try:
+            # #508 W7 — feed the TRUE house surplus, not the EV budget.
+            # ``grid_export_power`` is what the house is exporting after the
+            # EV and battery take their share; add back this controller's
+            # own active device draw so the signal is feedback-free (a
+            # device it turned on doesn't shrink the surplus it reads next
+            # cycle and oscillate). Heat pump / hot water now boost on real
+            # spare solar instead of competing for the EV's allocation.
+            true_surplus_w = (
+                float(getattr(power, "grid_export_power", 0.0) or 0.0)
+                + self._surplus_controller.active_surplus_draw_w()
+            )
+            # #508 W2 — hand the load-manager's peak posture to the surplus
+            # controller so it stops adding discretionary load (and backs
+            # its own devices off) when grid import is at risk, instead of
+            # re-activating next cycle whatever the load manager just shed.
+            peak_state = (
+                self._load_manager.get_state() if self._load_manager else None
+            )
             allocation = await self._surplus_controller.update(
-                available_power, price_level=tariff_data.tariff_price_level,
+                true_surplus_w,
+                price_level=tariff_data.tariff_price_level,
+                peak_state=peak_state,
             )
             surplus_data.surplus_total_w = allocation.total_surplus_w
             surplus_data.surplus_distributable_w = allocation.distributable_surplus_w

--- a/coordinator/surplus_controller.py
+++ b/coordinator/surplus_controller.py
@@ -293,22 +293,74 @@ class SurplusController:
             key=lambda d: d.priority,
         )
 
+    def active_surplus_draw_w(self) -> float:
+        """Sum the current draw of the surplus devices this controller
+        has activated (#508 W7).
+
+        The coordinator builds a *feedback-free* true house surplus as
+        ``grid_export + active_surplus_draw_w()``. Without the addback,
+        every device the controller turns on shrinks the grid export it
+        reads next cycle, so the surplus signal would chase its own tail
+        and the device would oscillate. Adding back the controller's own
+        active draw makes the input the surplus that WOULD exist if its
+        devices were off — the stable quantity to allocate from.
+
+        Externally-managed devices (the EV, driven by the decide/actuate
+        path) are excluded — their draw is already reflected in grid
+        export and must not be re-credited here.
+        """
+        return sum(
+            d.get_current_consumption()
+            for d in self.get_devices_sorted()
+            if d.is_active
+        )
+
     async def update(
         self,
         available_power_w: float,
         price_level: Optional[str] = None,
+        peak_state: Optional[str] = None,
     ) -> SurplusAllocationData:
         """Run the surplus allocation algorithm.
 
         This is called every coordinator update cycle (~10s).
 
         Args:
-            available_power_w: Total available surplus power (from FlowCalculator).
+            available_power_w: Total available surplus power. Since #508 W7
+                the coordinator passes the feedback-free TRUE house surplus
+                (grid export + this controller's own active draw), not the
+                EV charging budget — heat pump / hot water boost on what the
+                house is actually exporting after the EV and battery take
+                their share.
             price_level: Current price level (cheap/normal/expensive) for price-responsive mode.
+            peak_state: Current ``LoadManagementState`` (#508 W2). When the
+                grid-import peak is at risk (WARNING / SHEDDING / EMERGENCY)
+                the controller stops ADDING discretionary load, and on
+                SHEDDING / EMERGENCY proactively backs its own active
+                devices off by reverse priority — so it complements the
+                load manager instead of re-activating, next cycle, whatever
+                the load manager just shed. ``None`` = no peak awareness
+                (legacy behaviour).
 
         Returns:
             SurplusAllocationData with allocation results.
         """
+        # #508 W2 — peak posture. WARNING freezes new activation (don't add
+        # load while the peak is climbing); SHEDDING/EMERGENCY additionally
+        # sheds the controller's own discretionary devices. EMERGENCY sheds
+        # all of them at once; SHEDDING sheds gently (one per cycle) so the
+        # combined load-manager + surplus back-off doesn't overshoot.
+        from ..const import LoadManagementState
+        peak_freeze = peak_state in (
+            LoadManagementState.WARNING,
+            LoadManagementState.SHEDDING,
+            LoadManagementState.EMERGENCY,
+        )
+        peak_shed = peak_state in (
+            LoadManagementState.SHEDDING,
+            LoadManagementState.EMERGENCY,
+        )
+        peak_shed_all = peak_state == LoadManagementState.EMERGENCY
         # EMA smoothing to reduce oscillation from cloud transients
         if self._smoothed_surplus is None:
             self._smoothed_surplus = available_power_w
@@ -366,6 +418,8 @@ class SurplusController:
                 # Only activate if device is in "surplus" mode
                 if device.control_mode != DeviceControlMode.SURPLUS:
                     continue  # peak_only: never proactively turn on
+                if peak_freeze:
+                    continue  # #508 W2: don't add load while peak is at risk
                 if device.can_activate():
                     consumed = await device.activate(remaining_surplus)
                     if consumed > 0:
@@ -437,7 +491,46 @@ class SurplusController:
                             device.name,
                         )
 
-        # Check for scheduled devices that must start (deadline approaching)
+        # #508 W2 — peak shed pass. On SHEDDING/EMERGENCY, back the
+        # controller's own active discretionary (SURPLUS-mode) devices off
+        # by reverse priority. EMERGENCY sheds every one this cycle;
+        # SHEDDING sheds one per cycle so the load-manager + surplus
+        # back-off don't overshoot together. Externally-managed devices
+        # (the EV) are already excluded by ``get_devices_sorted``; the load
+        # manager owns the EV's peak shedding via ``shed_priority`` (#470).
+        if peak_shed:
+            for device in reversed(devices):
+                if device.control_mode != DeviceControlMode.SURPLUS:
+                    continue
+                if not device.is_active or not device.can_deactivate():
+                    continue
+                consumption = device.get_current_consumption()
+                await device.deactivate()
+                if not device.is_active:
+                    device.record_deactivated()
+                    active_count = max(0, active_count - 1)
+                    remaining_surplus += consumption
+                    _LOGGER.info(
+                        "Peak %s: shed %s (priority %d) to relieve %.0fW",
+                        peak_state, device.name, device.priority, consumption,
+                    )
+                    for a in allocations:
+                        if a.device_id == device.device_id:
+                            a.allocated_watts = 0.0
+                            a.actual_consumption_watts = 0.0
+                            a.state = DeviceState.IDLE.value
+                    if not peak_shed_all:
+                        break  # SHEDDING: gentle, one device per cycle
+                else:
+                    _LOGGER.debug(
+                        "Peak shed of %s blocked by anti-flicker", device.name,
+                    )
+
+        # Check for scheduled devices that must start (deadline approaching).
+        # #508 W2: deliberately NOT gated on peak_freeze — a deadline is a
+        # hard commitment that must run regardless of peak posture (like a
+        # critical device), and the one-cycle import is bounded by
+        # rated_power. Do not add a peak gate here.
         from ..devices.base import ScheduleDevice
         for device in devices:
             if isinstance(device, ScheduleDevice) and device.is_deadline_approaching and not device.is_active:
@@ -456,8 +549,10 @@ class SurplusController:
                 )
 
         # Off-peak activation pass: force-activate devices with runtime deficit
-        # Only for "surplus" mode devices — off-peak is a form of proactive activation (#49)
-        if price_level in ("cheap", "very_cheap", "negative"):
+        # Only for "surplus" mode devices — off-peak is a form of proactive activation (#49).
+        # #508 W2: suppressed while the peak is at risk — a cheap-tariff
+        # runtime deficit must not push grid import over the limit.
+        if price_level in ("cheap", "very_cheap", "negative") and not peak_freeze:
             for device in devices:
                 if device.control_mode != DeviceControlMode.SURPLUS:
                     continue

--- a/number.py
+++ b/number.py
@@ -474,6 +474,30 @@ async def async_setup_entry(
                     entity_category=EntityCategory.CONFIG,
                 ), "ev_phases",
                     charger_cfg.get("ev_phases", full_config.get("ev_phases", 3))),
+                # Surplus-allocation order (#470) — lower = charges first
+                # when solar surplus is distributed across the fleet.
+                (NumberEntityDescription(
+                    key=f"charger_{cid}_ev_surplus_priority",
+                    name=f"{cname} Surplus Priority",
+                    native_min_value=1, native_max_value=10, native_step=1,
+                    mode=NumberMode.SLIDER,
+                    icon="mdi:sort-numeric-ascending",
+                    entity_category=EntityCategory.CONFIG,
+                ), "ev_surplus_priority",
+                    charger_cfg.get("ev_surplus_priority", 5)),
+                # Load-shed order under peak (#470) — independent of surplus
+                # order; higher = shed first when grid import nears the peak
+                # limit. Defaults to the surplus priority.
+                (NumberEntityDescription(
+                    key=f"charger_{cid}_ev_shed_priority",
+                    name=f"{cname} Shed Priority",
+                    native_min_value=1, native_max_value=10, native_step=1,
+                    mode=NumberMode.SLIDER,
+                    icon="mdi:sort-numeric-descending",
+                    entity_category=EntityCategory.CONFIG,
+                ), "ev_shed_priority",
+                    charger_cfg.get("ev_shed_priority",
+                                    charger_cfg.get("ev_surplus_priority", 5))),
             ]:
                 per_charger_descriptions.append(base_desc)
                 entities.append(SEMPerChargerNumber(

--- a/tests/test_277_charge_mode_phase_a.py
+++ b/tests/test_277_charge_mode_phase_a.py
@@ -278,12 +278,12 @@ class TestMigrateEntryV5:
         captured = await self._run_migration_at_v4(options={
             "ev_chargers": [{"id": "ev_charger", "ev_charging_mode": "pv"}],
         })
-        assert captured["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
+        assert captured["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
 
     async def test_no_chargers_no_crash(self):
         """Pre-EV setups (no ev_chargers list) must still migrate."""
         captured = await self._run_migration_at_v4(options={})
-        assert captured["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
+        assert captured["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)
         # No ev_chargers to seed, so the key may or may not be present —
         # the migration must not invent one.
         assert "ev_chargers" not in captured["options"] or \

--- a/tests/test_277_charge_mode_phase_b.py
+++ b/tests/test_277_charge_mode_phase_b.py
@@ -411,7 +411,7 @@ class TestMigrateEntryV6:
             ],
         }, hass=hass)
         assert captured["options"]["ev_chargers"][0]["charge_mode"] == "solar_plus_cheap"
-        assert captured["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)
+        assert captured["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)
 
     async def test_preserves_explicit_min_plus_solar_without_tariff(self):
         """User explicitly picked min_plus_solar in the new selector
@@ -482,7 +482,7 @@ class TestMigrateEntryV6:
 
     async def test_no_chargers_safe_bumps_version(self):
         captured = await self._run(options={})
-        assert captured["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)
+        assert captured["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/test_508_phase2_surplus_peak.py
+++ b/tests/test_508_phase2_surplus_peak.py
@@ -1,0 +1,172 @@
+"""#508 phase 2 — true-surplus feed (W7) + peak-aware SurplusController (W2).
+
+Phase 1 made the heat-pump / hot-water controllers actually activate on
+surplus. Phase 2 fixes WHAT surplus they see and how they behave under a
+grid-import peak:
+
+* **W7 — true house surplus.** The controller used to be fed the EV
+  charging *budget*; it now receives ``grid_export + own active draw``.
+  ``active_surplus_draw_w()`` is the feedback-free addback: without it,
+  every device the controller turns on shrinks the export it reads next
+  cycle and the device oscillates.
+* **W2 — peak posture.** On WARNING the controller stops ADDING
+  discretionary load; on SHEDDING/EMERGENCY it backs its own active
+  devices off by reverse priority — complementing the load manager
+  instead of re-activating, next cycle, whatever it just shed.
+"""
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.surplus_controller import (
+    SurplusController,
+)
+from custom_components.solar_energy_management.devices.base import (
+    DeviceControlMode, DeviceState,
+)
+from custom_components.solar_energy_management.const import LoadManagementState
+
+
+def _make_device(
+    device_id="dev1", name="Test Device", priority=3, min_power=500,
+    enabled=True, managed_externally=False, is_active=False, consumption=0.0,
+    control_mode=DeviceControlMode.SURPLUS, antiflicker_blocks=False,
+):
+    device = MagicMock()
+    device.device_id = device_id
+    device.name = name
+    device.priority = priority
+    device.min_power_threshold = min_power
+    device.is_enabled = enabled
+    device.managed_externally = managed_externally
+    device.is_active = is_active
+    device.device_type = MagicMock(value="switch")
+    device.activate = AsyncMock(return_value=min_power)
+    device.adjust_power = AsyncMock(return_value=consumption or min_power)
+    device.get_current_consumption = MagicMock(return_value=consumption)
+    device.can_activate = MagicMock(return_value=True)
+    device.can_deactivate = MagicMock(return_value=True)
+    device.record_activated = MagicMock()
+    device.record_deactivated = MagicMock()
+    device.reset_surplus_timer = MagicMock()
+    device.status = MagicMock()
+    device.status.allocated_power_w = consumption
+    device.status.state = MagicMock(value="active" if is_active else "idle")
+    device.control_mode = control_mode
+    device._offpeak_forced = False
+    device.needs_offpeak_activation = False
+    device.remaining_daily_runtime_sec = 0
+    device.daily_min_runtime_sec = 0
+    device.__class__ = MagicMock
+    if antiflicker_blocks:
+        device.deactivate = AsyncMock()  # is_active stays True
+    else:
+        async def _deactivate():
+            device.is_active = False
+        device.deactivate = AsyncMock(side_effect=_deactivate)
+    return device
+
+
+# ── W7 — feedback-free true-surplus addback ──────────────────────────
+
+class TestActiveSurplusDraw:
+    def test_sums_only_active_surplus_devices(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        sc.register_device(_make_device("a", is_active=True, consumption=1200.0))
+        sc.register_device(_make_device("b", is_active=False, consumption=0.0))
+        sc.register_device(_make_device("c", is_active=True, consumption=800.0))
+        assert sc.active_surplus_draw_w() == 2000.0
+
+    def test_excludes_externally_managed_ev(self, mock_hass):
+        # The EV is driven by the decide/actuate path; its draw is already
+        # in grid export and must NOT be re-credited.
+        sc = SurplusController(mock_hass)
+        sc.register_device(
+            _make_device("ev", is_active=True, consumption=4000.0,
+                         managed_externally=True))
+        sc.register_device(_make_device("hp", is_active=True, consumption=1500.0))
+        assert sc.active_surplus_draw_w() == 1500.0
+
+    def test_zero_when_nothing_active(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        sc.register_device(_make_device("a", is_active=False))
+        assert sc.active_surplus_draw_w() == 0.0
+
+
+# ── W2 — peak posture ────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+class TestPeakFreezeActivation:
+    async def test_warning_blocks_new_activation(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        dev = _make_device("hp", min_power=500, is_active=False)
+        sc.register_device(dev)
+        # Plenty of surplus, but WARNING must not add load.
+        await sc.update(3000.0, peak_state=LoadManagementState.WARNING)
+        dev.activate.assert_not_called()
+
+    async def test_normal_state_activates(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        dev = _make_device("hp", min_power=500, is_active=False)
+        sc.register_device(dev)
+        await sc.update(3000.0, peak_state=LoadManagementState.NORMAL)
+        dev.activate.assert_called_once()
+
+    async def test_none_state_is_legacy_behaviour(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        dev = _make_device("hp", min_power=500, is_active=False)
+        sc.register_device(dev)
+        await sc.update(3000.0, peak_state=None)
+        dev.activate.assert_called_once()
+
+    async def test_warning_does_not_shed_existing(self, mock_hass):
+        # WARNING freezes activation but must NOT proactively shed.
+        sc = SurplusController(mock_hass)
+        dev = _make_device("hp", min_power=500, is_active=True, consumption=1500.0)
+        sc.register_device(dev)
+        await sc.update(3000.0, peak_state=LoadManagementState.WARNING)
+        dev.deactivate.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestPeakShed:
+    async def test_shedding_backs_off_one_device(self, mock_hass):
+        # SHEDDING sheds gently — one device per cycle, lowest priority first.
+        sc = SurplusController(mock_hass)
+        hi = _make_device("hp", priority=1, is_active=True, consumption=1500.0)
+        lo = _make_device("boiler", priority=5, is_active=True, consumption=2000.0)
+        sc.register_device(hi)
+        sc.register_device(lo)
+        await sc.update(0.0, peak_state=LoadManagementState.SHEDDING)
+        # Lowest priority (highest number) sheds first; the other survives.
+        lo.deactivate.assert_called_once()
+        hi.deactivate.assert_not_called()
+
+    async def test_emergency_sheds_all_active(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        a = _make_device("a", priority=1, is_active=True, consumption=1500.0)
+        b = _make_device("b", priority=5, is_active=True, consumption=2000.0)
+        sc.register_device(a)
+        sc.register_device(b)
+        await sc.update(0.0, peak_state=LoadManagementState.EMERGENCY)
+        a.deactivate.assert_called_once()
+        b.deactivate.assert_called_once()
+
+    async def test_shedding_skips_peak_only_devices(self, mock_hass):
+        # Only SURPLUS-mode devices are the controller's to shed; a
+        # peak_only device is the load manager's responsibility.
+        sc = SurplusController(mock_hass)
+        po = _make_device("po", priority=5, is_active=True, consumption=2000.0,
+                          control_mode=DeviceControlMode.PEAK_ONLY)
+        sc.register_device(po)
+        await sc.update(0.0, peak_state=LoadManagementState.EMERGENCY)
+        po.deactivate.assert_not_called()
+
+    async def test_shedding_respects_antiflicker(self, mock_hass):
+        sc = SurplusController(mock_hass)
+        dev = _make_device("hp", priority=5, is_active=True, consumption=2000.0,
+                            antiflicker_blocks=True)
+        dev.can_deactivate = MagicMock(return_value=False)
+        sc.register_device(dev)
+        await sc.update(0.0, peak_state=LoadManagementState.EMERGENCY)
+        dev.deactivate.assert_not_called()

--- a/tests/test_config_flow_migration.py
+++ b/tests/test_config_flow_migration.py
@@ -71,7 +71,7 @@ async def test_v1_to_v2_remaps_legacy_battery_priority_soc(hass) -> None:
     # Re-read from the registry, not the local var — the entry registry
     # owns the post-migration truth.
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12  # all hops compose (#446 bumped target)
+    assert updated.version == 13  # all hops compose (#446 bumped target)
     assert updated.data["battery_priority_soc"] == 30
 
 
@@ -261,7 +261,7 @@ async def test_full_chain_v1_to_v7(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     # v1→v2 effect
     assert updated.data["battery_priority_soc"] == 30
     # v2→v3 effect — flat → list
@@ -307,7 +307,7 @@ async def test_v7_to_v8_flips_static_to_percentile_for_dynamic_tariff(hass) -> N
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     assert updated.options["tariff_classification_mode"] == "percentile"
 
 
@@ -329,7 +329,7 @@ async def test_v7_to_v8_keeps_static_when_tariff_mode_is_not_dynamic(hass) -> No
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     assert updated.options["tariff_classification_mode"] == "static"
 
 
@@ -362,7 +362,7 @@ async def test_v8_to_v9_seeds_vehicle_min_current(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     chargers = updated.options["ev_chargers"]
     assert chargers[0]["vehicle_min_current"] is None
     assert chargers[1]["vehicle_min_current"] == 9
@@ -398,7 +398,7 @@ async def test_v9_to_v10_renames_night_initial_current(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     # Top-level legacy global key renamed
     assert "ev_night_initial_current" not in updated.data
     assert updated.data["initial_current"] == 12
@@ -410,17 +410,18 @@ async def test_v9_to_v10_renames_night_initial_current(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_v12_already_current_is_noop(hass) -> None:
-    """An entry already at v12 (the current target) sails through every
+async def test_v13_already_current_is_noop(hass) -> None:
+    """An entry already at v13 (the current target) sails through every
     ``if version < N`` gate untouched."""
     payload_data = {"battery_priority_soc": 30}
     payload_options = {"ev_chargers": [
         {"id": "ev_charger", "charge_mode": "solar_only",
-         "vehicle_min_current": None, "initial_current": 10}
+         "vehicle_min_current": None, "initial_current": 10,
+         "ev_surplus_priority": 5, "ev_shed_priority": 5}
     ]}
     entry = MockConfigEntry(
         domain=DOMAIN,
-        version=12,
+        version=13,
         data=payload_data,
         options=payload_options,
     )
@@ -429,9 +430,42 @@ async def test_v12_already_current_is_noop(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     assert updated.data == payload_data
     assert updated.options == payload_options
+
+
+@pytest.mark.asyncio
+async def test_v12_to_v13_seeds_shed_priority_from_surplus(hass) -> None:
+    """v12 → v13 (#470): each charger's ``ev_shed_priority`` is seeded from
+    its ``ev_surplus_priority`` so the decoupling is behaviour-neutral until
+    the user deliberately diverges them. A charger that already carries an
+    explicit shed priority is left untouched."""
+    payload_options = {"ev_chargers": [
+        {"id": "wb1", "ev_surplus_priority": 2},               # seed → 2
+        {"id": "wb2", "ev_surplus_priority": 4, "ev_shed_priority": 9},  # keep 9
+        {"id": "wb3", "ev_load_priority": 7},                  # legacy alias → 7
+        {"id": "wb4"},                                         # no priority at all
+    ]}
+    entry = MockConfigEntry(
+        domain=DOMAIN, version=12,
+        data={"battery_priority_soc": 30}, options=payload_options,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    updated = hass.config_entries.async_get_entry(entry.entry_id)
+    assert updated.version == 13
+    chargers = {c["id"]: c for c in updated.options["ev_chargers"]}
+    assert chargers["wb1"]["ev_shed_priority"] == 2     # seeded from surplus
+    assert chargers["wb2"]["ev_shed_priority"] == 9     # explicit value preserved
+    assert chargers["wb3"]["ev_shed_priority"] == 7     # seeded from legacy alias
+    # No priority source anywhere → nothing written; runtime fallback
+    # (ev_priority = 3 + idx) covers it. Migration must not crash or invent.
+    assert "ev_shed_priority" not in chargers["wb4"]
+    # Surplus priority itself is never mutated.
+    assert chargers["wb1"]["ev_surplus_priority"] == 2
 
 
 @pytest.mark.asyncio
@@ -462,7 +496,7 @@ async def test_v11_to_v12_drops_stale_global_ev_session_energy_sensor(hass) -> N
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     # Top-level stale key dropped
     assert "ev_session_energy_sensor" not in updated.data
     # Per-charger value preserved untouched
@@ -494,7 +528,7 @@ async def test_v11_to_v12_preserves_top_level_when_no_per_charger_value(hass) ->
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     # Defensive: kept the top-level value because no per-charger override exists
     assert updated.data["ev_session_energy_sensor"] == "sensor.keba_p30_session_energy"
 
@@ -531,7 +565,7 @@ async def test_v10_to_v11_clears_bad_ev_target_type_per_charger(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     chargers = updated.options["ev_chargers"]
     # Bad charger reset to kwh
     assert chargers[0]["ev_target_type"] == "kwh"
@@ -566,7 +600,7 @@ async def test_v10_to_v11_clears_legacy_ev_target_mode(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     assert updated.data["ev_target_mode"] == "kwh"
 
 
@@ -591,5 +625,5 @@ async def test_v10_to_v11_preserves_kwh_mode(hass) -> None:
     assert await async_migrate_entry(hass, entry) is True
 
     updated = hass.config_entries.async_get_entry(entry.entry_id)
-    assert updated.version == 12
+    assert updated.version == 13
     assert updated.options["ev_chargers"][0]["ev_target_type"] == "kwh"

--- a/tests/test_per_charger_seed_migration.py
+++ b/tests/test_per_charger_seed_migration.py
@@ -42,7 +42,7 @@ async def test_seeds_all_eight_from_global():
     )
     assert await async_migrate_entry(hass, entry) is True
     c, kwargs = _seeded_charger(hass)
-    assert kwargs["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
+    assert kwargs["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
     assert c["daily_ev_target"] == 8
     assert c["daily_ev_target_max"] == 50
     assert c["ev_target_soc"] == 70
@@ -99,7 +99,7 @@ async def test_no_chargers_is_safe_and_bumps_version():
     hass = MagicMock()
     entry = _entry(options={}, data={"daily_ev_target": 8})
     assert await async_migrate_entry(hass, entry) is True
-    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 12  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
+    assert hass.config_entries.async_update_entry.call_args.kwargs["version"] == 13  # bumped in v11→v12 (#135)  # bumped in v10→v11 (#446)  # bumped in v9→v10 (#441)  # bumped in v6→v7 (#277 Phase C)  # bumped in v5→v6 (#277 Phase B)  # bumped in v4→v5 (#277)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Two interlocking features the user asked for together (the peak-shed pass and the priority split share the shed-ordering concept).

## #508 phase 2 — heat pump / hot water on the real house surplus

**W7 — true surplus.** The `SurplusController` was fed the EV charging *budget* (`charging_context.available_power`), so heat pump / hot water effectively competed for the EV's allocation. It now receives the **true house surplus**: `grid_export_power + active_surplus_draw_w()`. The add-back is what makes it stable — without it, every device the controller switches on shrinks the grid export it reads next cycle, so the signal chases its own tail and the device flaps. With it, the input is the surplus that *would* exist if the controller's devices were off — the right quantity to allocate from. Externally-managed devices (the EV) are excluded from the add-back (their draw is already in grid export). Net: discretionary loads boost only on genuine spare solar, after the EV and battery take their share.

**W2 — peak posture (throttle / turn off).** The load manager and the surplus controller used to fight: the load manager sheds a heat pump to protect the 15-min peak, then the surplus controller (running later in the same cycle, coordinator ~1943 vs ~2762) sees surplus and switches it straight back on. `update()` now takes `peak_state` (from `self._load_manager.get_state()`):
- `WARNING` → stop *adding* discretionary load (freeze activation + off-peak forcing).
- `SHEDDING` → freeze + back its own active SURPLUS-mode devices off **one per cycle**, gentlest first (reverse priority).
- `EMERGENCY` → shed them all this cycle.

The EV stays owned by the load manager's shed path. Deadline-forced `ScheduleDevice` starts are deliberately **not** gated on peak (a hard commitment, bounded by rated_power) — documented in code.

## #470 — split `ev_surplus_priority` → surplus + shed priority

A single per-charger number drove two unrelated decisions: surplus-allocation order (cooperative, every cycle) and load-shed order (emergency throttle). A mixed fleet can't express both — a long-range EV should charge *first* on surplus yet shed *first* under peak. Now:
- `ev_surplus_priority` keeps the surplus-allocation order (lower = first).
- New per-charger **`ev_shed_priority`** drives the load-manager shed order. **Polarity:** same as the existing load-manager sort (`_get_devices_for_shedding`, `reverse=True` → higher number = shed first) so the default is byte-identical. It falls back to `ev_surplus_priority`, so single-charger / homogeneous fleets are behaviour-identical until you deliberately diverge them.
- **v12 → v13 migration** seeds `ev_shed_priority = ev_surplus_priority` per charger (legacy `ev_load_priority` and global fallbacks honoured).
- Exposed in the **options flow**, the **setup flow**, and as **two per-charger number entities** (surplus + shed priority).

> **Polarity confirmation wanted:** the #470 issue prose says shed_priority "lower = shed first", but the actual load-manager sort is "higher = shed first". I kept the code's polarity (higher = shed first) so defaults don't change behaviour. Flag if you want the issue's polarity instead — it'd mean inverting before the load-manager hand-off.

## Tests & verification
- New `test_508_phase2_surplus_peak.py` — 11 tests (W7 add-back incl. EV exclusion; W2 WARNING-freeze / SHEDDING one-per-cycle / EMERGENCY all / peak_only skip / anti-flicker).
- `test_config_flow_migration.py` — v12→v13 seed test (surplus / explicit / legacy-alias / no-priority cases); existing version assertions bumped 12→13.
- Full suite: **3601 passed, 8 skipped, 0 failed**.
- Reviewer (ruflo-core:reviewer): **APPROVE-WITH-NITS**, all 3 nits actioned, no blockers.
- HA-TEST full clean install: loads clean, no surplus/peak runtime errors, both new number entities present (`number.sem_charger_ev_charger_ev_surplus_priority` + `…_ev_shed_priority`), coordinator healthy.

Refs #508 #470