### PR TITLE
fix: make battery discharge controls fail closed

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,13 +54,11 @@ jobs:
       - name: Coverage summary
         if: always()
         working-directory: /tmp/ha-config
-        env:
-          PYTHONPATH: /tmp/ha-config
         run: |
-          python -m pytest custom_components/solar_energy_management/tests/ \
-            --cov=custom_components.solar_energy_management \
-            --cov-report=term \
-            -q --no-header 2>&1 | tail -30 || true
+          # The preceding pytest run already created .coverage.  Re-running the
+          # entire suite here doubled CI time and could leave PR checks stuck in
+          # this informational step for hours.
+          python -m coverage report --format=markdown --skip-empty
 
   card-test:
     # Dashboard-card JS unit tests (no browser): guards the load-device

--- a/coordinator/actuate_battery.py
+++ b/coordinator/actuate_battery.py
@@ -15,6 +15,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from .charger_types import BatteryIntent
+from .power_control import prepare_power_setpoint
 
 if TYPE_CHECKING:  # pragma: no cover
     from .battery_adapters.base import BatteryControlAdapter
@@ -128,6 +129,15 @@ async def restore_discharge_limit_on_startup(hass, config: dict) -> None:
     past ``decide_battery``'s NORMAL intent. This unconditionally pushes
     the configured max on startup.
     """
+    # Observer mode is a hard read-only boundary. Startup restoration used to
+    # bypass the normal per-cycle observer gate and could therefore write to
+    # hardware before the observer switch had been synchronised.
+    if config.get("observer_mode", False):
+        _LOGGER.info(
+            "Startup: observer mode active — battery discharge restore skipped"
+        )
+        return
+
     max_discharge = config.get("battery_max_discharge_power", 5000)
 
     # #691 — a multi-battery install carries PER-battery control entities
@@ -144,24 +154,24 @@ async def restore_discharge_limit_on_startup(hass, config: dict) -> None:
         entities.extend(e for e in per_battery if e)
 
     for control_entity in dict.fromkeys(entities):
-        current_state = hass.states.get(control_entity)
-        if current_state is None:
+        prepared = prepare_power_setpoint(hass, control_entity, max_discharge)
+        if prepared is None:
             continue
 
-        try:
-            current_limit = float(current_state.state)
-        except (ValueError, TypeError):
-            continue
-
-        if current_limit < max_discharge:
+        if prepared.current_value < prepared.value:
             await hass.services.async_call(
-                "number", "set_value",
-                {"entity_id": control_entity, "value": max_discharge},
+                prepared.domain, "set_value",
+                {"entity_id": control_entity, "value": prepared.value},
                 blocking=True,
             )
             _LOGGER.info(
-                "Startup: restored battery discharge limit on %s from %dW to %dW",
-                control_entity, int(current_limit), max_discharge,
+                "Startup: restored battery discharge limit on %s from %.3f%s "
+                "to %.3f%s",
+                control_entity,
+                prepared.current_value,
+                prepared.unit,
+                prepared.value,
+                prepared.unit,
             )
 
 

--- a/coordinator/battery_adapters/generic.py
+++ b/coordinator/battery_adapters/generic.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import logging
 
 from ..charger_types import BatteryIntent
+from ..power_control import async_write_power_setpoint
 from .base import BatteryControlAdapter
 
 _LOGGER = logging.getLogger(__name__)
@@ -280,21 +281,10 @@ class GenericBatteryAdapter(BatteryControlAdapter):
         if not self._discharge_control_entity:
             self._last_discharge_limit_w = watts
             return
-        # #531: domain-aware like _write_force_discharge — a user may point the
-        # discharge-limit at an ``input_number.*`` helper (common on HA-TEST
-        # rigs / DIY setups), which would 404 on the hardcoded ``number``
-        # domain. Both expose ``set_value``.
-        domain = self._discharge_control_entity.split(".", 1)[0]
-        if domain not in ("number", "input_number"):
-            domain = "number"
-        try:
-            await self._hass.services.async_call(
-                domain, "set_value",
-                {"entity_id": self._discharge_control_entity, "value": watts},
-                blocking=True,
-            )
+        if await async_write_power_setpoint(
+            self._hass,
+            self._discharge_control_entity,
+            watts,
+            context="Generic battery discharge limit",
+        ):
             self._last_discharge_limit_w = watts
-        except Exception as e:  # noqa: BLE001
-            _LOGGER.warning(
-                "Generic battery: failed to set discharge limit: %s", e,
-            )

--- a/coordinator/battery_adapters/goodwe.py
+++ b/coordinator/battery_adapters/goodwe.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import logging
 
 from ..charger_types import BatteryIntent
+from ..power_control import async_write_power_setpoint
 from .base import BatteryControlAdapter
 
 _LOGGER = logging.getLogger(__name__)
@@ -83,14 +84,10 @@ class GoodWeBatteryAdapter(BatteryControlAdapter):
         if not self._discharge_control_entity:
             self._last_discharge_limit_w = watts
             return
-        try:
-            await self._hass.services.async_call(
-                "number", "set_value",
-                {"entity_id": self._discharge_control_entity, "value": watts},
-                blocking=True,
-            )
+        if await async_write_power_setpoint(
+            self._hass,
+            self._discharge_control_entity,
+            watts,
+            context="GoodWe battery discharge limit",
+        ):
             self._last_discharge_limit_w = watts
-        except Exception as e:  # noqa: BLE001
-            _LOGGER.warning(
-                "GoodWe battery: failed to set discharge limit: %s", e,
-            )

--- a/coordinator/battery_adapters/huawei.py
+++ b/coordinator/battery_adapters/huawei.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 
 from ..charger_types import BatteryIntent
+from ..power_control import async_write_power_setpoint, prepare_power_setpoint
 from .base import BatteryControlAdapter
 
 _LOGGER = logging.getLogger(__name__)
@@ -452,28 +453,25 @@ class HuaweiBatteryAdapter(BatteryControlAdapter):
         # next polls it (~30-60s / 1-2 SEM cycles); the next cycle sees the
         # divergence and re-asserts. Bounded, and acceptable vs the per-cycle
         # Modbus flooding this guard removes.
-        st = self._hass.states.get(self._discharge_control_entity)
-        if st is not None:
-            try:
-                if abs(float(st.state) - watts) < 1.0:
-                    self._last_discharge_limit_w = watts
-                    return
-            except (TypeError, ValueError):
-                pass
-        try:
-            await self._hass.services.async_call(
-                "number", "set_value",
-                {"entity_id": self._discharge_control_entity, "value": watts},
-                blocking=True,
-            )
+        prepared = prepare_power_setpoint(
+            self._hass, self._discharge_control_entity, watts
+        )
+        if prepared is None:
+            return
+        tolerance = 1.0 / prepared.scale_to_watts
+        if abs(prepared.current_value - prepared.value) < tolerance:
+            self._last_discharge_limit_w = watts
+            return
+        if await async_write_power_setpoint(
+            self._hass,
+            self._discharge_control_entity,
+            watts,
+            context="Huawei battery discharge limit",
+        ):
             self._last_discharge_limit_w = watts
             _LOGGER.debug(
                 "Huawei battery: discharge limit %.0f W → %s",
                 watts, self._discharge_control_entity,
-            )
-        except Exception as e:  # noqa: BLE001
-            _LOGGER.warning(
-                "Huawei battery: failed to set discharge limit: %s", e,
             )
 
     def _autodetect_battery_device(self) -> str | None:

--- a/coordinator/power_control.py
+++ b/coordinator/power_control.py
@@ -7,6 +7,7 @@ so current, percentage, unavailable, and out-of-range controls fail closed.
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 
@@ -124,6 +125,14 @@ def prepare_power_setpoint(
             entity_id,
         )
         return None
+    if not all(math.isfinite(value) for value in (
+        current_value, native_value, scale_to_watts,
+    )):
+        _LOGGER.warning(
+            "Battery power control %s rejected: non-finite state or setpoint",
+            entity_id,
+        )
+        return None
 
     attrs = getattr(state, "attributes", None)
     if isinstance(attrs, Mapping):
@@ -139,6 +148,13 @@ def prepare_power_setpoint(
                 bound = float(raw_bound)
             except (TypeError, ValueError, OverflowError):
                 continue
+            if not math.isfinite(bound):
+                _LOGGER.warning(
+                    "Battery power control %s rejected: non-finite %s bound",
+                    entity_id,
+                    key,
+                )
+                return None
             if compare(native_value, bound):
                 _LOGGER.warning(
                     "Battery power control %s rejected: %.3f is outside %s=%s",

--- a/coordinator/power_control.py
+++ b/coordinator/power_control.py
@@ -1,0 +1,191 @@
+"""Safe battery power-control writes.
+
+SEM decisions use watts while Home Assistant number entities may expose another
+native unit. Every automatic discharge-limit write passes through this module
+so current, percentage, unavailable, and out-of-range controls fail closed.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from .units import (
+    is_battery_control_power_unit,
+    normalize_unit,
+    power_unit_scale,
+)
+
+_LOGGER = logging.getLogger(__name__)
+_UNREADABLE_STATES = {"unknown", "unavailable", "none", ""}
+
+
+@dataclass(frozen=True)
+class PreparedPowerSetpoint:
+    """A validated Home Assistant native-unit setpoint."""
+
+    domain: str
+    value: float
+    current_value: float
+    scale_to_watts: float
+    unit: str
+
+
+def _looks_like_current(entity_id: str) -> bool:
+    name = entity_id.lower()
+    return "current" in name or "ampere" in name or name.endswith("_amps")
+
+
+def _native_power_scale(
+    hass,
+    entity_id: str,
+    *,
+    require_explicit_unit: bool = False,
+) -> float | None:
+    """Return native-unit-to-watts scale, or ``None`` when unsafe."""
+    state = hass.states.get(entity_id)
+    if state is None:
+        return None
+
+    raw_state = str(getattr(state, "state", "")).strip().lower()
+    if raw_state in _UNREADABLE_STATES:
+        return None
+
+    attrs = getattr(state, "attributes", None)
+    if not isinstance(attrs, Mapping):
+        # Lightweight legacy test doubles and helper-like entities may not
+        # expose a real attributes mapping. Keep the historical base-unit
+        # assumption while still blocking obvious current-register names.
+        return None if _looks_like_current(entity_id) else 1.0
+
+    unit = normalize_unit(state)
+    if unit:
+        if not is_battery_control_power_unit(state):
+            _LOGGER.warning(
+                "Battery power control %s rejected: unit %r is not a supported "
+                "power-control unit",
+                entity_id,
+                attrs.get("unit_of_measurement"),
+            )
+            return None
+        return power_unit_scale(state)
+
+    if require_explicit_unit or _looks_like_current(entity_id):
+        _LOGGER.warning(
+            "Battery power control %s rejected: explicit power unit required",
+            entity_id,
+        )
+        return None
+
+    # Unitless number helpers have historically meant watts when explicitly
+    # selected by the user. Preserve that supported configuration.
+    return 1.0
+
+
+def is_valid_power_control_entity(
+    hass,
+    entity_id: str,
+    *,
+    require_explicit_unit: bool = False,
+) -> bool:
+    """Return whether a live entity is safe for a battery power setpoint."""
+    return _native_power_scale(
+        hass,
+        entity_id,
+        require_explicit_unit=require_explicit_unit,
+    ) is not None
+
+
+def prepare_power_setpoint(
+    hass,
+    entity_id: str,
+    watts: float,
+    *,
+    require_explicit_unit: bool = False,
+) -> PreparedPowerSetpoint | None:
+    """Validate and convert a watt request to the entity's native unit."""
+    scale_to_watts = _native_power_scale(
+        hass,
+        entity_id,
+        require_explicit_unit=require_explicit_unit,
+    )
+    if scale_to_watts is None:
+        return None
+
+    state = hass.states.get(entity_id)
+    if state is None:  # defensive; _native_power_scale already checked
+        return None
+    try:
+        current_value = float(state.state)
+        native_value = float(watts) / scale_to_watts
+    except (TypeError, ValueError, OverflowError):
+        _LOGGER.warning(
+            "Battery power control %s rejected: unreadable state or setpoint",
+            entity_id,
+        )
+        return None
+
+    attrs = getattr(state, "attributes", None)
+    if isinstance(attrs, Mapping):
+        bounds = (
+            ("min", lambda value, bound: value < bound),
+            ("max", lambda value, bound: value > bound),
+        )
+        for key, compare in bounds:
+            raw_bound = attrs.get(key)
+            if raw_bound is None:
+                continue
+            try:
+                bound = float(raw_bound)
+            except (TypeError, ValueError, OverflowError):
+                continue
+            if compare(native_value, bound):
+                _LOGGER.warning(
+                    "Battery power control %s rejected: %.3f is outside %s=%s",
+                    entity_id,
+                    native_value,
+                    key,
+                    raw_bound,
+                )
+                return None
+
+    domain = entity_id.split(".", 1)[0]
+    if domain not in {"number", "input_number"}:
+        _LOGGER.warning(
+            "Battery power control %s rejected: unsupported domain %s",
+            entity_id,
+            domain,
+        )
+        return None
+
+    return PreparedPowerSetpoint(
+        domain=domain,
+        value=native_value,
+        current_value=current_value,
+        scale_to_watts=scale_to_watts,
+        unit=normalize_unit(state),
+    )
+
+
+async def async_write_power_setpoint(
+    hass,
+    entity_id: str,
+    watts: float,
+    *,
+    context: str,
+) -> bool:
+    """Validate, convert, and write a watt setpoint. Return success."""
+    prepared = prepare_power_setpoint(hass, entity_id, watts)
+    if prepared is None:
+        return False
+    try:
+        await hass.services.async_call(
+            prepared.domain,
+            "set_value",
+            {"entity_id": entity_id, "value": prepared.value},
+            blocking=True,
+        )
+    except Exception as err:  # noqa: BLE001 - HA service exceptions vary
+        _LOGGER.warning("%s: failed to set %s: %s", context, entity_id, err)
+        return False
+    return True

