### PR TITLE
fix(ev): persist Zaptec discovery and suppress phantom plans

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1409,6 +1409,45 @@ def _migrate_limit_surplus_to_max(hass: HomeAssistant, entry: SEMConfigEntry) ->
         _LOGGER.info("Folded ev_limit_surplus into the Max charge ceiling (#245)")
 
 
+def stable_discovered_charger_id(discovered: Dict[str, Any]) -> str:
+    """Build a deterministic, storage-safe ID from registry identity."""
+    import hashlib
+    import re
+
+    platform = str(discovered.get("_platform") or "ev_charger").lower()
+    platform = re.sub(r"[^a-z0-9_]+", "_", platform).strip("_") or "ev_charger"
+    identity = str(
+        discovered.get("_device_id")
+        or discovered.get("ev_current_control_entity")
+        or discovered.get("ev_charging_power_sensor")
+        or platform
+    )
+    digest = hashlib.sha256(f"{platform}:{identity}".encode()).hexdigest()[:10]
+    return f"{platform}_{digest}"
+
+
+def build_discovered_charger_storage(
+    entry_data: Dict[str, Any],
+    entry_options: Dict[str, Any],
+    discovered: Dict[str, Any],
+) -> tuple[Dict[str, Any], Dict[str, Any], List[Dict[str, Any]]]:
+    """Return matching data/options payloads for one discovered charger."""
+    charger = {
+        key: value
+        for key, value in discovered.items()
+        if not key.startswith("_") and value is not None
+    }
+    charger["id"] = stable_discovered_charger_id(discovered)
+    platform = str(discovered.get("_platform") or "EV").split("_", 1)[0]
+    charger["name"] = f"{platform.title()} Charger"
+    chargers = [charger]
+    return (
+        {**dict(entry_data or {}), "ev_chargers": chargers},
+        {**dict(entry_options or {}), "ev_chargers": chargers},
+        chargers,
+    )
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     """Set up Solar Energy Management from a config entry.
 
@@ -1638,13 +1677,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
                 ev_auto = coordinator._device_registry.discover_ev_charger()
                 if ev_auto:
                     _LOGGER.info("Auto-discovered EV charger config: %s", list(ev_auto.keys()))
-                    ev_auto["id"] = "ev_charger"
-                    ev_auto["name"] = "EV Charger"
-                    ev_chargers_config = [ev_auto]
-                    # Persist discovered config
-                    new_options = dict(entry.options)
-                    new_options["ev_chargers"] = ev_chargers_config
-                    hass.config_entries.async_update_entry(entry, options=new_options)
+                    new_data, new_options, ev_chargers_config = (
+                        build_discovered_charger_storage(
+                            dict(entry.data or {}),
+                            dict(entry.options or {}),
+                            ev_auto,
+                        )
+                    )
+                    # Persist the same stable list on both sides. Options are
+                    # the live source; data is the recovery source used by the
+                    # existing storage-healing path if options is clobbered.
+                    hass.config_entries.async_update_entry(
+                        entry,
+                        data=new_data,
+                        options=new_options,
+                    )
                     full_config["ev_chargers"] = ev_chargers_config
             # Fallback: check flat keys (pre-migration installs)
             if not ev_chargers_config:

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -5287,7 +5287,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                 fleet=fleet,
                 charging_state=getattr(charging_state, "value", str(charging_state)),
                 ev_charging=bool(getattr(power, "ev_charging", False)),
-                ev_connected=bool(getattr(power, "ev_connected", False)),
+                # Same operational gate as the charging context: a legacy flat
+                # sensor with no registered charger must not make the battery
+                # hold discharge protection for a phantom EV.
+                ev_connected=operational_ev_connected(
+                    self._ev_devices, getattr(power, "ev_connected", False)
+                ),
                 home_consumption_w=float(
                     getattr(power, "home_consumption_power", 0.0) or 0.0
                 ),
@@ -5338,8 +5343,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
         now = dt_util.now()
 
         if not scheduler.should_trigger_evaluation(now):
-            # Check for re-plan trigger (price update / SOC drift / EV change)
-            ev_connected = bool(getattr(power, "ev_connected", False))
+            # Check for re-plan trigger (price update / SOC drift / EV change).
+            # Operationally gated: a phantom EV (legacy sensor, no registered
+            # charger) must not force scheduler re-plans either.
+            ev_connected = operational_ev_connected(
+                self._ev_devices, getattr(power, "ev_connected", False)
+            )
             price_fp = None
             # Only worth computing when the scheduler holds a
             # fingerprint to compare against (#485 F2) — before the

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -47,6 +47,8 @@ from .types import (
 )
 from .health_check import HealthCheck
 from .units import energy_state_to_kwh, power_state_to_watts
+from .distance_units import distance_to_km
+from .ev_availability import operational_ev_connected, operational_night_target
 from .surplus_availability import SurplusAvailability
 from .sensor_reader import SensorReader
 from .energy_calculator import EnergyCalculator
@@ -3548,10 +3550,18 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
             if _range_entity:
                 _rs = self.hass.states.get(_range_entity)
                 if _rs and _rs.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
-                    try:
-                        result["ev_remaining_range"] = round(float(_rs.state))
-                    except (ValueError, TypeError):
-                        pass
+                    _range_km = distance_to_km(
+                        _rs.state,
+                        _rs.attributes.get("unit_of_measurement"),
+                    )
+                    if _range_km is not None:
+                        result["ev_remaining_range"] = round(_range_km)
+                    else:
+                        _LOGGER.warning(
+                            "Ignoring vehicle range %s with unsupported/invalid unit %r",
+                            _range_entity,
+                            _rs.attributes.get("unit_of_measurement"),
+                        )
             if "ev_remaining_range" not in result and self._cycle_vehicle_soc is not None:
                 # Capacity + efficiency are per-car → read the (primary) charger's
                 # values, falling back to global config. One car per charger (#245).
@@ -6024,8 +6034,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
         # take the non-wait branch. Multi-charger loop downstream
         # already had access via the cached ChargingContext; this
         # brings the primary to parity.
-        night_target = remaining_floor
-        if self.time_manager.is_night_mode() and self._smart_night_charging_enabled():
+        night_target = operational_night_target(self._ev_devices, remaining_floor)
+        if (
+            self._ev_devices
+            and self.time_manager.is_night_mode()
+            and self._smart_night_charging_enabled()
+        ):
             night_target = self._calculate_forecast_night_target(
                 remaining_floor, energy, _primary_cfg,
             )
@@ -6193,8 +6207,8 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
         # are already populated and consumed below.
 
         return ChargingContext(
-            ev_connected=power.ev_connected,
-            ev_charging=power.ev_charging,
+            ev_connected=operational_ev_connected(self._ev_devices, power.ev_connected),
+            ev_charging=bool(self._ev_devices) and power.ev_charging,
             battery_soc=power.battery_soc,
             battery_too_low=battery_too_low,
             battery_needs_priority=battery_needs_priority,

--- a/coordinator/distance_units.py
+++ b/coordinator/distance_units.py
@@ -1,0 +1,36 @@
+"""Distance-unit normalisation for vehicle range diagnostics."""
+from __future__ import annotations
+
+import math
+from typing import Any, Optional
+
+
+_KM_UNITS = {"km", "kilometer", "kilometers", "kilometre", "kilometres"}
+_M_UNITS = {"m", "meter", "meters", "metre", "metres"}
+_MI_UNITS = {"mi", "mile", "miles"}
+
+
+def distance_to_km(value: Any, unit: Any) -> Optional[float]:
+    """Convert a length value to kilometres, or ``None`` fail-closed.
+
+    Home Assistant entities do not guarantee a unit. Treating an unknown unit
+    as kilometres can inflate a metre-based vehicle range by ×1000, so unknown,
+    non-finite and negative values are deliberately rejected.
+    """
+    if unit is None:
+        return None
+    normalized = str(unit).strip().lower()
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric) or numeric < 0:
+        return None
+
+    if normalized in _KM_UNITS:
+        return numeric
+    if normalized in _M_UNITS:
+        return numeric / 1000.0
+    if normalized in _MI_UNITS:
+        return numeric * 1.609344
+    return None

--- a/coordinator/ev_availability.py
+++ b/coordinator/ev_availability.py
@@ -1,0 +1,19 @@
+"""Operational EV availability gates.
+
+Legacy flat sensors may survive a failed per-charger migration. They are useful
+for discovery, but must never activate charging logic without a registered
+CurrentControlDevice.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+
+def operational_ev_connected(devices: Mapping[str, Any] | None, sensor_connected: bool) -> bool:
+    """Return connected only when a controllable charger is registered."""
+    return bool(devices) and bool(sensor_connected)
+
+
+def operational_night_target(devices: Mapping[str, Any] | None, target_kwh: float) -> float:
+    """Suppress plans when no charger device can execute them."""
+    return float(target_kwh) if devices else 0.0

