### PR TITLE
fix(tariff): #518 a configured price sensor no longer silently flips to Nord Pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+## 💶 A configured dynamic price sensor no longer silently flips to Nord Pool (#518)
+
+- **Your chosen price entity stays the source, even on a momentary blip** — when a user configures a dynamic price sensor (`dynamic_tariff_entity`, e.g. a Tibber sensor with VAT/fees), SEM used to *fall through* to auto-detecting another integration whenever that sensor read `unavailable`/`unknown` for a cycle. With the Nord Pool integration also installed, the provider silently switched to `nordpool_official` — a different source with different (tax-free spot) prices and percentile levels, so the schedules/price-levels appeared to flip back and forth (RienduPre, #518). A user-configured price entity is now authoritative: the provider stays `custom` and the cached curve / fallback price covers a transient gap. Auto-detection only runs when no price entity is configured (#518)
+
 ## 🌤️ Weather tile no longer shows "?" / "—°C" when the picked entity has no data (#516)
 
 - **The weather tile now finds a weather entity that actually has current data** — RienduPre's tile showed a "?" condition and "—°C / — % / — km/h" because the dashboard generator picked a `weather.*` entity that carried no `temperature` (a `weather.forecast_*` subentity, or one that was unavailable when the dashboard was generated). The generator now prefers a non-forecast entity that actually has a current temperature, and the card falls back at render time to any usable `weather.*` entity if its configured one is missing / unavailable / data-less — so the tile self-heals without regenerating the dashboard (#516)

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -364,14 +364,18 @@ class DynamicTariffProvider(TariffProvider):
 
         Returns True when fresh prices were stored.
         """
-        # #518: when the user configured their own price entity (e.g. a
-        # Tibber sensor with VAT/fees), do NOT pull the Nord Pool day-ahead
-        # curve even if that integration is installed. Mixing a custom
-        # current price with a Nord Pool curve gave different prices AND
-        # different percentile levels, and relabelled the provider
-        # "nordpool_official" (RienduPre). The custom entity (+ its forecast
-        # attribute / dynamic_forecast_entity) is the single source.
-        if self._user_configured_price:
+        # #518: when the user configured their own price entity that ISN'T a
+        # Nord Pool sensor (e.g. a Tibber sensor with VAT/fees), do NOT pull
+        # the Nord Pool day-ahead curve even if that integration is
+        # installed. Mixing a custom current price with a Nord Pool curve
+        # gave different prices AND percentile levels, and relabelled the
+        # provider "nordpool_official" (RienduPre). The custom entity (+ its
+        # forecast attribute / dynamic_forecast_entity) is the single source.
+        # A user who configured the official Nord Pool ``nord_pool_*`` sensor
+        # DOES need this fetch (that sensor exposes no curve), so it's kept.
+        if self._user_configured_price and not (
+            self._price_entity and "nord_pool" in self._price_entity
+        ):
             return False
         services = getattr(self.hass, "services", None)
         if services is None or not services.has_service(

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -290,6 +290,12 @@ class DynamicTariffProvider(TariffProvider):
         )
         self.currency = currency
         self._price_entity = price_entity
+        # #518: was the price entity EXPLICITLY configured by the user
+        # (``dynamic_tariff_entity``), or will it be auto-discovered? A
+        # user-configured entity is authoritative — its provider must stay
+        # "custom" even on a momentary unavailability, never silently
+        # switching to an auto-detected integration with different prices.
+        self._user_configured_price = bool(price_entity)
         self._provider_name = "unknown"
         self._forecast_entity: Optional[str] = forecast_entity
         self._feedin_entity: Optional[str] = feedin_entity
@@ -470,6 +476,18 @@ class DynamicTariffProvider(TariffProvider):
 
     def detect_provider(self) -> Optional[str]:
         """Auto-detect available price integration."""
+        # #518: a user-configured price entity (``dynamic_tariff_entity``) is
+        # authoritative — keep "custom" even when it momentarily reads
+        # unavailable/unknown. The previous code fell THROUGH to the
+        # auto-detect scan below on a transient blip, so a brief Tibber
+        # outage silently swapped the provider to "nordpool_official" (a
+        # different source with different prices/levels) — RienduPre's
+        # "schemas/prices/levels are very different" symptom. The cached
+        # curve / fallback price covers the gap; the source must not change.
+        if self._user_configured_price:
+            self._provider_name = "custom"
+            return "custom"
+
         if self._price_entity:
             state = self.hass.states.get(self._price_entity)
             if state and state.state not in ("unknown", "unavailable"):

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -296,7 +296,10 @@ class DynamicTariffProvider(TariffProvider):
         # "custom" even on a momentary unavailability, never silently
         # switching to an auto-detected integration with different prices.
         self._user_configured_price = bool(price_entity)
-        self._provider_name = "unknown"
+        # Start "custom" when the user configured a price entity: the label
+        # must not depend on whether detect_provider() / the Nord Pool
+        # service fetch happens to run first (#518).
+        self._provider_name = "custom" if self._user_configured_price else "unknown"
         self._forecast_entity: Optional[str] = forecast_entity
         self._feedin_entity: Optional[str] = feedin_entity
         self._prices_cache: List[PricePoint] = []
@@ -361,6 +364,15 @@ class DynamicTariffProvider(TariffProvider):
 
         Returns True when fresh prices were stored.
         """
+        # #518: when the user configured their own price entity (e.g. a
+        # Tibber sensor with VAT/fees), do NOT pull the Nord Pool day-ahead
+        # curve even if that integration is installed. Mixing a custom
+        # current price with a Nord Pool curve gave different prices AND
+        # different percentile levels, and relabelled the provider
+        # "nordpool_official" (RienduPre). The custom entity (+ its forecast
+        # attribute / dynamic_forecast_entity) is the single source.
+        if self._user_configured_price:
+            return False
         services = getattr(self.hass, "services", None)
         if services is None or not services.has_service(
             "nordpool", "get_prices_for_date",

--- a/tests/test_tariff_provider.py
+++ b/tests/test_tariff_provider.py
@@ -176,6 +176,40 @@ class TestDynamicTariffProvider:
         result = provider.detect_provider()
         assert result == "nordpool"
 
+    def test_user_price_stays_custom_when_unavailable(self, mock_hass):
+        """#518: a user-configured price entity must keep provider='custom'
+        even when it momentarily reads unavailable — it must NOT fall through
+        to auto-detect a different integration. RienduPre's Tibber sensor
+        intermittently flipped to 'nordpool_official' (different prices) on a
+        transient blip."""
+        unavail = MagicMock()
+        unavail.state = "unavailable"
+        mock_hass.states.get = MagicMock(return_value=unavail)
+        # A Nord Pool entity IS present — the tempting (wrong) fallback.
+        nordpool = MagicMock()
+        nordpool.entity_id = "sensor.nord_pool_nl_current_price"
+        nordpool.attributes = {}
+        mock_hass.states.async_all = MagicMock(return_value=[nordpool])
+
+        provider = DynamicTariffProvider(mock_hass, price_entity="sensor.my_tibber")
+        assert provider.detect_provider() == "custom"
+        assert provider._provider_name == "custom"
+
+    def test_no_user_price_autodetects_nordpool_official(self, mock_hass):
+        """The #518 fix must NOT break auto-detection — without a configured
+        price entity, the official Nord Pool core integration is still
+        detected as 'nordpool_official'."""
+        nordpool = MagicMock()
+        nordpool.entity_id = "sensor.nord_pool_nl_current_price"
+        nordpool.attributes = {}
+        other = MagicMock(); other.entity_id = "sensor.x"; other.attributes = {}
+        mock_hass.states.get = MagicMock(return_value=None)
+        mock_hass.states.async_all = MagicMock(
+            side_effect=lambda d: {"sensor": [other, nordpool]}.get(d, []))
+
+        provider = DynamicTariffProvider(mock_hass)  # no price_entity
+        assert provider.detect_provider() == "nordpool_official"
+
     def test_classify_price_negative(self, mock_hass):
         provider = DynamicTariffProvider(mock_hass)
         assert provider._classify_price(-0.05) == PriceLevel.NEGATIVE

--- a/tests/test_tariff_provider.py
+++ b/tests/test_tariff_provider.py
@@ -210,6 +210,26 @@ class TestDynamicTariffProvider:
         provider = DynamicTariffProvider(mock_hass)  # no price_entity
         assert provider.detect_provider() == "nordpool_official"
 
+    def test_provider_name_custom_from_init(self, mock_hass):
+        """#518: a user-configured price entity makes _provider_name 'custom'
+        from construction, so the Nord Pool service fetch (which only
+        relabels when name=='unknown') can't override it."""
+        provider = DynamicTariffProvider(mock_hass, price_entity="sensor.my_tibber")
+        assert provider._provider_name == "custom"
+        provider2 = DynamicTariffProvider(mock_hass)  # auto-detect path
+        assert provider2._provider_name == "unknown"
+
+    @pytest.mark.asyncio
+    async def test_service_fetch_skipped_when_user_configured(self, mock_hass):
+        """#518: don't pull the Nord Pool day-ahead curve when the user
+        configured their own price entity, even if Nord Pool is installed —
+        that mixed sources and relabelled the provider."""
+        mock_hass.services = MagicMock()
+        mock_hass.services.has_service = MagicMock(return_value=True)
+        provider = DynamicTariffProvider(mock_hass, price_entity="sensor.my_tibber")
+        assert await provider.async_refresh_service_prices() is False
+        mock_hass.services.has_service.assert_not_called()  # returned before the nordpool check
+
     def test_classify_price_negative(self, mock_hass):
         provider = DynamicTariffProvider(mock_hass)
         assert provider._classify_price(-0.05) == PriceLevel.NEGATIVE


### PR DESCRIPTION
## The bug (#518, RienduPre on beta.15)

With a dynamic price sensor configured (his Tibber sensor, incl. VAT/fees) **and** the Nord Pool integration installed, SEM's provider/prices/levels flipped between two sources — the schedules and price-levels were "very different" depending on the moment.

## Root cause

`detect_provider()` (`tariff/tariff_provider.py`) only returned `"custom"` for the user's configured entity **when its state was currently valid**:
```python
if self._price_entity:
    state = self.hass.states.get(self._price_entity)
    if state and state.state not in ("unknown", "unavailable"):
        return "custom"
# ↓ otherwise FALLS THROUGH to auto-detect Tibber/Amber/Octopus/Nord Pool
#   → "nordpool_official" (different prices, tax-free spot, different levels)
```
So a one-cycle Tibber blip silently swapped the provider — and the entire price curve + percentile levels — to Nord Pool.

## Fix

Track whether the price entity was **user-configured** (`_user_configured_price = bool(price_entity)`). If so, `detect_provider()` keeps `"custom"` unconditionally — never falling through to a different integration. The cached curve / fallback price covers a transient unavailability. Auto-detection only runs when **no** price entity is configured.

## Verification
- Reproduced on HA-TEST with the **Nord Pool core integration installed** (NL/EUR) — confirmed the detection mechanism (`nordpool_official`).
- Regression tests: configured-but-unavailable stays `custom` (not `nordpool_official`); no-configured-entity still auto-detects `nordpool_official`. 77 tariff tests green.

Fixes #518