--- a/coordinator/units.py
+++ b/coordinator/units.py
@@ -155,3 +155,17 @@ def is_power_unit(state_or_unit) -> bool:
     """
     unit = _unit_of(state_or_unit)
     return bool(unit) and unit in _POWER_TO_W
+
+
+def is_battery_control_power_unit(state_or_unit) -> bool:
+    """True for units safe for a battery power setpoint (W or kW only).
+
+    MW/GW are valid power *sensor* units but implausible control scales for the
+    residential inverter APIs supported by SEM. Keeping this policy beside the
+    canonical unit tables prevents another inline normalization copy (#641).
+    """
+    unit = _unit_of(state_or_unit)
+    return unit in {
+        "w", "watt", "watts",
+        "kw", "kilowatt", "kilowatts",
+    }

--- a/hardware_detection.py
+++ b/hardware_detection.py
@@ -1341,6 +1341,22 @@ def discover_inverter_from_registry(
     if not same_integration:
         return None
 
+    # A name match is not sufficient: Deye/ha-solarman exposes e.g.
+    # ``number.inverter_battery_max_discharging_current`` in amperes. Older
+    # discovery treated that as a watt setpoint and startup could write a
+    # configured watt maximum into a 0..350 A register. Auto-detection must
+    # therefore require a live W/kW control entity.
+    from .coordinator.power_control import is_valid_power_control_entity
+
+    same_integration = [
+        eid for eid in same_integration
+        if is_valid_power_control_entity(
+            hass, eid, require_explicit_unit=True
+        )
+    ]
+    if not same_integration:
+        return None
+
     # Score each candidate against the patterns; first hit wins. Prefer
     # entity IDs containing "batter" when multiple match the same pattern.
     def _score(eid: str) -> int:

--- a/tests/test_532_huawei_orphan_forcible.py
+++ b/tests/test_532_huawei_orphan_forcible.py
@@ -272,10 +272,10 @@ async def test_limit_skips_when_entity_already_at_target():
 
 
 @pytest.mark.asyncio
-async def test_writes_when_entity_state_unknown():
-    """Unknown/unavailable state → re-assert (write), never silently skip."""
+async def test_skips_when_entity_state_unknown():
+    """Unknown state fails closed instead of issuing a blind hardware write."""
     h = _hass_huawei(forcible_state="Stopped")
     h.states.get = MagicMock(return_value=_fake_state("number.lim", "unknown"))
     a = _adapter(h)
     await a.command_normal()
-    assert _LIMIT in _calls(h), "unknown state → write to be safe"
+    assert _LIMIT not in _calls(h), "unknown state → no blind write"

--- a/tests/test_battery_charge_scheduler.py
+++ b/tests/test_battery_charge_scheduler.py
@@ -1415,15 +1415,26 @@ class TestShellRetirement624:
 class TestStartupRestoreRelocated624:
     """The BatteryProtectionMixin's one job, relocated to actuate_battery."""
 
-    async def _run(self, state_value, control_entity="number.limit", max_w=5000):
+    async def _run(
+        self,
+        state_value,
+        control_entity="number.limit",
+        max_w=5000,
+        *,
+        attributes=None,
+        observer_mode=False,
+    ):
         from custom_components.solar_energy_management.coordinator.actuate_battery import (
-            restore_discharge_limit_on_startup)
+            restore_discharge_limit_on_startup,
+        )
         hass = MagicMock()
         hass.services.async_call = AsyncMock()
         st = MagicMock(); st.state = state_value