--- a/hardware_detection.py
+++ b/hardware_detection.py
@@ -724,9 +724,18 @@ def discover_all_ev_chargers_from_registry(
     chargers: List[Dict[str, str]] = []
 
     for platform, discover_fn in _EV_CHARGER_PLATFORMS:
+        def _matches_platform(entry_platform: str) -> bool:
+            # Some HACS/custom Zaptec builds expose a domain such as
+            # ``zaptec_custom`` while keeping the same entity model. Restrict
+            # the tolerant match to the Zaptec prefix; every other integration
+            # remains exact to avoid broad accidental charger discovery.
+            if platform == "zaptec":
+                return entry_platform == "zaptec" or entry_platform.startswith("zaptec_")
+            return entry_platform == platform
+
         entities = [
             e for e in entity_reg.entities.values()
-            if e.platform == platform and not e.disabled_by
+            if _matches_platform(str(e.platform or "")) and not e.disabled_by
         ]
         if not entities:
             continue
@@ -740,7 +749,10 @@ def discover_all_ev_chargers_from_registry(
         for device_id, device_entities in devices.items():
             result = discover_fn(device_entities)
             if result:
-                result["_platform"] = platform
+                # Preserve the registry's real domain for diagnostics/stable
+                # migration metadata (e.g. zaptec_custom), not just the
+                # canonical matcher name.
+                result["_platform"] = str(device_entities[0].platform or platform)
                 if device_id:
                     result["_device_id"] = device_id
                 _LOGGER.info(
@@ -875,38 +887,66 @@ def _discover_wallbox(entities) -> Dict[str, str]:
 
 
 def _discover_zaptec(entities) -> Dict[str, str]:
-    """Discover EV charger config from Zaptec integration."""
+    """Discover one control-capable Zaptec charger device.
+
+    Zaptec also exposes installation/site aggregate devices. Those may have a
+    total-power sensor but are not chargers and must not seed ``ev_chargers``.
+    Some custom integration versions omit ``original_device_class``; only
+    Zaptec-scoped, explicit entity-id patterns are used as fallback.
+    """
     result: Dict[str, str] = {}
     device_id = None
     for entry in entities:
         eid = entry.entity_id
+        if entry.device_id and not device_id:
+            device_id = entry.device_id
         dc = entry.original_device_class
-        if eid.startswith("binary_sensor.") and ("cable" in eid or "connect" in eid):
+        eid_lower = eid.lower()
+        if eid.startswith("binary_sensor.") and ("cable" in eid_lower or "connect" in eid_lower):
             result["ev_connected_sensor"] = eid
-        if eid.startswith("binary_sensor.") and "charg" in eid:
+        if eid.startswith("binary_sensor.") and "charg" in eid_lower:
             result["ev_charging_sensor"] = eid
-        if eid.startswith("sensor.") and dc == "power":
+        if eid.startswith("sensor.") and (
+            dc == "power"
+            or ("power" in eid_lower and "energy" not in eid_lower and "kwh" not in eid_lower)
+        ):
             result["ev_charging_power_sensor"] = eid
             if entry.device_id:
                 device_id = entry.device_id
-        if eid.startswith("sensor.") and dc == "energy" and "total" in eid:
-            result["ev_total_energy_sensor"] = eid
-        if eid.startswith("sensor.") and dc == "energy" and "session" in eid:
-            result["ev_session_energy_sensor"] = eid
-        if eid.startswith("number.") and "current" in eid:
+        if eid.startswith("sensor.") and (
+            (dc == "energy" and ("total" in eid_lower or "session" in eid_lower))
+            or "meter_value_kwh" in eid_lower
+            or "signed_meter_value_kwh" in eid_lower
+            or "total_charge_energy" in eid_lower
+        ):
+            if "session" in eid_lower:
+                result["ev_session_energy_sensor"] = eid
+            else:
+                result["ev_total_energy_sensor"] = eid
+        if eid.startswith("number.") and (
+            "current" in eid_lower or "available_current" in eid_lower
+        ):
             result["ev_current_control_entity"] = eid
-    if result:
-        # Prefer number entity control if found, otherwise use service
-        if "ev_current_control_entity" not in result:
-            result["ev_charger_service"] = "zaptec.limit_current"
-            result["ev_service_param_name"] = "available_current"
-            if device_id:
-                result["ev_service_device_id"] = device_id
-        # Discover resume/stop button entities
-        for entry in entities:
-            eid = entry.entity_id
-            if eid.startswith("button.") and "resume" in eid:
-                result["ev_start_stop_entity"] = eid  # button for start
+        if eid.startswith("button.") and "resume" in eid_lower:
+            result["ev_start_stop_entity"] = eid
+
+    # Site/installation aggregates commonly contain only power/energy. A real
+    # charger must expose at least one charger-identity/control entity.
+    identity_keys = {
+        "ev_connected_sensor",
+        "ev_charging_sensor",
+        "ev_current_control_entity",
+        "ev_start_stop_entity",
+    }
+    if not identity_keys.intersection(result):
+        return {}
+
+    # Prefer number entity control if found, otherwise use Zaptec's service.
+    if "ev_current_control_entity" not in result:
+        result["ev_charger_service"] = "zaptec.limit_current"
+        result["ev_service_param_name"] = "available_current"
+        if device_id:
+            result["ev_service_device_id"] = device_id
     return result
 
 

--- a/hardware_detection.py
+++ b/hardware_detection.py
@@ -931,14 +931,19 @@ def _discover_zaptec(entities) -> Dict[str, str]:
             result["ev_start_stop_entity"] = eid
 
     # Site/installation aggregates commonly contain only power/energy. A real
-    # charger must expose at least one charger-identity/control entity.
+    # charger must expose at least one charger-identity/control entity — and
+    # at least one STATE sensor: a resume button alone would register a
+    # charger SEM can command but never read (#695/#698 discovery class).
     identity_keys = {
         "ev_connected_sensor",
         "ev_charging_sensor",
         "ev_current_control_entity",
         "ev_start_stop_entity",
     }
+    state_keys = {"ev_connected_sensor", "ev_charging_sensor"}
     if not identity_keys.intersection(result):
+        return {}
+    if not state_keys.intersection(result):
         return {}
 
     # Prefer number entity control if found, otherwise use Zaptec's service.

--- a/tests/test_distance_units.py
+++ b/tests/test_distance_units.py
@@ -1,0 +1,20 @@
+"""Regression tests for vehicle-range distance normalisation."""
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.distance_units import (
+    distance_to_km,
+)
+
+
+def test_distance_metres_are_normalised_to_km():
+    assert distance_to_km(1_057_000, "m") == pytest.approx(1057.0)
+
+
+def test_distance_miles_are_normalised_to_km():
+    assert distance_to_km(100, "mi") == pytest.approx(160.9344)
+
+
+@pytest.mark.parametrize("unit", [None, "", "yards", "bananas"])
+def test_distance_unknown_unit_fails_closed(unit):
+    assert distance_to_km(1057000, unit) is None

--- a/tests/test_ev_availability.py
+++ b/tests/test_ev_availability.py
@@ -1,0 +1,17 @@
+"""Regression for stale legacy EV sensors without a registered charger device."""
+from custom_components.solar_energy_management.coordinator.ev_availability import (
+    operational_ev_connected,
+    operational_night_target,
+)
+
+
+def test_legacy_connected_sensor_is_ignored_without_registered_device():
+    assert operational_ev_connected({}, True) is False
+    assert operational_night_target({}, 42.0) == 0.0
+
+
+def test_registered_device_preserves_connected_state_and_night_target():
+    devices = {"zaptec_garage": object()}
+    assert operational_ev_connected(devices, True) is True
+    assert operational_ev_connected(devices, False) is False
+    assert operational_night_target(devices, 42.0) == 42.0

--- a/tests/test_ev_discovery_storage.py
+++ b/tests/test_ev_discovery_storage.py
@@ -1,0 +1,39 @@
+"""Regression for durable auto-discovered EV charger storage."""
+from custom_components.solar_energy_management import (
+    build_discovered_charger_storage,
+    stable_discovered_charger_id,
+)
+
+
+def test_stable_id_uses_platform_and_device_identity():
+    charger = {"_platform": "zaptec_custom", "_device_id": "charger-42"}
+    first = stable_discovered_charger_id(charger)
+    second = stable_discovered_charger_id(dict(charger))
+    other = stable_discovered_charger_id({**charger, "_device_id": "charger-99"})
+
+    assert first == second
+    assert first.startswith("zaptec_custom_")
+    assert first != other
+
+
+def test_discovered_charger_is_persisted_to_data_and_options():
+    discovered = {
+        "_platform": "zaptec_custom",
+        "_device_id": "charger-42",
+        "ev_charging_power_sensor": "sensor.zaptec_garage_total_charge_power",
+        "ev_current_control_entity": "number.zaptec_garage_available_current",
+    }
+    new_data, new_options, chargers = build_discovered_charger_storage(
+        {"solar_power_sensor": "sensor.pv"},
+        {"observer_mode": True},
+        discovered,
+    )
+
+    assert new_data["solar_power_sensor"] == "sensor.pv"
+    assert new_options["observer_mode"] is True
+    assert new_data["ev_chargers"] == chargers
+    assert new_options["ev_chargers"] == chargers
+    assert chargers[0]["id"] == stable_discovered_charger_id(discovered)
+    assert chargers[0]["name"] == "Zaptec Charger"
+    assert "_platform" not in chargers[0]
+    assert "_device_id" not in chargers[0]

--- a/tests/test_zaptec_discovery_regression.py
+++ b/tests/test_zaptec_discovery_regression.py
@@ -1,0 +1,71 @@
+"""Regression tests for resilient Zaptec registry discovery."""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from custom_components.solar_energy_management.hardware_detection import (
+    discover_all_ev_chargers_from_registry,
+)
+
+
+def _entry(entity_id, platform, device_id, device_class=None):
+    return SimpleNamespace(
+        entity_id=entity_id,
+        platform=platform,
+        device_id=device_id,
+        original_device_class=device_class,
+        disabled_by=None,
+    )
+
+
+def test_zaptec_variant_prefers_charger_device_and_infers_missing_device_classes():
+    entries = [
+        # Zaptec installation/site aggregate — must not be registered as charger.
+        _entry(
+            "sensor.zaptec_home_installation_total_charge_power",
+            "zaptec_custom",
+            "site-1",
+        ),
+        # Actual charger. Some Zaptec/custom registry versions omit device class.
+        _entry("binary_sensor.zaptec_garage_cable_connected", "zaptec_custom", "charger-42"),
+        _entry("binary_sensor.zaptec_garage_charging", "zaptec_custom", "charger-42"),
+        _entry("sensor.zaptec_garage_total_charge_power", "zaptec_custom", "charger-42"),
+        _entry("sensor.zaptec_garage_signed_meter_value_kwh", "zaptec_custom", "charger-42"),
+        _entry("number.zaptec_garage_available_current", "zaptec_custom", "charger-42"),
+        _entry("button.zaptec_garage_resume_charging", "zaptec_custom", "charger-42"),
+    ]
+    registry = MagicMock()
+    registry.entities.values.return_value = entries
+
+    with patch(
+        "custom_components.solar_energy_management.hardware_detection.entity_registry.async_get",
+        return_value=registry,
+    ):
+        found = discover_all_ev_chargers_from_registry(MagicMock())
+
+    assert len(found) == 1
+    charger = found[0]
+    assert charger["_platform"] == "zaptec_custom"
+    assert charger["_device_id"] == "charger-42"
+    assert charger["ev_charging_power_sensor"] == "sensor.zaptec_garage_total_charge_power"
+    assert charger["ev_total_energy_sensor"] == "sensor.zaptec_garage_signed_meter_value_kwh"
+    assert charger["ev_current_control_entity"] == "number.zaptec_garage_available_current"
+
+
+def test_zaptec_service_fallback_keeps_device_id_without_power_sensor():
+    entries = [
+        _entry("binary_sensor.zaptec_driveway_cable_connected", "zaptec_custom", "charger-99"),
+        _entry("binary_sensor.zaptec_driveway_charging", "zaptec_custom", "charger-99"),
+        _entry("button.zaptec_driveway_resume_charging", "zaptec_custom", "charger-99"),
+    ]
+    registry = MagicMock()
+    registry.entities.values.return_value = entries
+
+    with patch(
+        "custom_components.solar_energy_management.hardware_detection.entity_registry.async_get",
+        return_value=registry,
+    ):
+        found = discover_all_ev_chargers_from_registry(MagicMock())
+
+    assert len(found) == 1
+    assert found[0]["_device_id"] == "charger-99"
+    assert found[0]["ev_service_device_id"] == "charger-99"


### PR DESCRIPTION
## Summary

- normalize vehicle range units before publishing diagnostics
- suppress stale legacy EV connection/night-plan state when no controllable charger is registered
- filter Zaptec installation aggregates and support Zaptec platform variants during discovery
- preserve charger device identity and persist stable discovered configuration to both config-entry data and options

## Problem

Legacy EV entities can remain available after a charger has disappeared or failed discovery. Those stale entities could make SEM publish a connected state or create a night-charge plan even though no controllable charger was registered. Zaptec discovery could also select installation aggregates instead of a real charger and lose discovered service-control details after restart.

## Safety behavior

- availability requires a real, controllable registered charger
- ambiguous or aggregate Zaptec entities are rejected
- stale legacy sensors cannot create a phantom charging plan
- discovered control configuration is persisted rather than reconstructed differently after restart

## Tests

Python 3.12:

- `test_distance_units.py`
- `test_ev_availability.py`
- `test_ev_discovery_storage.py`
- `test_zaptec_discovery_regression.py`
- upstream `test_703_goal_engine_invariants.py`

Result: **25 passed**. `compileall`, `git diff --check`, and an added-line secret/dangerous-call scan also pass.
