### PR TITLE
fix(coordinator): #517 per-charger daily energy resets at midnight even when idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## 🔢 Per-charger "today" energy now resets at midnight even when idle (#517)
+
+- **A charger that didn't draw power all day no longer carries yesterday's energy forward** — RienduPre (dual Wallbox) saw "Vandaag" (today) = 81.5 kWh on a charger that wasn't even connected, while the fleet total correctly showed 0. The per-charger daily *rollover/reset* was nested inside the `if charger_power > 0` accumulation guard, so an idle/unplugged charger never executed it and its counter grew across idle days. The reset now runs every cycle for every charger (only the increment stays gated on power); a stored stale value self-heals on the next cycle after update. Single-charger installs were unaffected (they report the correctly-resetting fleet total) (#517)
+
 # [1.7.3-beta.15] - 14.06.2026
 
 ## 🏷️ Config-tab label audit + clearer forecast/EV-priority controls (#514)

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -4452,20 +4452,28 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin, BatteryProtectionMix
                 # counter only rolls over once today's commitment is closed.
                 # Solar charging between sunrise and the deadline accumulates
                 # into yesterday's bucket — harmless, since Min was already hit.
+                # Per-charger daily rollover — MUST run every cycle, even when
+                # the charger draws no power. #517: nesting the reset inside
+                # ``if charger_power > 0`` meant an unplugged/idle charger never
+                # rolled over, so its "today" counter carried yesterday's value
+                # forward indefinitely and grew across idle days (RienduPre saw
+                # 81.5 kWh "Vandaag" on a charger that wasn't even connected,
+                # while the correctly-resetting fleet total showed 0). Only the
+                # INCREMENT is gated on power; the date check / reset is not.
+                cfg_for_cid = (
+                    next((c for c in (self.config.get("ev_chargers") or [])
+                          if c.get("id") == cid), {})
+                ) or {}
+                target_time = self._charger_target_time(cfg_for_cid)
+                ev_day = self.time_manager.get_current_meter_day_offset_based(
+                    target_time
+                ).isoformat()
+                if self._daily_ev_per_charger_date.get(cid) != ev_day:
+                    # Per-charger reset (Car A at 07:00, Car B at 08:00 don't
+                    # disturb each other) — only this cid's bucket rolls over.
+                    self._daily_ev_per_charger[cid] = 0.0
+                    self._daily_ev_per_charger_date[cid] = ev_day
                 if charger_power > 0:
-                    cfg_for_cid = (
-                        next((c for c in (self.config.get("ev_chargers") or [])
-                              if c.get("id") == cid), {})
-                    ) or {}
-                    target_time = self._charger_target_time(cfg_for_cid)
-                    ev_day = self.time_manager.get_current_meter_day_offset_based(
-                        target_time
-                    ).isoformat()
-                    if self._daily_ev_per_charger_date.get(cid) != ev_day:
-                        # Per-charger reset (Car A at 07:00, Car B at 08:00 don't
-                        # disturb each other) — only this cid's bucket rolls over.
-                        self._daily_ev_per_charger[cid] = 0.0
-                        self._daily_ev_per_charger_date[cid] = ev_day
                     increment = charger_power * interval_hours / 1000  # W → kWh
                     self._daily_ev_per_charger[cid] = (
                         self._daily_ev_per_charger.get(cid, 0.0) + increment

--- a/tests/test_517_per_charger_daily_reset.py
+++ b/tests/test_517_per_charger_daily_reset.py
@@ -1,0 +1,87 @@
+"""#517 — per-charger daily EV energy must roll over even when idle.
+
+RienduPre (dual Wallbox) saw "Vandaag" (today) = 81.5 kWh on a charger
+that wasn't even connected, while the fleet total correctly showed 0.
+
+Root cause: in ``SEMCoordinator._update_ev_intelligence`` the per-charger
+daily ROLLOVER (``self._daily_ev_per_charger[cid] = 0.0`` + date stamp)
+was nested inside ``if charger_power > 0:`` together with the increment.
+A charger that drew no power for a day never executed that block, so its
+"today" counter never reset and carried yesterday's value forward,
+growing across idle days.
+
+The fix moves the date-check / reset OUT of the power guard so it runs
+every cycle for every charger; only the INCREMENT stays gated on power.
+
+This is an AST guard (matching the repo's other source lints) — it pins
+that the reset is present AND not gated on ``charger_power > 0``, so the
+regression can't silently return.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_COORD = Path(__file__).resolve().parents[1] / "coordinator" / "coordinator.py"
+
+
+def _method_node(name: str) -> ast.FunctionDef:
+    tree = ast.parse(_COORD.read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} not found in coordinator.py")
+
+
+def _is_per_charger_daily_reset(node: ast.AST) -> bool:
+    """Match ``self._daily_ev_per_charger[<...>] = 0.0`` / ``= 0``."""
+    if not isinstance(node, ast.Assign):
+        return False
+    for tgt in node.targets:
+        if (
+            isinstance(tgt, ast.Subscript)
+            and isinstance(tgt.value, ast.Attribute)
+            and tgt.value.attr == "_daily_ev_per_charger"
+        ):
+            v = node.value
+            if isinstance(v, ast.Constant) and v.value in (0, 0.0):
+                return True
+    return False
+
+
+def _is_power_guard(node: ast.AST) -> bool:
+    """Match ``if charger_power > 0:``."""
+    if not isinstance(node, ast.If) or not isinstance(node.test, ast.Compare):
+        return False
+    left = node.test.left
+    return isinstance(left, ast.Name) and left.id == "charger_power"
+
+
+@pytest.mark.unit
+class TestPerChargerDailyRollover:
+    def test_reset_exists_in_method(self):
+        method = _method_node("_update_ev_intelligence")
+        assert any(_is_per_charger_daily_reset(n) for n in ast.walk(method)), (
+            "the per-charger daily reset (_daily_ev_per_charger[cid] = 0.0) "
+            "vanished from _update_ev_intelligence"
+        )
+
+    def test_reset_not_nested_under_charger_power_guard(self):
+        method = _method_node("_update_ev_intelligence")
+        offenders = []
+        for guard in ast.walk(method):
+            if not _is_power_guard(guard):
+                continue
+            for child in guard.body:
+                for sub in ast.walk(child):
+                    if _is_per_charger_daily_reset(sub):
+                        offenders.append(getattr(sub, "lineno", "?"))
+        assert not offenders, (
+            "#517 regression: the per-charger daily reset is nested inside "
+            f"`if charger_power > 0:` (line(s) {offenders}). An idle/unplugged "
+            "charger would never roll over and its 'today' counter would carry "
+            "yesterday's value forward. Move the date-check/reset OUT of the "
+            "power guard; gate only the increment on power."
+        )


### PR DESCRIPTION
## The bug (#517, RienduPre on beta.15)

A dual-Wallbox user saw **"Vandaag" (today) = 81.5 kWh** on a charger that *wasn't even connected*, while the fleet "Vandaag" correctly showed **0**. The per-charger "today" counter had been accumulating across idle days and never reset.

<img width="400" src="https://github.com/user-attachments/assets/a506ecdb-44b3-4a0d-8729-2e705d710fc6" />

## Root cause

In `SEMCoordinator._update_ev_intelligence`, the per-charger daily **rollover/reset** (`self._daily_ev_per_charger[cid] = 0.0` + date stamp) was nested *inside* `if charger_power > 0:`, together with the energy increment. A charger drawing no power for a day never executed that block, so its bucket never rolled over and carried yesterday's value forward — growing indefinitely across idle days. The **fleet** daily uses a separate, correct path, which is why only the per-charger value was wrong (single-charger installs report the fleet total, so they were never affected).

## Fix

Move the date-check/reset **out** of the power guard so it runs every cycle for every charger; only the *increment* stays gated on `charger_power > 0`. A stored stale value self-heals on the first cycle after update (`stored date != today` → reset to 0).

## Verification
- **Live-proven on HA-TEST**: injected Rien's exact scenario — a **50 kWh phantom** on an idle charger (`ev_charger_1`) with a stale date (2026-06-10) — restarted, and `charger_ev_charger_1_daily_energy` reset to **0.0**.
- New AST regression test (`test_517_per_charger_daily_reset.py`) pins that the reset is present and **not** nested under `if charger_power > 0:`.
- Full suite: **3609 passed, 8 skipped, 0 failed**.

Fixes #517