+        st.attributes = attributes or {}
         hass.states.get = MagicMock(return_value=st if state_value is not None else None)
         cfg = {"battery_discharge_control_entity": control_entity,
-               "battery_max_discharge_power": max_w}
+               "battery_max_discharge_power": max_w,
+               "observer_mode": observer_mode}
         await restore_discharge_limit_on_startup(hass, cfg)
         return hass
 
@@ -1445,3 +1456,32 @@ class TestStartupRestoreRelocated624:
     async def test_unreadable_state_noop(self):
         hass = await self._run("unavailable")
         hass.services.async_call.assert_not_awaited()
+
+    async def test_observer_mode_never_writes_stale_limit(self):
+        """Observer mode is a hard read-only boundary, including startup."""
+        hass = await self._run(
+            "1200",
+            attributes={"unit_of_measurement": "W", "min": 0, "max": 12000},
+            observer_mode=True,
+        )
+        hass.services.async_call.assert_not_awaited()
+
+    async def test_ampere_entity_rejected_without_write(self):
+        """Deye max-discharging-current is A, never a watt setpoint."""
+        hass = await self._run(
+            "185",
+            control_entity="number.inverter_battery_max_discharging_current",
+            max_w=12000,
+            attributes={"unit_of_measurement": "A", "min": 0, "max": 350},
+        )
+        hass.services.async_call.assert_not_awaited()
+
+    async def test_kw_entity_scales_watts_and_checks_native_range(self):
+        hass = await self._run(
+            "1.2",
+            max_w=5000,
+            attributes={"unit_of_measurement": "kW", "min": 0, "max": 12},
+        )
+        hass.services.async_call.assert_awaited_once()
+        args = hass.services.async_call.await_args
+        assert args.args[2]["value"] == 5.0

--- a/tests/test_battery_modes_523.py
+++ b/tests/test_battery_modes_523.py
@@ -225,9 +225,9 @@ def test_off_mode_beats_scheduler_arbitrage_and_protection():
 
 
 @pytest.mark.asyncio
-async def test_command_off_one_time_handoff_then_silent():
-    # First off cycle after SEM was controlling → one clean command_normal
-    # (clear force, release strategy, un-limit). Subsequent cycles: silent.
+async def test_command_off_missing_control_state_fails_closed_then_silent():
+    # A missing control entity cannot be validated, so the first OFF handoff
+    # must not issue a blind set_value. Subsequent cycles remain silent.
     from unittest.mock import AsyncMock, MagicMock
     from custom_components.solar_energy_management.coordinator.battery_adapters.generic import (
         GenericBatteryAdapter,
@@ -241,8 +241,7 @@ async def test_command_off_one_time_handoff_then_silent():
     gen._last_intent = BatteryIntent.FORCE_DISCHARGE  # was controlling
     await gen.command_off()
     assert gen.last_intent is BatteryIntent.OFF
-    first = hass.services.async_call.await_count
-    assert first > 0  # one-time handoff issued service calls
+    assert hass.services.async_call.await_count == 0
     hass.services.async_call.reset_mock()
     await gen.command_off()  # already off → silent
     assert hass.services.async_call.await_count == 0

--- a/tests/test_battery_review_fixes.py
+++ b/tests/test_battery_review_fixes.py
@@ -117,3 +117,50 @@ def test_decide_battery_now_in_window_uses_is_active_now():
     assert _now_in_window(view) is False
     view.scheduler_decision.schedule = NightChargeSchedule(slots=[_slot(-0.2, 1.0)])
     assert _now_in_window(view) is True
+
+
+# ── Deye safety: adapter writes remain power-unit aware ──────────────────
+
+@pytest.mark.asyncio
+async def test_generic_adapter_rejects_ampere_discharge_entity():
+    from custom_components.solar_energy_management.coordinator.battery_adapters.generic import (
+        GenericBatteryAdapter,
+    )
+
+    hass = _hass()
+    state = MagicMock()
+    state.state = "185"
+    state.attributes = {"unit_of_measurement": "A", "min": 0, "max": 350}
+    hass.states.get = MagicMock(return_value=state)
+    adapter = GenericBatteryAdapter(hass, {
+        "battery_discharge_control_entity": (
+            "number.inverter_battery_max_discharging_current"
+        ),
+        "battery_max_discharge_power": 12000,
+    })
+
+    await adapter.command_normal()
+
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_generic_adapter_scales_watts_for_kw_entity():
+    from custom_components.solar_energy_management.coordinator.battery_adapters.generic import (
+        GenericBatteryAdapter,
+    )
+
+    hass = _hass()
+    state = MagicMock()
+    state.state = "1.2"
+    state.attributes = {"unit_of_measurement": "kW", "min": 0, "max": 12}
+    hass.states.get = MagicMock(return_value=state)
+    adapter = GenericBatteryAdapter(hass, {
+        "battery_discharge_control_entity": "number.battery_discharge_power",
+        "battery_max_discharge_power": 5000,
+    })
+
+    await adapter.command_normal()
+
+    hass.services.async_call.assert_awaited_once()
+    assert hass.services.async_call.await_args.args[2]["value"] == 5.0

--- a/tests/test_battery_review_fixes.py
+++ b/tests/test_battery_review_fixes.py
@@ -164,3 +164,70 @@ async def test_generic_adapter_scales_watts_for_kw_entity():
 
     hass.services.async_call.assert_awaited_once()
     assert hass.services.async_call.await_args.args[2]["value"] == 5.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("target_w", [float("nan"), float("inf"), -float("inf")])
+async def test_power_control_rejects_non_finite_target(target_w):
+    from custom_components.solar_energy_management.coordinator.power_control import (
+        async_write_power_setpoint,
+    )
+
+    hass = _hass()
+    state = MagicMock()
+    state.state = "1200"
+    state.attributes = {"unit_of_measurement": "W", "min": 0, "max": 12000}
+    hass.states.get = MagicMock(return_value=state)
+
+    assert await async_write_power_setpoint(
+        hass, "number.battery_discharge_power", target_w, context="test",
+    ) is False
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("current", ["nan", "inf", "-inf"])
+async def test_power_control_rejects_non_finite_current_state(current):
+    from custom_components.solar_energy_management.coordinator.power_control import (
+        async_write_power_setpoint,
+    )
+
+    hass = _hass()
+    state = MagicMock()
+    state.state = current
+    state.attributes = {"unit_of_measurement": "W", "min": 0, "max": 12000}
+    hass.states.get = MagicMock(return_value=state)
+
+    assert await async_write_power_setpoint(
+        hass, "number.battery_discharge_power", 5000, context="test",
+    ) is False
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("key", "bound"), [
+    ("min", float("nan")),
+    ("max", float("nan")),
+    ("min", -float("inf")),
+    ("max", float("inf")),
+])
+async def test_power_control_rejects_non_finite_bounds(key, bound):
+    from custom_components.solar_energy_management.coordinator.power_control import (
+        async_write_power_setpoint,
+    )
+
+    hass = _hass()
+    state = MagicMock()
+    state.state = "1200"
+    state.attributes = {
+        "unit_of_measurement": "W",
+        "min": 0,
+        "max": 12000,
+        key: bound,
+    }
+    hass.states.get = MagicMock(return_value=state)
+
+    assert await async_write_power_setpoint(
+        hass, "number.battery_discharge_power", 5000, context="test",
+    ) is False
+    hass.services.async_call.assert_not_awaited()

--- a/tests/test_hardware_detection.py
+++ b/tests/test_hardware_detection.py
@@ -697,6 +697,36 @@ class TestDiscoverInverterFromRegistry:
             result = discover_inverter_from_registry(hass, cfg)
         assert result == "number.deye_battery_discharge_limit"
 
+    def test_solarman_deye_current_entity_is_not_power_control(self):
+        """Do not mistake Deye's ampere register for a watt setpoint."""
+        from custom_components.solar_energy_management.hardware_detection import (
+            discover_inverter_from_registry,
+        )
+
+        hass = MagicMock()
+        amp_state = MagicMock()
+        amp_state.state = "185"
+        amp_state.attributes = {
+            "unit_of_measurement": "A",
+            "min": 0,
+            "max": 350,
+        }
+        hass.states.get = MagicMock(return_value=amp_state)
+        entries = [
+            _make_registry_entry("sensor.inverter_battery_power", "solarman"),
+            _make_registry_entry(
+                "number.inverter_battery_max_discharging_current", "solarman"
+            ),
+        ]
+        cfg = _FakeEnergyDashboardConfig(
+            battery_power="sensor.inverter_battery_power"
+        )
+
+        with self._patch_registry(entries):
+            result = discover_inverter_from_registry(hass, cfg)
+
+        assert result is None
+
     def test_growatt_discharge_entity(self):
         """Growatt discharge control entity should be detected."""
         from custom_components.solar_energy_management.hardware_detection import (


### PR DESCRIPTION
## Problem

SEM restored a configured battery discharge maximum during startup even when Observer Mode was enabled. Inverter auto-discovery also selected `number` entities by name without proving that they represented power.

With Deye/ha-solarman, this could select `number.inverter_battery_max_discharging_current` (A, max 350) and feed it a watt value such as 5,000 or 12,000. A disabled, unavailable, unitless, percentage, current, out-of-range, or otherwise incompatible control must fail closed and must never cause a service call.

## Fix

- make startup discharge-limit restoration a hard no-op in Observer Mode
- require a live, explicitly unit-labelled W/kW entity for automatic inverter control discovery
- centralize validation and W↔kW conversion for Generic, GoodWe, and Huawei discharge-limit writes
- reject unavailable/unknown entities, unsupported domains, A/%/unknown units, out-of-range targets, and non-finite values (`NaN`/`±Infinity`)
- preserve explicitly configured unitless `input_number` helpers as legacy watt controls
- update cached “last applied” values only after a successful validated write
- fix the relative import used by startup actuation
- make the coverage-summary step read the existing `.coverage` data instead of running the complete suite a second time

## Safety properties / regression coverage

- Observer Mode performs no startup write
- Deye/ha-solarman current controls are not auto-selected as watt controls
- missing, disabled, unavailable, unknown, A, %, unknown-unit, non-finite, and out-of-range controls produce no service call
- W decisions are scaled correctly before comparison and write to kW entities
- Generic, GoodWe, Huawei, and startup paths use the same fail-closed validation
- non-finite current state, target, minimum, or maximum bounds are rejected explicitly

## Verification

Final commit: `666b9a998ae0abcc46081bd73c47787eaeacddef`

- changed/regression-adjacent selection: **272 passed**
- complete Python 3.12 suite with the CI coverage flags: **5,476 passed, 2 skipped, 0 failed** in 14:33
- the four lifecycle tests that exceeded an additional local 60 s diagnostic timeout were rerun without that non-CI limit: **4/4 passed** (~70 s each)
- previous GitHub matrix on the functional fix: Python 3.12, Python 3.13, card tests, HACS Validation, and Hassfest all passed
- `git diff --check`: passed
- Python 3.12 compilation of every changed production/test module: passed
- workflow YAML parse and practical `coverage report --format=markdown --skip-empty` check: passed
- added-line security scan for dynamic execution, subprocess/shell injection, secret logging, and network writes: no findings

## Manual diff review

Reviewed startup ordering, Observer Mode gates, entity-registry filtering, unit normalization, native bounds, adapter idempotency, and success-state caching. No remaining blocking finding was identified. One review finding—non-finite float values passing Python conversion—was fixed and covered by ten regression cases.

## Release note / changelog candidate

### 🐛 Fixes

- 🔋 **Battery discharge controls now fail closed and Observer Mode stays write-free at startup** — inverter auto-discovery now accepts only live W/kW controls, so current-based Deye/ha-solarman entities can no longer receive watt setpoints. Generic, GoodWe, Huawei, and startup writes share one validation path that rejects missing, unavailable, unsupported, non-finite, and out-of-range controls, with correct W/kW conversion. The CI coverage summary also reuses the completed test run instead of executing the entire suite twice. (by @tintinz)

## HACS / release path

The repository currently reports `1.7.5-beta.34`. This fix becomes a normal HACS-installable update only after merge into the upstream release branch/default distribution path and publication of a tagged release. Suggested next version is the next available beta after upstream HEAD (currently this would be `1.7.5-beta.35`); no version or price/configuration value is changed in this PR.
