### PR TITLE
feat(battery): add fail-closed Deye support

### DIFF
--- a/config_flow.py
+++ b/config_flow.py
@@ -770,6 +770,7 @@ OPTIONS_FLOW_OWNED_KEYS = frozenset({
     "battery_auto_start_soc",
     "battery_buffer_soc",
     "battery_capacity_kwh",
+    "battery_charge_platform",
     "battery_charge_scheduler_enabled",
     "battery_cycle_cost",
     "battery_discharge_control_entity",
@@ -790,6 +791,22 @@ OPTIONS_FLOW_OWNED_KEYS = frozenset({
     "daily_ev_target",
     "daily_ev_target_max",
     "demand_charge_rate",
+    "deye_actuation_enabled",
+    "deye_battery_voltage_entity",
+    "deye_battery_voltage_max_age_s",
+    "deye_bms_max_charge_current_a",
+    "deye_charge_current_entity",
+    "deye_force_charge_work_mode",
+    "deye_grid_charge_switch",
+    "deye_max_charge_current_a",
+    "deye_max_discharge_power",
+    "deye_observer_mode",
+    "deye_program_control",
+    "deye_program_groups",
+    "deye_work_mode_battery_first_option",
+    "deye_work_mode_control",
+    "deye_work_mode_entity",
+    "deye_work_mode_load_first_option",
     "diagram_style",
     "dynamic_feedin_entity",
     "dynamic_forecast_entity",
@@ -1963,6 +1980,8 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
 
         if user_input is not None:
             self._data.update(user_input)
+            if self._data.get("battery_charge_platform") == "deye":
+                return await self.async_step_deye()
             return await self.async_step_pv_naming()
 
         current_config = {**self.config_entry.data, **self.config_entry.options}
@@ -1971,6 +1990,18 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
         return self.async_show_form(
             step_id="battery_scheduler",
             data_schema=vol.Schema({
+                vol.Optional(
+                    "battery_charge_platform",
+                    default=_c("battery_charge_platform", "generic"),
+                ): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            {"value": "generic", "label": "Generic / other"},
+                            {"value": "deye", "label": "Deye hybrid inverter"},
+                        ],
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                ),
                 vol.Optional(
                     "battery_charge_scheduler_enabled",
                     default=_c("battery_charge_scheduler_enabled", False),
@@ -2072,6 +2103,249 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 ): selector.BooleanSelector(),
             }),
             errors=errors,
+        )
+
+    async def async_step_deye(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """(#709) Deye forced-grid-charge configuration section.
+
+        Lets an operator wire a Deye hybrid inverter without editing YAML:
+        the grid-charge switch, the charge-current number (unit A), the
+        battery-voltage sensor, exactly six program groups (time/soc/charge
+        entities), a safe max current, an optional BMS max current, an
+        optional Work Mode select with two distinct mapping values, and the
+        two safety gates (observer mode default **on**, actuation default
+        **off** — so a bare config never writes until explicitly enabled).
+
+        The submitted form is normalised into the documented Deye contract
+        keys read by ``DeyeBatteryAdapter`` (``deye_program_groups`` as a
+        list of six {time, soc, charge} dicts). Booleans stay real bools.
+        The runtime snapshot store is never part of entry options — it is
+        attached to the adapter at runtime, not serialised here.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            # Keep only the Deye-owned keys so a generic/other platform
+            # doesn't accumulate stale deye_* keys.
+            clean = {k: v for k, v in user_input.items() if k.startswith("deye_")}
+            self._data["battery_charge_platform"] = user_input.get(
+                "battery_charge_platform",
+                self._data.get("battery_charge_platform", "generic"),
+            )
+            if self._data["battery_charge_platform"] == "deye":
+                # Normalise the six numbered program groups into the list shape.
+                groups = []
+                for n in range(1, 7):
+                    group = {
+                        "time": clean.get(f"deye_program_{n}_time", "").strip(),
+                        "soc": clean.get(f"deye_program_{n}_soc", "").strip(),
+                        "charge": clean.get(f"deye_program_{n}_charge", "").strip(),
+                    }
+                    groups.append(group)
+                self._data["deye_program_groups"] = groups
+
+                # Validation: exactly six complete groups.
+                if len(groups) != 6 or not all(
+                    g["time"] and g["soc"] and g["charge"] for g in groups
+                ):
+                    errors["base"] = "deye_program_groups_incomplete"
+
+                # Work Mode mappings must be explicit and distinct when enabled.
+                load_first = clean.get("deye_work_mode_load_first_option", "").strip()
+                battery_first = clean.get(
+                    "deye_work_mode_battery_first_option", ""
+                ).strip()
+                if clean.get("deye_work_mode_control") is True:
+                    if not load_first or not battery_first or load_first == battery_first:
+                        errors["deye_work_mode_battery_first_option"] = (
+                            "deye_work_mode_mapping_not_distinct"
+                        )
+                    force_mode = clean.get("deye_force_charge_work_mode", "")
+                    if force_mode not in ("load_first", "battery_first"):
+                        errors["deye_force_charge_work_mode"] = (
+                            "deye_force_charge_work_mode_invalid"
+                        )
+
+                # Safety booleans must stay real bools (never strings).
+                self._data["deye_observer_mode"] = clean.get(
+                    "deye_observer_mode", True,
+                ) is True
+                self._data["deye_actuation_enabled"] = clean.get(
+                    "deye_actuation_enabled", False,
+                ) is True
+                self._data["deye_program_control"] = clean.get(
+                    "deye_program_control", True,
+                ) is True
+                self._data["deye_work_mode_control"] = clean.get(
+                    "deye_work_mode_control", False,
+                ) is True
+                # Copy the scalar Deye config terms through.
+                for key in (
+                    "deye_grid_charge_switch",
+                    "deye_charge_current_entity",
+                    "deye_battery_voltage_entity",
+                    "deye_battery_voltage_max_age_s",
+                    "deye_max_charge_current_a",
+                    "deye_bms_max_charge_current_a",
+                    "deye_max_discharge_power",
+                    "deye_work_mode_entity",
+                    "deye_work_mode_load_first_option",
+                    "deye_work_mode_battery_first_option",
+                    "deye_force_charge_work_mode",
+                ):
+                    if clean.get(key) is not None:
+                        self._data[key] = clean[key]
+            else:
+                # Non-Deye platform: drop stale Deye keys from the payload.
+                for key in list(self._data.keys()):
+                    if key.startswith("deye_") or key == "deye_program_groups":
+                        self._data.pop(key, None)
+
+            if not errors:
+                return await self.async_step_pv_naming()
+
+        current_config = {**self.config_entry.data, **self.config_entry.options}
+        _c = lambda key, fb: self._cfg(current_config, key, fb)
+        _platform = _c("battery_charge_platform", "generic")
+
+        return self.async_show_form(
+            step_id="deye",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "deye_grid_charge_switch",
+                        description={"suggested_value": _c("deye_grid_charge_switch", None)},
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="switch")
+                    ),
+                    vol.Optional(
+                        "deye_charge_current_entity",
+                        description={"suggested_value": _c("deye_charge_current_entity", None)},
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain=["number", "input_number"])
+                    ),
+                    vol.Optional(
+                        "deye_battery_voltage_entity",
+                        description={"suggested_value": _c("deye_battery_voltage_entity", None)},
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="sensor")
+                    ),
+                    vol.Optional(
+                        "deye_battery_voltage_max_age_s",
+                        default=_c("deye_battery_voltage_max_age_s", 30),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1, max=600, step=1,
+                            unit_of_measurement="s",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        "deye_max_charge_current_a",
+                        default=_c("deye_max_charge_current_a", 25),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=1, max=100, step=1,
+                            unit_of_measurement="A",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        "deye_bms_max_charge_current_a",
+                        default=_c("deye_bms_max_charge_current_a", 0),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0, max=200, step=1,
+                            unit_of_measurement="A",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        "deye_max_discharge_power",
+                        default=_c("deye_max_discharge_power", 0),
+                    ): selector.NumberSelector(
+                        selector.NumberSelectorConfig(
+                            min=0, max=50000, step=100,
+                            unit_of_measurement="W",
+                            mode=selector.NumberSelectorMode.BOX,
+                        )
+                    ),
+                    vol.Optional(
+                        "deye_program_control",
+                        default=_c("deye_program_control", True),
+                    ): selector.BooleanSelector(),
+                    vol.Optional(
+                        "deye_observer_mode",
+                        default=_c("deye_observer_mode", True),
+                    ): selector.BooleanSelector(),
+                    vol.Optional(
+                        "deye_actuation_enabled",
+                        default=_c("deye_actuation_enabled", False),
+                    ): selector.BooleanSelector(),
+                    vol.Optional(
+                        "deye_work_mode_control",
+                        default=_c("deye_work_mode_control", False),
+                    ): selector.BooleanSelector(),
+                    vol.Optional(
+                        "deye_work_mode_entity",
+                        description={"suggested_value": _c("deye_work_mode_entity", None)},
+                    ): selector.EntitySelector(
+                        selector.EntitySelectorConfig(domain="select")
+                    ),
+                    vol.Optional(
+                        "deye_work_mode_load_first_option",
+                        description={"suggested_value": _c("deye_work_mode_load_first_option", "Load First")},
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                    ),
+                    vol.Optional(
+                        "deye_work_mode_battery_first_option",
+                        description={"suggested_value": _c("deye_work_mode_battery_first_option", "Battery First")},
+                    ): selector.TextSelector(
+                        selector.TextSelectorConfig(type=selector.TextSelectorType.TEXT)
+                    ),
+                    vol.Optional(
+                        "deye_force_charge_work_mode",
+                        default=_c("deye_force_charge_work_mode", "battery_first"),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[
+                                {"value": "load_first", "label": "Load First"},
+                                {"value": "battery_first", "label": "Battery First"},
+                            ],
+                            mode=selector.SelectSelectorMode.DROPDOWN,
+                        )
+                    ),
+                }
+                | {
+                    vol.Optional(
+                        f"deye_program_{n}_{kind}",
+                        description={"suggested_value": _c(
+                            f"deye_program_{n}_{kind}", None,
+                        )},
+                    ): (
+                        selector.EntitySelector(
+                            selector.EntitySelectorConfig(domain="select")
+                        )
+                        if kind == "time"
+                        else selector.EntitySelector(
+                            selector.EntitySelectorConfig(domain=["number", "input_number"])
+                        )
+                        if kind == "soc"
+                        else selector.EntitySelector(
+                            selector.EntitySelectorConfig(domain="select")
+                        )
+                    )
+                    for n in range(1, 7)
+                    for kind in ("time", "soc", "charge")
+                }
+            ),
+            errors=errors,
+            description_placeholders={
+                "platform": _platform,
+            },
         )
 
     async def async_step_pv_naming(

--- a/coordinator/battery_adapters/__init__.py
+++ b/coordinator/battery_adapters/__init__.py
@@ -13,6 +13,7 @@ per :class:`BatteryIntent`. Mirrors the EV ``charger_adapters/``
 pattern.
 """
 from .base import BatteryControlAdapter
+from .deye import DeyeBatteryAdapter, DeyeCapability, DeyeControlSnapshot
 from .generic import GenericBatteryAdapter
 from .goodwe import GoodWeBatteryAdapter
 from .huawei import HuaweiBatteryAdapter
@@ -30,6 +31,8 @@ def adapter_for(hass, config: dict) -> BatteryControlAdapter:
     4. Otherwise → GenericBatteryAdapter (switch + number target)
     """
     platform = (config.get("battery_charge_platform") or "auto").lower()
+    if platform == "deye":
+        return DeyeBatteryAdapter(hass, config)
     if platform == "huawei":
         return HuaweiBatteryAdapter(hass, config)
     if platform == "goodwe":
@@ -85,6 +88,9 @@ def _integration_loaded(hass, domain: str) -> bool:
 
 __all__ = [
     "BatteryControlAdapter",
+    "DeyeBatteryAdapter",
+    "DeyeCapability",
+    "DeyeControlSnapshot",
     "HuaweiBatteryAdapter",
     "GoodWeBatteryAdapter",
     "GenericBatteryAdapter",

--- a/coordinator/battery_adapters/base.py
+++ b/coordinator/battery_adapters/base.py
@@ -64,6 +64,11 @@ class BatteryControlAdapter(ABC):
         # always goes through; a plain -1.0 sentinel would alias a real
         # negative charge setpoint on a bidirectional entity, #523).
         self._last_force_discharge_w: Optional[float] = None
+        # #709: runtime scope — config entry + battery identity. Injected by the
+        # coordinator's ``_battery_adapter_context``; pure metadata, never part
+        # of entry data/options and never serialised into the adapter.
+        self._config_entry_id: str = config.get("config_entry_id", "")
+        self._battery_id: str = config.get("battery_id", "")
 
     # ─── Capability ────────────────────────────────────────────
 
@@ -99,6 +104,15 @@ class BatteryControlAdapter(ABC):
         return self._last_error
 
     # ─── Commands ──────────────────────────────────────────────
+
+    async def async_recover_pending(self) -> bool:
+        """Recover persistent brand state before first actuation.
+
+        Most adapters have no transactional state and therefore need no work.
+        Stateful adapters override this method and fail closed on recovery
+        errors.
+        """
+        return True
 
     @abstractmethod
     async def command_normal(self) -> None:

--- a/coordinator/battery_adapters/deye.py
+++ b/coordinator/battery_adapters/deye.py
@@ -1,0 +1,1020 @@
+"""DeyeBatteryAdapter — Deye hybrid inverters.
+
+Deye exposes forced grid charging through a per-program "time slice"
+model rather than a single service call: a grid-charge switch that
+enables the feature, a charge-current number (max grid-charge current in
+amperes), a battery-voltage sensor (for power conversion), and up to
+six programmable time slices each with a start time, an SOC target and a
+charge-enable select.
+
+This Deye contract slice ships:
+
+- the :class:`DeyeBatteryAdapter` with explicit observer/actuation gates,
+  persistent pre-write snapshots, read-back and fail-closed rollback.
+- a fail-closed, state-validated capability computation
+  (:meth:`DeyeBatteryAdapter.capability` / ``supports_forced_charge``)
+  that only reports forced-charge available when every entity is present,
+  correctly shaped and fresh.
+- an immutable, serialisable :class:`DeyeCapability` result.
+
+Config shape (documented):
+
+    battery_charge_platform: deye          # REQUIRED — no auto-detect
+    deye_grid_charge_switch: switch.deye_grid_charge
+    deye_charge_current_entity: number.deye_charge_current   # unit A
+    deye_battery_voltage_entity: sensor.deye_battery_voltage
+    deye_battery_voltage_max_age_s: 30     # default 30
+    deye_max_charge_current_a: 25          # optional safe ceiling
+    deye_bms_max_charge_current_a: 30      # optional BMS max
+    deye_max_discharge_power: 5000         # safe discharge config (or 0)
+    deye_program_control: true             # require 6 complete slices
+    deye_program_groups:                   # list of 6 dicts (preferred)
+      - time: select.deye_slice_1_time
+        soc: number.deye_slice_1_soc
+        charge: select.deye_slice_1_charge
+      # ... 6 entries
+    # Numbered-key alternative (either style resolves to the same 6 slots):
+    #   deye_program_1_time / deye_program_1_soc / deye_program_1_charge
+    #   ...
+    deye_observer_mode: true                # default true; False required to write
+    deye_actuation_enabled: false           # exact boolean True required to write
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import math
+from dataclasses import asdict, dataclass
+from datetime import datetime, time
+from typing import Any, Optional
+from uuid import uuid4
+
+from homeassistant.util import dt as dt_util
+
+from ..charger_types import BatteryIntent
+from .base import BatteryControlAdapter
+
+_LOGGER = logging.getLogger(__name__)
+
+_NUMERIC_DOMAINS = ("number", "input_number")
+_SELECT_DOMAINS = ("select", "input_select")
+_SLOT_KEYS = ("time", "soc", "charge")
+_DEFAULT_VOLTAGE_MAX_AGE_S = 30.0
+_MIN_BATTERY_VOLTAGE_V = 40.0
+_DEFAULT_PROGRAM_COUNT = 6
+
+
+@dataclass(frozen=True)
+class DeyeCapability:
+    """Immutable, serialisable snapshot of what Deye forced-charge can do now.
+
+    ``available`` is the single gate for ``supports_forced_charge``; every
+    other field lets a caller render diagnostics without re-reading states.
+    """
+
+    available: bool
+    reason: str
+    max_charge_current_a: float
+    battery_voltage_age_s: float
+    snapshot_supported: bool
+    readback_supported: bool
+    restore_supported: bool
+
+
+@dataclass(frozen=True)
+class DeyeControlSnapshot:
+    """Serializable pre-write state for one battery control session."""
+
+    schema_version: int
+    config_entry_id: str
+    battery_id: str
+    session_id: str
+    created_at: float
+    entity_mapping: tuple[tuple[str, str], ...]
+    grid_charge_enabled: bool
+    charge_current_a: float
+    program_times: tuple[str, ...]
+    program_socs: tuple[float, ...]
+    program_charging: tuple[str, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["entity_mapping"] = [list(item) for item in self.entity_mapping]
+        data["program_times"] = list(self.program_times)
+        data["program_socs"] = list(self.program_socs)
+        data["program_charging"] = list(self.program_charging)
+        return data
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "DeyeControlSnapshot":
+        if type(data.get("grid_charge_enabled")) is not bool:
+            raise ValueError("grid_charge_enabled must be a boolean")
+        return cls(
+            schema_version=int(data["schema_version"]),
+            config_entry_id=str(data["config_entry_id"]),
+            battery_id=str(data["battery_id"]),
+            session_id=str(data["session_id"]),
+            created_at=float(data["created_at"]),
+            entity_mapping=tuple(
+                (str(key), str(value)) for key, value in data["entity_mapping"]
+            ),
+            grid_charge_enabled=bool(data["grid_charge_enabled"]),
+            charge_current_a=float(data["charge_current_a"]),
+            program_times=tuple(str(value) for value in data["program_times"]),
+            program_socs=tuple(float(value) for value in data["program_socs"]),
+            program_charging=tuple(
+                str(value) for value in data["program_charging"]
+            ),
+        )
+
+
+class DeyeBatteryAdapter(BatteryControlAdapter):
+    """Fail-closed Deye battery control with transactional restoration."""
+
+    def __init__(self, hass, config: dict) -> None:
+        super().__init__(hass, config)
+        self._grid_charge_switch = self._clean_string(
+            config.get("deye_grid_charge_switch"),
+        )
+        self._charge_current_entity = self._clean_string(
+            config.get("deye_charge_current_entity"),
+        )
+        self._voltage_entity = self._clean_string(
+            config.get("deye_battery_voltage_entity"),
+        )
+        self._voltage_max_age_raw = config.get(
+            "deye_battery_voltage_max_age_s", _DEFAULT_VOLTAGE_MAX_AGE_S,
+        )
+        self._voltage_max_age_s = self._finite_gt0(self._voltage_max_age_raw)
+        # Effective max grid-charge current = min(entity max, safe ceiling,
+        # optional BMS max). The entity max always participates (validated);
+        # the two config terms only participate when explicitly configured.
+        self._safe_max_current_raw = config.get("deye_max_charge_current_a")
+        self._safe_max_current: Optional[float] = self._finite_gt0(
+            self._safe_max_current_raw,
+        )
+        self._bms_max_current_raw = config.get("deye_bms_max_charge_current_a")
+        self._bms_max_current: Optional[float] = self._finite_gt0(
+            self._bms_max_current_raw,
+        )
+        # Discharge power comes from safe finite config only (never states).
+        self._max_discharge_w = self._finite_geq0(
+            config.get("deye_max_discharge_power"), default=0.0,
+        )
+        self._program_control = config.get("deye_program_control", False) is True
+        self._config_entry_id = self._clean_string(config.get("config_entry_id"))
+        self._battery_id = self._clean_string(config.get("battery_id"))
+        self._snapshot_store = config.get("deye_snapshot_store")
+        self._snapshot_max_age_s = self._finite_gt0(
+            config.get("deye_snapshot_max_age_s", 300),
+        )
+        # Only exact booleans can open write gates.  In particular, strings
+        # such as "false" must never become truthy actuation permissions.
+        self._observer_mode = config.get("deye_observer_mode", True) is not False
+        self._actuation_enabled = config.get("deye_actuation_enabled", False) is True
+        try:
+            self._active_program_index = int(config.get("deye_active_program_index", 1))
+        except (TypeError, ValueError):
+            self._active_program_index = 0
+        self._snapshot: Optional[DeyeControlSnapshot] = None
+        self._snapshot_load_failed = False
+        self._session_first_write_at: Optional[float] = None
+        try:
+            self._readback_attempts = int(config.get("deye_readback_attempts", 3))
+            self._readback_delay_s = float(config.get("deye_readback_delay_s", 0))
+        except (TypeError, ValueError):
+            self._readback_attempts = 0
+            self._readback_delay_s = -1.0
+        unsafe_raw = config.get(
+            "deye_unsafe_latched",
+            getattr(self._snapshot_store, "unsafe", False),
+        )
+        self._unsafe_latched = unsafe_raw is not False
+        implemented = bool(
+            self._snapshot_store is not None
+            and callable(getattr(self._snapshot_store, "async_save", None))
+            and callable(getattr(self._snapshot_store, "async_load", None))
+            and callable(getattr(self._snapshot_store, "async_clear", None))
+            and callable(getattr(self._snapshot_store, "async_set_unsafe", None))
+        )
+        self._snapshot_supported = implemented
+        self._readback_supported = implemented
+        self._restore_supported = implemented
+
+    # ─── Config helpers ────────────────────────────────────────
+
+    @staticmethod
+    def _clean_string(value: Any) -> str:
+        return value.strip() if isinstance(value, str) else ""
+
+    @staticmethod
+    def _finite_gt0(value):
+        """Return ``float(value)`` if it is finite and > 0, else None."""
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return None
+        return v if math.isfinite(v) and v > 0 else None
+
+    @staticmethod
+    def _finite_geq0(value, default):
+        """Return ``float(value)`` if finite and >= 0, else ``default``."""
+        try:
+            v = float(value)
+        except (TypeError, ValueError):
+            return default
+        return v if math.isfinite(v) and v >= 0 else default
+
+    def _get_state(self, entity_id: str):
+        """Return the HA state for ``entity_id`` or None (fail-closed)."""
+        if not entity_id:
+            return None
+        try:
+            return self._hass.states.get(entity_id)
+        except Exception:  # noqa: BLE001 — never let a flaky read crash
+            return None
+
+    def _state_age_s(self, state, now: datetime) -> Optional[float]:
+        """Age of a state in seconds (None if no timestamp -> treat as stale)."""
+        ts = getattr(state, "last_updated", None) or getattr(
+            state, "last_changed", None
+        )
+        if ts is None:
+            return None
+        try:
+            age = (now - ts).total_seconds()
+        except (TypeError, ValueError):
+            return None
+        return age if age >= 0 else None
+
+    @staticmethod
+    def _state_is_usable(state) -> bool:
+        """Reject Home Assistant sentinel states everywhere, fail-closed."""
+        raw = getattr(state, "state", None)
+        return not (
+            raw is None
+            or (isinstance(raw, str) and raw.strip().lower() in {
+                "", "unknown", "unavailable", "none", "nan", "inf", "-inf",
+            })
+        )
+
+    def _program_slots(self):
+        """Return the 6 program slots as a list of ``{time, soc, charge}``.
+
+        Resolves from the documented list shape (``deye_program_groups``)
+        or the numbered-key fallback (``deye_program_<n>_{time,soc,charge}``,
+        1-indexed). A slot is only complete when all three keys are present.
+        Missing/partial slots come back as ``None`` entries.
+        """
+        slots = []
+        groups = self._config.get("deye_program_groups")
+        if isinstance(groups, list) and groups:
+            for g in groups:
+                if not isinstance(g, dict):
+                    slots.append(None)
+                    continue
+                slot = {k: self._clean_string(g.get(k)) for k in _SLOT_KEYS}
+                slots.append(slot if all(slot.values()) else None)
+            return slots
+        # Numbered-key fallback.
+        for i in range(1, _DEFAULT_PROGRAM_COUNT + 1):
+            slot = {
+                k: self._clean_string(self._config.get(f"deye_program_{i}_{k}"))
+                for k in _SLOT_KEYS
+            }
+            slots.append(slot if all(slot.values()) else None)
+        return slots
+
+    # ─── Capability ────────────────────────────────────────────
+
+    def capability(self) -> DeyeCapability:
+        """Fail-closed forced-charge capability from current states/config.
+
+        Returns :class:`DeyeCapability` with ``available=False`` and a
+        clear ``reason`` for the first problem found. A single missing,
+        mis-shaped, stale or non-finite entity flips the whole result off.
+        """
+        now = dt_util.utcnow()
+        reason = ""
+
+        # 1. Grid-charge switch must be a switch.* entity.
+        st_switch = self._get_state(self._grid_charge_switch)
+        if st_switch is None:
+            reason = "grid-charge switch entity missing/not configured"
+            return self._unavailable(reason)
+        sw_domain = (self._grid_charge_switch or "").split(".", 1)[0]
+        if sw_domain != "switch":
+            reason = (
+                f"grid-charge switch must be switch.* domain, got "
+                f"{self._grid_charge_switch!r}"
+            )
+            return self._unavailable(reason)
+        if not self._state_is_usable(st_switch):
+            return self._unavailable("grid-charge switch state unavailable")
+        if self._normalise_switch(st_switch.state) is None:
+            return self._unavailable("grid-charge switch state must be on or off")
+
+        # 2. Charge-current entity: number/input_number, unit A, sane range.
+        st_current = self._get_state(self._charge_current_entity)
+        if st_current is None:
+            reason = "charge-current entity missing/not configured"
+            return self._unavailable(reason)
+        cur_domain = (self._charge_current_entity or "").split(".", 1)[0]
+        if cur_domain not in _NUMERIC_DOMAINS:
+            reason = (
+                f"charge-current entity must be number/input_number domain, "
+                f"got {self._charge_current_entity!r}"
+            )
+            return self._unavailable(reason)
+        if not self._state_is_usable(st_current):
+            return self._unavailable("charge-current state unavailable")
+        cur_attrs = getattr(st_current, "attributes", None) or {}
+        if cur_attrs.get("unit_of_measurement") != "A":
+            reason = "charge-current entity must have unit A"
+            return self._unavailable(reason)
+        cur_min = cur_attrs.get("min")
+        cur_max = cur_attrs.get("max")
+        if not (isinstance(cur_min, (int, float)) and isinstance(cur_max, (int, float))):
+            reason = "charge-current entity missing numeric min/max"
+            return self._unavailable(reason)
+        if not (math.isfinite(float(cur_min)) and math.isfinite(float(cur_max))):
+            reason = "charge-current entity min/max must be finite"
+            return self._unavailable(reason)
+        if not (0.0 <= float(cur_min) <= float(cur_max)):
+            reason = "charge-current entity range must satisfy 0 <= min <= max"
+            return self._unavailable(reason)
+        current_value = self._parse_number(st_current.state)
+        if (
+            current_value is None
+            or not math.isfinite(current_value)
+            or not float(cur_min) <= current_value <= float(cur_max)
+        ):
+            return self._unavailable("charge-current state must be finite and within range")
+        if self._voltage_max_age_s is None:
+            return self._unavailable("battery-voltage max age must be finite and > 0")
+
+        # 3. Voltage entity: positive, finite numeric state, fresh.
+        st_voltage = self._get_state(self._voltage_entity)
+        if st_voltage is None:
+            reason = "battery-voltage entity missing/not configured"
+            return self._unavailable(reason)
+        if not self._state_is_usable(st_voltage):
+            return self._unavailable("battery-voltage state unavailable")
+        voltage = self._finite_gt0(self._parse_number(getattr(st_voltage, "state", None)))
+        if voltage is None or voltage < _MIN_BATTERY_VOLTAGE_V:
+            reason = "battery-voltage state must be finite and at least 40 V"
+            return self._unavailable(reason)
+        age = self._state_age_s(st_voltage, now)
+        if age is None:
+            reason = "battery-voltage state has no usable timestamp (stale)"
+            return self._unavailable(reason)
+        if age > self._voltage_max_age_s:
+            reason = (
+                f"battery-voltage state is stale ({age:.0f}s > "
+                f"{self._voltage_max_age_s:.0f}s max age)"
+            )
+            return self._unavailable(reason)
+
+        # 4. Effective max charge current = min(entity max, safe, BMS).
+        if self._safe_max_current is None:
+            return self._unavailable(
+                "configured safe max charge current must be finite and > 0"
+            )
+        if (
+            self._bms_max_current_raw is not None
+            and self._bms_max_current is None
+        ):
+            return self._unavailable("BMS max charge current must be finite and > 0")
+        entity_max = float(cur_max)
+        terms = [entity_max, self._safe_max_current]
+        if self._bms_max_current is not None:
+            terms.append(self._bms_max_current)
+        effective_current = min(terms)
+        if not (math.isfinite(effective_current) and effective_current > 0):
+            reason = "effective max charge current must be finite and > 0"
+            return self._unavailable(reason)
+
+        # 5. Program control: require all 6 complete + valid slots.
+        if self._program_control:
+            slots = self._program_slots()
+            if len(slots) != _DEFAULT_PROGRAM_COUNT:
+                reason = (
+                    f"program control requires {_DEFAULT_PROGRAM_COUNT} "
+                    f"slots, got {len(slots)}"
+                )
+                return self._unavailable(reason)
+            for idx, slot in enumerate(slots, start=1):
+                if slot is None:
+                    reason = f"program slot {idx} incomplete (time/soc/charge)"
+                    return self._unavailable(reason)
+                slot_reason = self._validate_slot(slot, idx)
+                if slot_reason:
+                    return self._unavailable(slot_reason)
+
+        return DeyeCapability(
+            available=True,
+            reason="ok",
+            max_charge_current_a=effective_current,
+            battery_voltage_age_s=age,
+            snapshot_supported=self._snapshot_supported,
+            readback_supported=self._readback_supported,
+            restore_supported=self._restore_supported,
+        )
+
+    @staticmethod
+    def _parse_number(raw):
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            return None
+
+    def _validate_slot(self, slot: dict, idx: int) -> str:
+        """Validate one program slot; return a reason string or ''."""
+        # SOC entity: number/input_number, unit %, min<=0 and max>=100.
+        soc_eid = slot.get("soc", "")
+        st_soc = self._get_state(soc_eid)
+        if st_soc is None:
+            return f"program slot {idx} SOC entity missing ({soc_eid!r})"
+        if not self._state_is_usable(st_soc):
+            return f"program slot {idx} SOC state unavailable"
+        soc_domain = soc_eid.split(".", 1)[0]
+        if soc_domain not in _NUMERIC_DOMAINS:
+            return f"program slot {idx} SOC must be number/input_number"
+        soc_attrs = getattr(st_soc, "attributes", None) or {}
+        if soc_attrs.get("unit_of_measurement") != "%":
+            return f"program slot {idx} SOC must have unit %"
+        soc_min = soc_attrs.get("min")
+        soc_max = soc_attrs.get("max")
+        if not (isinstance(soc_min, (int, float)) and isinstance(soc_max, (int, float))):
+            return f"program slot {idx} SOC missing numeric min/max"
+        if not (math.isfinite(float(soc_min)) and math.isfinite(float(soc_max))):
+            return f"program slot {idx} SOC min/max must be finite"
+        soc_value = self._parse_number(st_soc.state)
+        if (
+            soc_value is None
+            or not math.isfinite(soc_value)
+            or not 0 <= soc_value <= 100
+        ):
+            return f"program slot {idx} SOC state must be finite and within 0-100"
+        if not (float(soc_min) <= 0.0 and float(soc_max) >= 100.0):
+            return (
+                f"program slot {idx} SOC range must satisfy min<=0 and "
+                f"max>=100"
+            )
+
+        # Charging select: options must include Disabled and Grid.
+        charge_eid = slot.get("charge", "")
+        st_charge = self._get_state(charge_eid)
+        if st_charge is None:
+            return f"program slot {idx} charging select missing ({charge_eid!r})"
+        if not self._state_is_usable(st_charge):
+            return f"program slot {idx} charging select state unavailable"
+        charge_domain = charge_eid.split(".", 1)[0]
+        if charge_domain not in _SELECT_DOMAINS:
+            return f"program slot {idx} charging select must be select/input_select"
+        charge_attrs = getattr(st_charge, "attributes", None) or {}
+        options = charge_attrs.get("options") or []
+        if "Disabled" not in options or "Grid" not in options:
+            return (
+                f"program slot {idx} charging select must offer Disabled "
+                f"and Grid options"
+            )
+        if str(st_charge.state) not in options:
+            return f"program slot {idx} charging select state is not an offered option"
+
+        # Time entity must be HA's writable time domain.
+        time_eid = slot.get("time", "")
+        st_time = self._get_state(time_eid)
+        if st_time is None:
+            return f"program slot {idx} time entity missing ({time_eid!r})"
+        if time_eid.split(".", 1)[0] != "time":
+            return f"program slot {idx} time entity must be time.*"
+        if not self._state_is_usable(st_time):
+            return f"program slot {idx} time state unavailable"
+        try:
+            time.fromisoformat(self._normalise_time(st_time.state))
+        except ValueError:
+            return f"program slot {idx} time state is invalid"
+        return ""
+
+    def _unavailable(self, reason: str) -> DeyeCapability:
+        return DeyeCapability(
+            available=False,
+            reason=reason,
+            max_charge_current_a=0.0,
+            battery_voltage_age_s=0.0,
+            snapshot_supported=self._snapshot_supported,
+            readback_supported=self._readback_supported,
+            restore_supported=self._restore_supported,
+        )
+
+    # ─── Transactional snapshot/read-back/restore ──────────────
+
+    @property
+    def unsafe_latched(self) -> bool:
+        return self._unsafe_latched
+
+    # Deliberately no public reset here.  A later control-plane slice must
+    # provide an audited operator action; the adapter never clears the latch
+    # implicitly.
+
+    def _entity_mapping(self) -> tuple[tuple[str, str], ...]:
+        mapping = [
+            ("grid_charge_switch", self._grid_charge_switch),
+            ("charge_current", self._charge_current_entity),
+            ("battery_voltage", self._voltage_entity),
+        ]
+        for index, slot in enumerate(self._program_slots(), start=1):
+            if slot:
+                mapping.extend(
+                    (f"program_{index}_{key}", slot[key]) for key in _SLOT_KEYS
+                )
+        return tuple(mapping)
+
+    @staticmethod
+    def _normalise_time(value: Any) -> str:
+        text = str(value).strip()
+        parts = text.split(":")
+        if len(parts) == 2:
+            text += ":00"
+        return text
+
+    @staticmethod
+    def _normalise_switch(value: Any) -> Optional[bool]:
+        if isinstance(value, bool):
+            return value
+        text = str(value).strip().lower()
+        if text == "on":
+            return True
+        if text == "off":
+            return False
+        return None
+
+    async def _store_call(self, method: str, *args):
+        if self._snapshot_store is None:
+            raise RuntimeError("Deye snapshot store is not configured")
+        fn = getattr(self._snapshot_store, method, None)
+        if fn is None:
+            raise RuntimeError(f"Deye snapshot store lacks {method}")
+        result = fn(*args)
+        return await result if inspect.isawaitable(result) else result
+
+    async def _store_unsafe(self, value: bool) -> None:
+        if self._snapshot_store is None:
+            return
+        fn = getattr(self._snapshot_store, "async_set_unsafe", None)
+        if fn is None:
+            return
+        try:
+            result = fn(value)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001
+            _LOGGER.exception("Deye: failed to persist unsafe latch")
+
+    async def _load_snapshot(self) -> Optional[DeyeControlSnapshot]:
+        if self._snapshot is not None:
+            self._snapshot_load_failed = False
+            return self._snapshot
+        self._snapshot_load_failed = False
+        try:
+            raw = await self._store_call("async_load")
+            if raw:
+                self._snapshot = DeyeControlSnapshot.from_dict(raw)
+        except Exception as err:  # noqa: BLE001
+            self._snapshot_load_failed = True
+            self._last_error = f"snapshot load failed: {err}"
+            return None
+        return self._snapshot
+
+    async def _clear_snapshot(self) -> bool:
+        try:
+            await self._store_call("async_clear")
+        except Exception as err:  # noqa: BLE001
+            self._last_error = f"snapshot clear failed: {err}"
+            return False
+        self._snapshot = None
+        self._session_first_write_at = None
+        return True
+
+    def _snapshot_scope_valid(
+        self, snapshot: DeyeControlSnapshot, *, require_fresh: bool,
+    ) -> tuple[bool, str]:
+        if snapshot.schema_version != 1:
+            return False, "snapshot schema mismatch"
+        if (
+            not snapshot.session_id
+            or not math.isfinite(snapshot.created_at)
+            or len(snapshot.program_times) != 6
+            or len(snapshot.program_socs) != 6
+            or len(snapshot.program_charging) != 6
+            or not math.isfinite(snapshot.charge_current_a)
+        ):
+            return False, "snapshot structure is invalid"
+        current_state = self._get_state(self._charge_current_entity)
+        current_min = self._parse_number(
+            getattr(current_state, "attributes", {}).get("min")
+            if current_state is not None else None
+        )
+        current_max = self._parse_number(
+            getattr(current_state, "attributes", {}).get("max")
+            if current_state is not None else None
+        )
+        if (
+            current_min is None
+            or current_max is None
+            or not math.isfinite(current_min)
+            or not math.isfinite(current_max)
+            or not 0 <= current_min <= current_max
+            or not current_min <= snapshot.charge_current_a <= current_max
+        ):
+            return False, "snapshot charge current is outside entity range"
+        slots = self._program_slots()
+        if len(slots) != 6 or any(slot is None for slot in slots):
+            return False, "snapshot requires six complete program slots"
+        for index, slot in enumerate(slots):
+            assert slot is not None
+            try:
+                time.fromisoformat(self._normalise_time(snapshot.program_times[index]))
+            except ValueError:
+                return False, "snapshot program time is invalid"
+            soc = snapshot.program_socs[index]
+            if not math.isfinite(soc) or not 0 <= soc <= 100:
+                return False, "snapshot program SOC is invalid"
+            charge_state = self._get_state(slot["charge"])
+            options = getattr(charge_state, "attributes", {}).get("options", [])
+            if snapshot.program_charging[index] not in options:
+                return False, "snapshot program charging source is invalid"
+        if not self._config_entry_id or not self._battery_id:
+            return False, "config entry and battery scope are required"
+        if snapshot.config_entry_id != self._config_entry_id:
+            return False, "snapshot config-entry scope mismatch"
+        if snapshot.battery_id != self._battery_id:
+            return False, "snapshot battery scope mismatch"
+        if snapshot.entity_mapping != self._entity_mapping():
+            return False, "snapshot entity mapping mismatch"
+        now_ts = dt_util.utcnow().timestamp()
+        if snapshot.created_at > now_ts:
+            return False, "snapshot timestamp is in the future"
+        if require_fresh:
+            if self._snapshot_max_age_s is None:
+                return False, "snapshot max age must be finite and > 0"
+            if now_ts - snapshot.created_at > self._snapshot_max_age_s:
+                return False, "snapshot is stale"
+        if (
+            self._session_first_write_at is not None
+            and snapshot.created_at > self._session_first_write_at
+        ):
+            return False, "snapshot was not created before first write"
+        return True, "ok"
+
+    async def _take_snapshot(self, session_id: str) -> Optional[DeyeControlSnapshot]:
+        capability = self.capability()
+        slots = self._program_slots()
+        if not capability.available:
+            self._last_error = capability.reason
+            return None
+        if not self._program_control or len(slots) != 6 or any(s is None for s in slots):
+            self._last_error = "snapshot requires six complete Deye program slots"
+            return None
+        switch_state = self._get_state(self._grid_charge_switch)
+        current_state = self._get_state(self._charge_current_entity)
+        enabled = self._normalise_switch(getattr(switch_state, "state", None))
+        current = self._parse_number(getattr(current_state, "state", None))
+        if enabled is None or current is None or not math.isfinite(current):
+            self._last_error = "snapshot contains invalid switch/current state"
+            return None
+        times: list[str] = []
+        socs: list[float] = []
+        charging: list[str] = []
+        for slot in slots:
+            assert slot is not None
+            time_state = self._get_state(slot["time"])
+            soc_state = self._get_state(slot["soc"])
+            charge_state = self._get_state(slot["charge"])
+            if not all(
+                self._state_is_usable(state)
+                for state in (time_state, soc_state, charge_state)
+            ):
+                self._last_error = "snapshot program state unavailable"
+                return None
+            soc = self._parse_number(getattr(soc_state, "state", None))
+            if soc is None or not math.isfinite(soc):
+                self._last_error = "snapshot program SOC is invalid"
+                return None
+            times.append(self._normalise_time(time_state.state))
+            socs.append(soc)
+            charging.append(str(charge_state.state))
+        snapshot = DeyeControlSnapshot(
+            schema_version=1,
+            config_entry_id=self._config_entry_id,
+            battery_id=self._battery_id,
+            session_id=session_id,
+            created_at=dt_util.utcnow().timestamp(),
+            entity_mapping=self._entity_mapping(),
+            grid_charge_enabled=enabled,
+            charge_current_a=current,
+            program_times=tuple(times),
+            program_socs=tuple(socs),
+            program_charging=tuple(charging),
+        )
+        valid, reason = self._snapshot_scope_valid(snapshot, require_fresh=True)
+        if not valid:
+            self._last_error = reason
+            return None
+        try:
+            await self._store_call("async_save", snapshot.to_dict())
+            persisted_raw = await self._store_call("async_load")
+            persisted = DeyeControlSnapshot.from_dict(persisted_raw)
+        except Exception as err:  # noqa: BLE001
+            self._last_error = f"snapshot persistence failed: {err}"
+            return None
+        if persisted != snapshot:
+            self._last_error = "snapshot persistence read-back mismatch"
+            return None
+        self._snapshot = snapshot
+        return snapshot
+
+    def _read_matches(self, entity_id: str, expected: Any, kind: str) -> bool:
+        state = self._get_state(entity_id)
+        if state is None or not self._state_is_usable(state):
+            return False
+        actual = state.state
+        if kind == "number":
+            parsed = self._parse_number(actual)
+            return (
+                parsed is not None
+                and math.isfinite(parsed)
+                and math.isclose(parsed, float(expected), abs_tol=1e-6)
+            )
+        if kind == "switch":
+            return self._normalise_switch(actual) is bool(expected)
+        if kind == "time":
+            return self._normalise_time(actual) == self._normalise_time(expected)
+        return str(actual) == str(expected)
+
+    async def _write_and_verify(
+        self, entity_id: str, value: Any, kind: str,
+    ) -> bool:
+        domain = entity_id.split(".", 1)[0]
+        if kind == "switch":
+            service = "turn_on" if bool(value) else "turn_off"
+            data = {"entity_id": entity_id}
+        elif kind == "select":
+            service = "select_option"
+            data = {"entity_id": entity_id, "option": value}
+        elif kind == "time":
+            service = "set_value"
+            data = {"entity_id": entity_id, "time": self._normalise_time(value)}
+        else:
+            service = "set_value"
+            data = {"entity_id": entity_id, "value": float(value)}
+        try:
+            if self._session_first_write_at is None:
+                self._session_first_write_at = dt_util.utcnow().timestamp()
+            await self._hass.services.async_call(
+                domain, service, data, blocking=True,
+            )
+        except Exception as err:  # noqa: BLE001
+            self._last_error = f"write failed for {entity_id}: {err}"
+            return False
+        attempts = self._readback_attempts
+        delay = self._readback_delay_s
+        for attempt in range(attempts):
+            if self._read_matches(entity_id, value, kind):
+                return True
+            if attempt + 1 < attempts:
+                await asyncio.sleep(delay)
+        self._last_error = f"read-back mismatch for {entity_id}"
+        return False
+
+    async def _restore_snapshot(self, snapshot: DeyeControlSnapshot) -> bool:
+        valid, reason = self._snapshot_scope_valid(snapshot, require_fresh=False)
+        if not valid:
+            self._last_error = reason
+            return False
+        slots = self._program_slots()
+        safe_zero = await self._write_and_verify(
+            self._charge_current_entity, 0.0, "number",
+        )
+        safe_off = await self._write_and_verify(
+            self._grid_charge_switch, False, "switch",
+        )
+        if not (safe_zero and safe_off):
+            self._unsafe_latched = True
+            await self._store_unsafe(True)
+            self._last_error = self._last_error or (
+                "Deye rollback could not establish zero-current/switch-off state"
+            )
+            return False
+        ok = True
+        for index, slot in enumerate(slots):
+            assert slot is not None
+            ok = await self._write_and_verify(
+                slot["time"], snapshot.program_times[index], "time",
+            ) and ok
+            ok = await self._write_and_verify(
+                slot["soc"], snapshot.program_socs[index], "number",
+            ) and ok
+            ok = await self._write_and_verify(
+                slot["charge"], snapshot.program_charging[index], "select",
+            ) and ok
+        ok = await self._write_and_verify(
+            self._charge_current_entity, snapshot.charge_current_a, "number",
+        ) and ok
+        ok = await self._write_and_verify(
+            self._grid_charge_switch, snapshot.grid_charge_enabled, "switch",
+        ) and ok
+        if not ok:
+            self._unsafe_latched = True
+            await self._store_unsafe(True)
+            self._last_error = self._last_error or "Deye rollback read-back failed"
+            return False
+        return await self._clear_snapshot()
+
+    async def _rollback_after_failure(
+        self, snapshot: DeyeControlSnapshot, original_error: str,
+    ) -> None:
+        restored = await self._restore_snapshot(snapshot)
+        if restored:
+            self._last_error = f"{original_error}; rollback verified"
+        else:
+            self._unsafe_latched = True
+            await self._store_unsafe(True)
+            self._last_error = f"{original_error}; rollback FAILED — unsafe latched"
+
+    # ─── BatteryControlAdapter capability surface ─────────────
+
+    @property
+    def max_charge_power_w(self) -> float:
+        """Validated current × validated voltage when available, else 0."""
+        cap = self.capability()
+        if not cap.available:
+            return 0.0
+        st_voltage = self._get_state(self._voltage_entity)
+        voltage = self._finite_gt0(
+            self._parse_number(getattr(st_voltage, "state", None))
+        )
+        if voltage is None:
+            return 0.0
+        return cap.max_charge_current_a * voltage
+
+    @property
+    def max_discharge_power_w(self) -> float:
+        """Safe finite discharge config, else 0 (never a state read)."""
+        return self._max_discharge_w
+
+    @property
+    def supports_forced_charge(self) -> bool:
+        """True only behind all hardware, transaction and operator gates."""
+        capability = self.capability()
+        return bool(
+            capability.available
+            and capability.snapshot_supported
+            and capability.readback_supported
+            and capability.restore_supported
+            and self._config_entry_id
+            and self._battery_id
+            and self._program_control
+            and 1 <= self._active_program_index <= 6
+            and self._readback_attempts > 0
+            and math.isfinite(self._readback_delay_s)
+            and self._readback_delay_s >= 0
+            and self._actuation_enabled
+            and not self._observer_mode
+            and not self._unsafe_latched
+        )
+
+    # ─── Commands ──────────────────────────────────────────────
+
+    async def command_normal(self) -> None:
+        snapshot = await self._load_snapshot()
+        if snapshot is None:
+            if self._snapshot_load_failed:
+                self._unsafe_latched = True
+                await self._store_unsafe(True)
+                return
+            if self._unsafe_latched:
+                self._last_error = "Deye unsafe latch is set"
+                return
+            self._last_error = None
+            self._last_intent = BatteryIntent.NORMAL
+            return
+        restored = await self._restore_snapshot(snapshot)
+        if restored:
+            if self._unsafe_latched:
+                self._last_error = "Deye snapshot restored; unsafe latch remains set"
+                return
+            self._last_error = None
+            self._last_intent = BatteryIntent.NORMAL
+        elif not self._unsafe_latched:
+            self._unsafe_latched = True
+            await self._store_unsafe(True)
+
+    async def command_limit_discharge(self, watts: float) -> None:
+        # Deye discharge limiting is intentionally outside this first contract.
+        self._last_error = "Deye discharge limiting is not implemented"
+
+    async def command_force_charge(
+        self, target_soc: float, charge_power_w: float, duration_min: int,
+    ) -> None:
+        if not self.supports_forced_charge:
+            capability = self.capability()
+            if self._unsafe_latched:
+                reason = "unsafe latch is set"
+            elif self._observer_mode:
+                reason = "observer mode is active"
+            elif not self._actuation_enabled:
+                reason = "actuation is not explicitly enabled"
+            else:
+                reason = capability.reason
+            self._last_error = f"Deye force charge blocked: {reason}"
+            return
+        try:
+            target = float(target_soc)
+            requested_power = float(charge_power_w)
+            duration = int(duration_min)
+        except (TypeError, ValueError):
+            self._last_error = "Deye force charge parameters are invalid"
+            return
+        if not (
+            math.isfinite(target)
+            and 0 <= target <= 100
+            and math.isfinite(requested_power)
+            and requested_power > 0
+            and duration > 0
+        ):
+            self._last_error = "Deye force charge parameters are out of range"
+            return
+        existing = await self._load_snapshot()
+        if self._snapshot_load_failed:
+            self._unsafe_latched = True
+            await self._store_unsafe(True)
+            return
+        if existing is not None:
+            self._last_error = "pending Deye snapshot must be restored before a new session"
+            return
+        snapshot = await self._take_snapshot(str(uuid4()))
+        if snapshot is None:
+            return
+        valid, reason = self._snapshot_scope_valid(snapshot, require_fresh=True)
+        if not valid:
+            self._last_error = reason
+            return
+        voltage_state = self._get_state(self._voltage_entity)
+        voltage = self._finite_gt0(
+            self._parse_number(getattr(voltage_state, "state", None))
+        )
+        capability = self.capability()
+        if voltage is None or not capability.available:
+            await self._rollback_after_failure(snapshot, "voltage/capability changed")
+            return
+        requested_current = math.floor(requested_power / voltage)
+        current = min(float(requested_current), capability.max_charge_current_a)
+        if not math.isfinite(current) or current <= 0:
+            await self._rollback_after_failure(snapshot, "calculated charge current is zero")
+            return
+        slot = self._program_slots()[self._active_program_index - 1]
+        assert slot is not None
+        operations = (
+            (self._charge_current_entity, current, "number"),
+            (slot["soc"], target, "number"),
+            (slot["charge"], "Grid", "select"),
+            (self._grid_charge_switch, True, "switch"),
+        )
+        for entity_id, value, kind in operations:
+            if not await self._write_and_verify(entity_id, value, kind):
+                error = self._last_error or f"Deye write failed for {entity_id}"
+                await self._rollback_after_failure(snapshot, error)
+                return
+        valid, reason = self._snapshot_scope_valid(snapshot, require_fresh=False)
+        if not valid:
+            await self._rollback_after_failure(snapshot, reason)
+            return
+        self._last_error = None
+        self._last_intent = BatteryIntent.FORCE_CHARGE
+
+    async def command_stop_force_charge(self) -> None:
+        snapshot = await self._load_snapshot()
+        if snapshot is None:
+            if self._snapshot_load_failed:
+                self._unsafe_latched = True
+                await self._store_unsafe(True)
+                return
+            if self._unsafe_latched:
+                self._last_error = "Deye unsafe latch is set"
+                return
+            self._last_error = None
+            self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+            return
+        restored = await self._restore_snapshot(snapshot)
+        if restored:
+            if self._unsafe_latched:
+                self._last_error = "Deye snapshot restored; unsafe latch remains set"
+                return
+            self._last_error = None
+            self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+        elif not self._unsafe_latched:
+            self._unsafe_latched = True
+            await self._store_unsafe(True)

--- a/coordinator/battery_adapters/deye.py
+++ b/coordinator/battery_adapters/deye.py
@@ -980,6 +980,40 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
 
     # ─── Commands ──────────────────────────────────────────────
 
+    async def async_recover_pending(self) -> bool:
+        """Load the persisted unsafe latch and recover a pending snapshot.
+
+        Called once by the coordinator before the adapter's first actuation.
+        Any latch/store failure is fail-closed and leaves active control blocked.
+        A persisted unsafe latch is never acknowledged or reset automatically.
+        """
+        load_latch = getattr(self._snapshot_store, "async_load_latch", None)
+        if not callable(load_latch):
+            self._unsafe_latched = True
+            self._last_error = "Deye unsafe latch store is unavailable"
+            await self._store_unsafe(True)
+            return False
+        try:
+            loaded = load_latch()
+            if inspect.isawaitable(loaded):
+                loaded = await loaded
+        except Exception as err:  # noqa: BLE001
+            self._unsafe_latched = True
+            self._last_error = f"Deye unsafe latch load failed: {err}"
+            await self._store_unsafe(True)
+            return False
+        if type(loaded) is not bool:
+            self._unsafe_latched = True
+            self._last_error = "Deye unsafe latch payload is invalid"
+            await self._store_unsafe(True)
+            return False
+        self._unsafe_latched = loaded
+        if loaded:
+            self._last_error = "Deye unsafe latch is set"
+            return False
+        await self.command_normal()
+        return not self._unsafe_latched and not self._snapshot_load_failed
+
     async def command_normal(self) -> None:
         snapshot = await self._load_snapshot()
         if snapshot is None:

--- a/coordinator/battery_adapters/deye.py
+++ b/coordinator/battery_adapters/deye.py
@@ -209,7 +209,13 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
         self._session_first_write_at: Optional[float] = None
         try:
             self._readback_attempts = int(config.get("deye_readback_attempts", 3))
-            self._readback_delay_s = float(config.get("deye_readback_delay_s", 0))
+            # Default 2 s between verify reads: Deye registers travel a
+            # Modbus TCP/serial hop and HA's entity state reflects them on
+            # the NEXT poll, not synchronously. A 0 s verify races that
+            # poll, reads back the pre-write value, and rolls back a write
+            # that actually succeeded — latching the adapter unsafe on
+            # perfectly healthy hardware.
+            self._readback_delay_s = float(config.get("deye_readback_delay_s", 2.0))
         except (TypeError, ValueError):
             self._readback_attempts = 0
             self._readback_delay_s = -1.0
@@ -652,6 +658,12 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             self._snapshot_load_failed = False
             return self._snapshot
         self._snapshot_load_failed = False
+        if self._snapshot_store is None:
+            # No store configured is a CONFIGURATION, not a failure: there
+            # is nothing to load and nothing pending. Treating it as a load
+            # failure would latch the adapter unsafe on the first
+            # command_normal of every store-less install.
+            return None
         try:
             raw = await self._store_call("async_load")
             if raw:
@@ -1027,6 +1039,19 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             self._last_error = None
             self._last_intent = BatteryIntent.NORMAL
             return
+        # Restore WRITES 18 registers. The same gates that protect
+        # command_force_charge protect the restore path: a persisted
+        # snapshot from an earlier actuation-enabled session must not be
+        # replayed to the inverter on an observer-mode startup (#702 —
+        # the exact class this adapter's contract promises to close).
+        # The snapshot is held, not cleared: it replays once the user
+        # re-opens the gates.
+        if self._observer_mode or not self._actuation_enabled:
+            self._last_error = (
+                "pending Deye snapshot held: restore requires actuation "
+                "enabled and observer mode off"
+            )
+            return
         restored = await self._restore_snapshot(snapshot)
         if restored:
             if self._unsafe_latched:
@@ -1039,7 +1064,11 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             await self._store_unsafe(True)
 
     async def command_limit_discharge(self, watts: float) -> None:
-        # Deye discharge limiting is intentionally outside this first contract.
+        # Deye discharge limiting is intentionally outside this first
+        # contract. The intent still records what the coordinator asked
+        # for — last_intent tracks the accepted command stream, last_error
+        # carries the honesty (sibling adapters' convention).
+        self._last_intent = BatteryIntent.LIMIT_DISCHARGE
         self._last_error = "Deye discharge limiting is not implemented"
 
     async def command_force_charge(
@@ -1098,6 +1127,18 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             await self._store_unsafe(True)
             return
         if existing is not None:
+            # The coordinator re-issues FORCE_CHARGE every cycle for the
+            # duration of a session (~30 s cadence, like every sibling
+            # adapter). A snapshot belonging to the session THIS adapter
+            # instance opened is the active session — re-issue is a no-op
+            # success, not an error, or last_error flags a healthy session
+            # on every cycle. Changed parameters are NOT re-applied
+            # mid-session; the inverter holds the compiled plan. A snapshot
+            # this instance did NOT open (restart recovery) still refuses:
+            # it must replay through command_normal first.
+            if self._last_intent is BatteryIntent.FORCE_CHARGE:
+                self._last_error = None
+                return
             self._last_error = "pending Deye snapshot must be restored before a new session"
             return
         snapshot = await self._take_snapshot(str(uuid4()))
@@ -1166,6 +1207,13 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
                 return
             self._last_error = None
             self._last_intent = BatteryIntent.STOP_FORCE_CHARGE
+            return
+        # Same write gate as command_normal — restore is a hardware write.
+        if self._observer_mode or not self._actuation_enabled:
+            self._last_error = (
+                "pending Deye snapshot held: restore requires actuation "
+                "enabled and observer mode off"
+            )
             return
         restored = await self._restore_snapshot(snapshot)
         if restored:

--- a/coordinator/battery_adapters/deye.py
+++ b/coordinator/battery_adapters/deye.py
@@ -28,6 +28,11 @@ Config shape (documented):
     deye_bms_max_charge_current_a: 30      # optional BMS max
     deye_max_discharge_power: 5000         # safe discharge config (or 0)
     deye_program_control: true             # require 6 complete slices
+    deye_work_mode_control: true           # optional, explicit only
+    deye_work_mode_entity: select.deye_energy_pattern
+    deye_work_mode_load_first_option: Load First
+    deye_work_mode_battery_first_option: Battery First
+    deye_force_charge_work_mode: battery_first
     deye_program_groups:                   # list of 6 dicts (preferred)
       - time: select.deye_slice_1_time
         soc: number.deye_slice_1_soc
@@ -54,6 +59,11 @@ from homeassistant.util import dt as dt_util
 
 from ..charger_types import BatteryIntent
 from .base import BatteryControlAdapter
+from .deye_schedule import (
+    DeyeScheduleError,
+    compile_deye_charge_window,
+    validate_deye_boundaries,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,6 +107,7 @@ class DeyeControlSnapshot:
     program_times: tuple[str, ...]
     program_socs: tuple[float, ...]
     program_charging: tuple[str, ...]
+    work_mode: str
 
     def to_dict(self) -> dict[str, Any]:
         data = asdict(self)
@@ -110,6 +121,8 @@ class DeyeControlSnapshot:
     def from_dict(cls, data: dict[str, Any]) -> "DeyeControlSnapshot":
         if type(data.get("grid_charge_enabled")) is not bool:
             raise ValueError("grid_charge_enabled must be a boolean")
+        if not isinstance(data.get("work_mode"), str):
+            raise ValueError("work_mode must be a string")
         return cls(
             schema_version=int(data["schema_version"]),
             config_entry_id=str(data["config_entry_id"]),
@@ -126,6 +139,7 @@ class DeyeControlSnapshot:
             program_charging=tuple(
                 str(value) for value in data["program_charging"]
             ),
+            work_mode=data["work_mode"],
         )
 
 
@@ -143,6 +157,23 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
         self._voltage_entity = self._clean_string(
             config.get("deye_battery_voltage_entity"),
         )
+        self._work_mode_control = config.get("deye_work_mode_control", False) is True
+        self._work_mode_entity = self._clean_string(
+            config.get("deye_work_mode_entity"),
+        )
+        self._work_mode_options = {
+            "load_first": self._clean_string(
+                config.get("deye_work_mode_load_first_option"),
+            ),
+            "battery_first": self._clean_string(
+                config.get("deye_work_mode_battery_first_option"),
+            ),
+        }
+        self._force_charge_work_mode = self._clean_string(
+            config.get("deye_force_charge_work_mode"),
+        ).lower()
+        now_provider = config.get("deye_now_provider")
+        self._now_provider = now_provider if callable(now_provider) else dt_util.now
         self._voltage_max_age_raw = config.get(
             "deye_battery_voltage_max_age_s", _DEFAULT_VOLTAGE_MAX_AGE_S,
         )
@@ -173,10 +204,6 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
         # such as "false" must never become truthy actuation permissions.
         self._observer_mode = config.get("deye_observer_mode", True) is not False
         self._actuation_enabled = config.get("deye_actuation_enabled", False) is True
-        try:
-            self._active_program_index = int(config.get("deye_active_program_index", 1))
-        except (TypeError, ValueError):
-            self._active_program_index = 0
         self._snapshot: Optional[DeyeControlSnapshot] = None
         self._snapshot_load_failed = False
         self._session_first_write_at: Optional[float] = None
@@ -285,6 +312,43 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             }
             slots.append(slot if all(slot.values()) else None)
         return slots
+
+    def _program_time_values(self) -> tuple[str, ...]:
+        """Read all six program boundaries without guessing or reordering."""
+        slots = self._program_slots()
+        if len(slots) != _DEFAULT_PROGRAM_COUNT or any(slot is None for slot in slots):
+            raise DeyeScheduleError("Deye schedule requires six complete slots")
+        values: list[str] = []
+        for slot in slots:
+            assert slot is not None
+            state = self._get_state(slot["time"])
+            if state is None or not self._state_is_usable(state):
+                raise DeyeScheduleError("Deye program boundary state is unavailable")
+            values.append(self._normalise_time(state.state))
+        validate_deye_boundaries(values)
+        return tuple(values)
+
+    def _validate_work_mode(self) -> str:
+        """Return an error for any ambiguous Work Mode mapping/state."""
+        if not self._work_mode_control:
+            return ""
+        if self._work_mode_entity.split(".", 1)[0] != "select":
+            return "Deye Work Mode entity must be select.*"
+        state = self._get_state(self._work_mode_entity)
+        if state is None or not self._state_is_usable(state):
+            return "Deye Work Mode state is unavailable"
+        options = getattr(state, "attributes", {}).get("options", [])
+        load_first = self._work_mode_options["load_first"]
+        battery_first = self._work_mode_options["battery_first"]
+        if not load_first or not battery_first or load_first == battery_first:
+            return "Deye Work Mode mappings must be explicit and distinct"
+        if load_first not in options or battery_first not in options:
+            return "Deye Work Mode mappings are not offered select options"
+        if state.state not in options:
+            return "Deye Work Mode state is not an offered option"
+        if self._force_charge_work_mode not in self._work_mode_options:
+            return "Deye force-charge Work Mode must be load_first or battery_first"
+        return ""
 
     # ─── Capability ────────────────────────────────────────────
 
@@ -411,6 +475,14 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
                 slot_reason = self._validate_slot(slot, idx)
                 if slot_reason:
                     return self._unavailable(slot_reason)
+            try:
+                self._program_time_values()
+            except DeyeScheduleError as err:
+                return self._unavailable(str(err))
+
+        work_mode_reason = self._validate_work_mode()
+        if work_mode_reason:
+            return self._unavailable(work_mode_reason)
 
         return DeyeCapability(
             available=True,
@@ -525,6 +597,8 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             ("charge_current", self._charge_current_entity),
             ("battery_voltage", self._voltage_entity),
         ]
+        if self._work_mode_control:
+            mapping.append(("work_mode", self._work_mode_entity))
         for index, slot in enumerate(self._program_slots(), start=1):
             if slot:
                 mapping.extend(
@@ -601,7 +675,7 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
     def _snapshot_scope_valid(
         self, snapshot: DeyeControlSnapshot, *, require_fresh: bool,
     ) -> tuple[bool, str]:
-        if snapshot.schema_version != 1:
+        if snapshot.schema_version != 2:
             return False, "snapshot schema mismatch"
         if (
             not snapshot.session_id
@@ -635,10 +709,6 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             return False, "snapshot requires six complete program slots"
         for index, slot in enumerate(slots):
             assert slot is not None
-            try:
-                time.fromisoformat(self._normalise_time(snapshot.program_times[index]))
-            except ValueError:
-                return False, "snapshot program time is invalid"
             soc = snapshot.program_socs[index]
             if not math.isfinite(soc) or not 0 <= soc <= 100:
                 return False, "snapshot program SOC is invalid"
@@ -646,6 +716,17 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             options = getattr(charge_state, "attributes", {}).get("options", [])
             if snapshot.program_charging[index] not in options:
                 return False, "snapshot program charging source is invalid"
+        try:
+            validate_deye_boundaries(snapshot.program_times)
+        except DeyeScheduleError:
+            return False, "snapshot program times are invalid"
+        if self._work_mode_control:
+            mode_state = self._get_state(self._work_mode_entity)
+            mode_options = getattr(mode_state, "attributes", {}).get("options", [])
+            if not snapshot.work_mode or snapshot.work_mode not in mode_options:
+                return False, "snapshot Work Mode is invalid"
+        elif snapshot.work_mode:
+            return False, "snapshot unexpectedly contains Work Mode"
         if not self._config_entry_id or not self._battery_id:
             return False, "config entry and battery scope are required"
         if snapshot.config_entry_id != self._config_entry_id:
@@ -706,8 +787,15 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             times.append(self._normalise_time(time_state.state))
             socs.append(soc)
             charging.append(str(charge_state.state))
+        work_mode = ""
+        if self._work_mode_control:
+            work_mode_state = self._get_state(self._work_mode_entity)
+            if work_mode_state is None or not self._state_is_usable(work_mode_state):
+                self._last_error = "snapshot Work Mode state unavailable"
+                return None
+            work_mode = str(work_mode_state.state)
         snapshot = DeyeControlSnapshot(
-            schema_version=1,
+            schema_version=2,
             config_entry_id=self._config_entry_id,
             battery_id=self._battery_id,
             session_id=session_id,
@@ -718,6 +806,7 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             program_times=tuple(times),
             program_socs=tuple(socs),
             program_charging=tuple(charging),
+            work_mode=work_mode,
         )
         valid, reason = self._snapshot_scope_valid(snapshot, require_fresh=True)
         if not valid:
@@ -820,6 +909,10 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             ok = await self._write_and_verify(
                 slot["charge"], snapshot.program_charging[index], "select",
             ) and ok
+        if self._work_mode_control:
+            ok = await self._write_and_verify(
+                self._work_mode_entity, snapshot.work_mode, "select",
+            ) and ok
         ok = await self._write_and_verify(
             self._charge_current_entity, snapshot.charge_current_a, "number",
         ) and ok
@@ -877,7 +970,6 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             and self._config_entry_id
             and self._battery_id
             and self._program_control
-            and 1 <= self._active_program_index <= 6
             and self._readback_attempts > 0
             and math.isfinite(self._readback_delay_s)
             and self._readback_delay_s >= 0
@@ -931,11 +1023,17 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
                 reason = capability.reason
             self._last_error = f"Deye force charge blocked: {reason}"
             return
+        if any(
+            isinstance(value, bool)
+            for value in (target_soc, charge_power_w, duration_min)
+        ):
+            self._last_error = "Deye force charge parameters are invalid"
+            return
         try:
             target = float(target_soc)
             requested_power = float(charge_power_w)
             duration = int(duration_min)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             self._last_error = "Deye force charge parameters are invalid"
             return
         if not (
@@ -946,6 +1044,19 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
             and duration > 0
         ):
             self._last_error = "Deye force charge parameters are out of range"
+            return
+        try:
+            schedule_now = self._now_provider()
+            if not isinstance(schedule_now, datetime):
+                raise DeyeScheduleError("current time provider did not return datetime")
+            schedule_plan = compile_deye_charge_window(
+                self._program_time_values(),
+                schedule_now,
+                duration,
+                target,
+            )
+        except DeyeScheduleError as err:
+            self._last_error = f"Deye schedule compile failed: {err}"
             return
         existing = await self._load_snapshot()
         if self._snapshot_load_failed:
@@ -975,14 +1086,28 @@ class DeyeBatteryAdapter(BatteryControlAdapter):
         if not math.isfinite(current) or current <= 0:
             await self._rollback_after_failure(snapshot, "calculated charge current is zero")
             return
-        slot = self._program_slots()[self._active_program_index - 1]
-        assert slot is not None
-        operations = (
+        operations: list[tuple[str, Any, str]] = [
             (self._charge_current_entity, current, "number"),
-            (slot["soc"], target, "number"),
-            (slot["charge"], "Grid", "select"),
-            (self._grid_charge_switch, True, "switch"),
-        )
+        ]
+        slots = self._program_slots()
+        for slot_index in schedule_plan.slot_indices:
+            slot = slots[slot_index - 1]
+            assert slot is not None
+            operations.extend(
+                (
+                    (slot["soc"], schedule_plan.reserve_soc, "number"),
+                    (slot["charge"], schedule_plan.charging_source, "select"),
+                )
+            )
+        if self._work_mode_control:
+            operations.append(
+                (
+                    self._work_mode_entity,
+                    self._work_mode_options[self._force_charge_work_mode],
+                    "select",
+                )
+            )
+        operations.append((self._grid_charge_switch, True, "switch"))
         for entity_id, value, kind in operations:
             if not await self._write_and_verify(entity_id, value, kind):
                 error = self._last_error or f"Deye write failed for {entity_id}"

--- a/coordinator/battery_adapters/deye_schedule.py
+++ b/coordinator/battery_adapters/deye_schedule.py
@@ -1,0 +1,128 @@
+"""Pure, deterministic compiler for Deye's six-slot TOU schedule.
+
+This module has no Home Assistant side effects.  It validates Deye's six
+ordered daily boundaries, derives the active slot from an aware local time,
+and compiles a bounded charge window into the exact slots that overlap it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, time
+import math
+from typing import Iterable
+
+_PROGRAM_COUNT = 6
+_SECONDS_PER_DAY = 24 * 60 * 60
+
+
+class DeyeScheduleError(ValueError):
+    """Raised when a Deye schedule cannot be compiled safely."""
+
+
+@dataclass(frozen=True)
+class DeyeChargeWindowPlan:
+    """Validated slot updates for one temporary grid-charge window."""
+
+    slot_indices: tuple[int, ...]  # one-based Deye program numbers
+    reserve_soc: float
+    charging_source: str = "Grid"
+
+
+def _boundary_seconds(value: str) -> int:
+    if not isinstance(value, str) or not value.strip():
+        raise DeyeScheduleError("program boundary must be a non-empty string")
+    try:
+        parsed = time.fromisoformat(value.strip())
+    except ValueError as err:
+        raise DeyeScheduleError(f"invalid program boundary {value!r}") from err
+    if parsed.tzinfo is not None:
+        raise DeyeScheduleError("program boundaries must be local wall-clock times")
+    return parsed.hour * 3600 + parsed.minute * 60 + parsed.second
+
+
+def validate_deye_boundaries(values: Iterable[str]) -> tuple[int, ...]:
+    """Return six strictly increasing boundary seconds or fail closed."""
+
+    raw = tuple(values)
+    if len(raw) != _PROGRAM_COUNT:
+        raise DeyeScheduleError(
+            f"Deye schedule requires exactly {_PROGRAM_COUNT} boundaries"
+        )
+    boundaries = tuple(_boundary_seconds(value) for value in raw)
+    if len(set(boundaries)) != _PROGRAM_COUNT:
+        raise DeyeScheduleError("Deye program boundaries must be unique")
+    if any(left >= right for left, right in zip(boundaries, boundaries[1:])):
+        raise DeyeScheduleError("Deye program boundaries must be strictly increasing")
+    return boundaries
+
+
+def _aware_seconds(now: datetime) -> int:
+    if not isinstance(now, datetime) or now.tzinfo is None or now.utcoffset() is None:
+        raise DeyeScheduleError("current time must be timezone-aware")
+    return now.hour * 3600 + now.minute * 60 + now.second
+
+
+def active_deye_slot(values: Iterable[str], now: datetime) -> int:
+    """Return the one-based active Deye slot, including midnight wrap."""
+
+    boundaries = validate_deye_boundaries(values)
+    current = _aware_seconds(now)
+    active = _PROGRAM_COUNT - 1
+    for index, boundary in enumerate(boundaries):
+        if boundary > current:
+            break
+        active = index
+    return active + 1
+
+
+def compile_deye_charge_window(
+    values: Iterable[str],
+    now: datetime,
+    duration_min: int,
+    reserve_soc: float,
+) -> DeyeChargeWindowPlan:
+    """Compile a temporary window into only the overlapping Deye slots.
+
+    The window starts at ``now`` and may cross midnight.  Durations longer
+    than one day are rejected: a temporary dispatch must never silently
+    rewrite a whole recurring daily schedule.
+    """
+
+    boundaries = validate_deye_boundaries(values)
+    start = _aware_seconds(now)
+    if isinstance(duration_min, bool) or isinstance(reserve_soc, bool):
+        raise DeyeScheduleError("duration and reserve SOC must be numeric, not boolean")
+    try:
+        duration = int(duration_min)
+        target = float(reserve_soc)
+    except (TypeError, ValueError, OverflowError) as err:
+        raise DeyeScheduleError("duration and reserve SOC must be numeric") from err
+    if duration != duration_min or not 1 <= duration <= 24 * 60:
+        raise DeyeScheduleError("duration must be between 1 and 1440 whole minutes")
+    if not math.isfinite(target) or not 0 <= target <= 100:
+        raise DeyeScheduleError("reserve SOC must be finite and within 0-100")
+
+    window_start = start
+    window_end = start + duration * 60
+    selected: list[int] = []
+    for index, slot_start in enumerate(boundaries):
+        slot_end = (
+            boundaries[index + 1]
+            if index + 1 < _PROGRAM_COUNT
+            else boundaries[0] + _SECONDS_PER_DAY
+        )
+        # Compare two adjacent daily copies so both the pre-first-boundary
+        # (slot 6) region and a window crossing midnight are represented.
+        overlaps = False
+        for day_shift in (-_SECONDS_PER_DAY, 0, _SECONDS_PER_DAY):
+            left = slot_start + day_shift
+            right = slot_end + day_shift
+            if max(window_start, left) < min(window_end, right):
+                overlaps = True
+                break
+        if overlaps:
+            selected.append(index + 1)
+
+    if not selected:
+        raise DeyeScheduleError("charge window does not overlap a valid Deye slot")
+    return DeyeChargeWindowPlan(tuple(selected), target)

--- a/coordinator/battery_adapters/deye_snapshot_store.py
+++ b/coordinator/battery_adapters/deye_snapshot_store.py
@@ -1,0 +1,146 @@
+"""Persistent Deye snapshot store backed by Home Assistant's ``Store`` (#709).
+
+``DeyeBatteryAdapter`` implements a transactional snapshot/restore protocol,
+but the *production* persistence behind it lived only as an in-memory
+test stand-in.  This module ships the first production slice:
+
+- :class:`DeyeSnapshotStore` wraps Home Assistant's persistent
+  :class:`~homeassistant.helpers.storage.Store` and exposes the exact
+  interface the adapter already talks to (``async_save`` / ``async_load`` /
+  ``async_clear`` / ``async_set_unsafe`` plus the ``unsafe`` property) and
+  the startup latch load (``async_load_latch``).
+- Scope safety: every underlying store key embeds ``config_entry_id`` +
+  ``battery_id``, so two batteries or two config entries never share a
+  snapshot or a safety latch.  The runtime store object is never written
+  into entry ``data``/``options`` — the coordinator attaches it to the
+  adapter object only (runtime injection).
+- Fail-closed startup: if a persisted unsafe latch (or a corrupt latch)
+  is present, ``async_load_latch`` latches the adapter ``unsafe`` True so
+  the pending snapshot is never replayed to the inverter.  A corrupt
+  snapshot is surfaced by the adapter's strict load path (no service
+  writes), and a valid pending snapshot is restored and cleared by the
+  adapter's ``command_normal`` recovery path.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from homeassistant.helpers.storage import Store
+
+_LOGGER = logging.getLogger(__name__)
+
+_SNAPSHOT_VERSION = 1
+_UNSAFE_VERSION = 1
+
+
+def _snapshot_store_key(config_entry_id: str, battery_id: str) -> str:
+    """Persistent Store key for a battery control snapshot — scope-separated.
+
+    Both identifiers are embedded so two batteries / two config entries
+    never alias the same persisted snapshot.
+    """
+    return f"sem.deye.snapshot.{config_entry_id}.{battery_id}"
+
+
+def _unsafe_store_key(config_entry_id: str, battery_id: str) -> str:
+    """Persistent Store key for the Deye safety latch — scope-separated."""
+    return f"sem.deye.unsafe.{config_entry_id}.{battery_id}"
+
+
+class DeyeSnapshotStore:
+    """Persistent, scope-separated snapshot + safety-latch store (HA Store).
+
+    The instance is constructed per (config entry, battery) scope and handed
+    to the adapter at runtime.  It is *not* part of entry ``data``/``options``.
+    """
+
+    def __init__(self, hass, config_entry_id: str, battery_id: str) -> None:
+        self.hass = hass
+        self.config_entry_id = str(config_entry_id)
+        self.battery_id = str(battery_id)
+        # The unsafe latch defaults closed (False); only an explicitly
+        # persisted True (or a load failure -> fail-closed) flips it open.
+        self.unsafe = False
+        self._snapshot_key = _snapshot_store_key(self.config_entry_id, self.battery_id)
+        self._unsafe_key = _unsafe_store_key(self.config_entry_id, self.battery_id)
+        self._store = Store(self.hass, _SNAPSHOT_VERSION, self._snapshot_key)
+        self._unsafe_store = Store(self.hass, _UNSAFE_VERSION, self._unsafe_key)
+
+    # ─── snapshot payload ───────────────────────────────────────
+
+    async def async_save(self, data: dict[str, Any]) -> None:
+        """Persist the control snapshot dict for this scope."""
+        await self._store.async_save(data)
+
+    async def async_load(self) -> Optional[dict[str, Any]]:
+        """Return the persisted snapshot dict (or None when empty/corrupt)."""
+        return await self._store.async_load()
+
+    async def async_clear(self) -> None:
+        """Remove the persisted snapshot for this scope."""
+        await self._store.async_remove()
+
+    # ─── safety latch ───────────────────────────────────────────
+
+    @property
+    def unsafe(self) -> bool:
+        """Current in-memory unsafe-latch state (defaults closed / False)."""
+        return self._unsafe
+
+    @unsafe.setter
+    def unsafe(self, value: bool) -> None:
+        self._unsafe = bool(value)
+
+    async def async_set_unsafe(self, value: bool) -> None:
+        """Persist and update the safety latch.
+
+        ``True`` latches the scope unsafe — the adapter must not replay a
+        pending snapshot to the inverter.
+        """
+        new_value = bool(value)
+        self._unsafe = new_value
+        try:
+            await self._unsafe_store.async_save({"unsafe": new_value})
+        except Exception as err:  # noqa: BLE001 — never let persistence fail the call
+            _LOGGER.exception("Deye: failed to persist unsafe latch: %s", err)
+
+    async def async_load_latch(self) -> bool:
+        """Load the persisted safety latch at startup (fail-closed).
+
+        A missing latch, an explicit ``True``, or any load error leaves the
+        scope latched closed-safely per the persisted truth; on a load error
+        we latch ``unsafe=True`` so recovery never replays an unknown
+        snapshot to the inverter.
+        """
+        try:
+            data = await self._unsafe_store.async_load()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.exception("Deye: unsafe latch load failed — fail closed: %s", err)
+            self._unsafe = True
+            return True
+        if isinstance(data, dict):
+            unsafe_value = data.get("unsafe")
+            if type(unsafe_value) is bool:
+                self._unsafe = unsafe_value
+            else:
+                # Corrupt / non-boolean unsafe payload → fail-closed. Only an
+                # exact ``bool`` Truth may open the latch; anything else (a
+                # stray string, ``0``/``1``, ``None``) keeps the scope unsafe
+                # so a pending snapshot is never replayed to the inverter.
+                _LOGGER.warning(
+                    "Deye: unsafe latch payload is not an exact bool (%r) — "
+                    "fail closed", unsafe_value,
+                )
+                self._unsafe = True
+        elif data:
+            # Any residual truthy payload → keep it latched unsafe.
+            self._unsafe = True
+        return self._unsafe
+
+
+__all__ = [
+    "DeyeSnapshotStore",
+    "_snapshot_store_key",
+    "_unsafe_store_key",
+]

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -4746,6 +4746,42 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                 overrides[single_key] = multi_default
         return {**cfg, **overrides} if overrides else cfg
 
+    def _battery_adapter_context(
+        self, battery_id: str, index: int = 0, count: int = 1,
+    ) -> Dict[str, Any]:
+        """Runtime-only context used to build a battery adapter (#709).
+
+        Merges the coordinator config with the per-battery entity overlays,
+        then injects the runtime scope — ``config_entry_id``, ``battery_id``
+        and, for the Deye platform, a persistent ``DeyeSnapshotStore``.
+
+        The store and scope are *runtime attachments*: they are passed to the
+        adapter constructor and held on the adapter object only.  They are
+        never written into entry ``data``/``options`` (HA serialises those),
+        so nothing here can leak into persisted config.
+        """
+        base = self._per_battery_config(index, count) or dict(self.config)
+        ctx = dict(base)
+        entry_id = str(getattr(self.config_entry, "entry_id", "") or "")
+        ctx.setdefault("config_entry_id", "")
+        if entry_id:
+            ctx["config_entry_id"] = entry_id
+        ctx["battery_id"] = str(battery_id)
+        platform = (ctx.get("battery_charge_platform") or "auto").lower()
+        if platform == "deye":
+            if not entry_id:
+                # Never share a degenerate ``entry_id=''`` persistence scope
+                # between config entries.  The Deye adapter then remains
+                # unavailable/fail-closed until runtime identity is complete.
+                ctx["deye_snapshot_store"] = None
+            else:
+                from .battery_adapters.deye_snapshot_store import DeyeSnapshotStore
+
+                ctx["deye_snapshot_store"] = DeyeSnapshotStore(
+                    self.hass, entry_id, ctx["battery_id"],
+                )
+        return ctx
+
     def _warn_battery_entity_collision(self, battery_id: str, pbc: dict) -> None:
         """Warn (once per entity) when two batteries share a control entity.
 
@@ -5218,7 +5254,10 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
             # independently. Falls back to the global single-entity keys.
             adapter = self._battery_adapters.get(battery_id)
             if adapter is None:
-                _pbc = self._per_battery_config(batt_idx, _bat_count)
+                # #709: runtime context — injects the persistent Deye snapshot
+                # store + config-entry/battery scope at build time (never part of
+                # entry data/options, and never for non-Deye brands).
+                _pbc = self._battery_adapter_context(battery_id, batt_idx, _bat_count)
                 self._warn_battery_entity_collision(battery_id, _pbc)
                 adapter = adapter_for(self.hass, _pbc)
                 # H2 (review): share one orphan-stop guard across the fleet so a
@@ -5229,6 +5268,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                         self._battery_orphan_guard = {}
                     adapter._orphan_guard = self._battery_orphan_guard
                 self._battery_adapters[battery_id] = adapter
+                recovered = await adapter.async_recover_pending()
+                if not recovered:
+                    _LOGGER.warning(
+                        "Battery %s: startup recovery blocked active control: %s",
+                        battery_id, getattr(adapter, "last_error", "unknown error"),
+                    )
                 _LOGGER.info(
                     "Battery %s: %s (forced-discharge support=%s)",
                     battery_id, type(adapter).__name__,

--- a/diagnostics.py
+++ b/diagnostics.py
@@ -90,6 +90,50 @@ async def _get_recent_sem_logs(hass: HomeAssistant) -> list[str]:
 
 type SEMConfigEntry = ConfigEntry[SEMCoordinator]
 
+
+def _build_deye_diagnostics(adapters: dict[str, Any]) -> dict[str, Any] | None:
+    """Return a read-only Deye diagnostics block for the first Deye adapter.
+
+    Exposes the fail-closed capability gate (``available`` + ``reason``),
+    the effective max charge current, the persisted unsafe latch, and the
+    last recovery/actuation error. Pure read — it never writes to the
+    adapter or store, and it never serialises the runtime snapshot store
+    object. Returns ``None`` when no Deye adapter is present so installs
+    that don't use Deye keep the dump compact.
+    """
+    deye_adapters = [
+        ad for ad in adapters.values()
+        if type(ad).__name__ == "DeyeBatteryAdapter"
+    ]
+    if not deye_adapters:
+        return None
+
+    ad = deye_adapters[0]
+    try:
+        capability = ad.capability()
+    except Exception:  # noqa: BLE001 — diagnostics must never raise
+        capability = None
+
+    available = bool(
+        getattr(capability, "available", False) if capability is not None else False
+    )
+    reason = str(
+        getattr(capability, "reason", "") if capability is not None else ""
+    )
+    return {
+        "available": available,
+        "reason": reason,
+        "max_charge_current_a": float(
+            getattr(capability, "max_charge_current_a", 0.0)
+            if capability is not None else 0.0
+        ),
+        "unsafe_latched": bool(getattr(ad, "unsafe_latched", False)),
+        "recovery_error": getattr(ad, "_last_error", None) or None,
+        "observer_mode": bool(getattr(ad, "_observer_mode", False)),
+        "actuation_enabled": bool(getattr(ad, "_actuation_enabled", False)),
+    }
+
+
 # Config keys that could contain user-specific entity IDs (not secrets, but privacy)
 REDACT_CONFIG_KEYS = {
     "ev_connected_sensor",
@@ -339,6 +383,11 @@ async def async_get_config_entry_diagnostics(
                 "state": str(getattr(getattr(sched, "state", None), "value", "")) or None,
             },
         }
+        # #709 — Deye forced-grid-charge observability. Read-only. Keep the
+        # generic payload unchanged when no Deye adapter exists.
+        deye_info = _build_deye_diagnostics(_adapters)
+        if deye_info is not None:
+            battery_info["deye"] = deye_info
     except Exception as exc:  # noqa: BLE001 — diagnostics must never raise
         battery_info = {"error": str(exc)}
 

--- a/strings.json
+++ b/strings.json
@@ -88,7 +88,8 @@
       "unknown": "An unexpected error occurred. Please try again.",
       "entity_not_found": "Entity not found. Please verify the entity ID exists.",
       "service_not_found": "Notification service not found. Please check the service name (e.g., notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready needs BOTH relay entities. Set both relays — or leave both empty and configure only the climate entity for climate-only setpoint boost."
+      "heat_pump_partial_relays": "SG-Ready needs BOTH relay entities. Set both relays — or leave both empty and configure only the climate entity for climate-only setpoint boost.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management is already configured. Only one instance is allowed.",

--- a/tests/test_deye_battery_adapter.py
+++ b/tests/test_deye_battery_adapter.py
@@ -661,3 +661,109 @@ async def test_tampered_snapshot_with_ambiguous_times_is_never_restored():
     assert restarted.unsafe_latched is True
     assert store.unsafe is True
     assert "program times are invalid" in restarted.last_error
+
+
+# ---------------------------------------------------------------------------
+# Maintainer-review additions: the restore path is a WRITE and must honour
+# the same gates as force charge; a re-issued force charge is the session
+# heartbeat, not an error; a store-less config is a configuration, not a
+# failure.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_observer_mode_startup_never_replays_a_persisted_snapshot():
+    """The #702 class: a snapshot from an earlier actuation-enabled session
+    must not reach the inverter on an observer-mode startup via
+    command_normal's recovery path."""
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    assert store.data is not None
+
+    observer_config = dict(config)
+    observer_config["deye_observer_mode"] = True
+    observer_config["deye_actuation_enabled"] = False
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, observer_config)
+
+    await restarted.command_normal()
+
+    restarted_hass.services.async_call.assert_not_awaited()
+    assert store.data is not None  # held, not cleared — replays when gated open
+    assert "held" in restarted.last_error
+    assert restarted.last_intent is None
+
+
+@pytest.mark.asyncio
+async def test_observer_mode_startup_never_replays_via_stop_force_charge():
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+
+    observer_config = dict(config)
+    observer_config["deye_observer_mode"] = True
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, observer_config)
+
+    await restarted.command_stop_force_charge()
+
+    restarted_hass.services.async_call.assert_not_awaited()
+    assert store.data is not None
+    assert "held" in restarted.last_error
+
+
+@pytest.mark.asyncio
+async def test_reissued_force_charge_is_the_session_heartbeat_not_an_error():
+    """The coordinator re-issues FORCE_CHARGE every cycle for the whole
+    session, like every sibling adapter. The second issue must be a no-op
+    success — otherwise last_error flags a healthy session every ~30 s."""
+    adapter, _, _, store, _ = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    assert adapter.last_error is None
+    saved = store.data
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert adapter.last_error is None
+    assert adapter.last_intent.name == "FORCE_CHARGE"
+    assert store.data is saved  # no second snapshot was taken
+
+
+@pytest.mark.asyncio
+async def test_snapshot_from_another_life_still_refuses_a_new_session():
+    """Restart recovery keeps its teeth: a snapshot THIS instance did not
+    open must replay through command_normal before a new session starts."""
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, config)
+
+    await restarted.command_force_charge(80, 1067, 60)
+
+    assert "must be restored" in restarted.last_error
+
+
+@pytest.mark.asyncio
+async def test_no_snapshot_store_is_a_configuration_not_a_failure():
+    """A store-less install (capability reporting only) must not latch the
+    adapter unsafe on its first command_normal."""
+    config, states = _valid_setup()
+    hass = _Hass(states)
+    adapter = DeyeBatteryAdapter(hass, config)
+
+    await adapter.command_normal()
+
+    assert adapter.unsafe_latched is False
+    assert adapter.last_error is None
+    assert adapter.last_intent.name == "NORMAL"
+    hass.services.async_call.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_limit_discharge_records_the_intent_it_declined():
+    adapter, _, _, _, _ = _active_adapter()
+
+    await adapter.command_limit_discharge(1500)
+
+    assert adapter.last_intent.name == "LIMIT_DISCHARGE"
+    assert "not implemented" in adapter.last_error

--- a/tests/test_deye_battery_adapter.py
+++ b/tests/test_deye_battery_adapter.py
@@ -3,6 +3,12 @@ from __future__ import annotations
 
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
+
+from custom_components.solar_energy_management.coordinator.battery_adapters.deye_schedule import (
+    DeyeScheduleError,
+    active_deye_slot,
+    compile_deye_charge_window,
+)
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -106,6 +112,7 @@ def _valid_setup(*, program_control=True):
         ),
         "sensor.battery_voltage": _state(53.35),
     }
+    program_times = ("01:00:00", "05:00:00", "09:00:00", "13:00:00", "17:00:00", "21:00:00")
     for index in range(1, 7):
         time_entity = f"time.program_{index}"
         soc_entity = f"number.program_{index}_soc"
@@ -113,7 +120,7 @@ def _valid_setup(*, program_control=True):
         config["deye_program_groups"].append(
             {"time": time_entity, "soc": soc_entity, "charge": charge_entity}
         )
-        states[time_entity] = _state("00:00:00")
+        states[time_entity] = _state(program_times[index - 1])
         states[soc_entity] = _state(
             21, unit_of_measurement="%", min=0, max=100,
         )
@@ -129,7 +136,9 @@ def _adapter(config=None, states=None, *, hass=None):
     return DeyeBatteryAdapter(hass or _Hass(states), config)
 
 
-def _active_adapter(*, mismatch_pairs=None, fail_pairs=None, store=None, events=None):
+def _active_adapter(
+    *, mismatch_pairs=None, fail_pairs=None, store=None, events=None, work_mode=False
+):
     config, states = _valid_setup()
     shared_events = events if events is not None else []
     snapshot_store = store or _Store(shared_events)
@@ -140,7 +149,12 @@ def _active_adapter(*, mismatch_pairs=None, fail_pairs=None, store=None, events=
         deye_observer_mode=False,
         deye_actuation_enabled=True,
         deye_readback_attempts=1,
+        deye_now_provider=lambda: datetime(
+            2026, 8, 1, 1, 30, tzinfo=timezone.utc
+        ),
     )
+    if work_mode:
+        _enable_work_mode(config, states)
     hass = _Hass(
         states,
         events=shared_events,
@@ -148,6 +162,19 @@ def _active_adapter(*, mismatch_pairs=None, fail_pairs=None, store=None, events=
         fail_pairs=fail_pairs,
     )
     return DeyeBatteryAdapter(hass, config), config, states, snapshot_store, shared_events
+
+
+def _enable_work_mode(config, states, *, state="Load First"):
+    config.update(
+        deye_work_mode_control=True,
+        deye_work_mode_entity="select.work_mode",
+        deye_work_mode_load_first_option="Load First",
+        deye_work_mode_battery_first_option="Battery First",
+        deye_force_charge_work_mode="battery_first",
+    )
+    states["select.work_mode"] = _state(
+        state, options=["Load First", "Battery First"]
+    )
 
 
 def test_complete_capability_is_available_and_serialisable():
@@ -483,3 +510,154 @@ async def test_corrupt_snapshot_never_reports_successful_stop_or_writes():
     assert store.unsafe is True
     assert store.data == {"grid_charge_enabled": "false"}
     assert "snapshot load failed" in restarted.last_error
+
+
+def test_work_mode_requires_explicit_verified_select_mapping():
+    config, states = _valid_setup()
+    _enable_work_mode(config, states)
+    assert _adapter(config, states).capability().available is True
+
+    config["deye_work_mode_entity"] = "input_select.work_mode"
+    capability = _adapter(config, states).capability()
+    assert capability.available is False
+    assert "select.*" in capability.reason
+
+
+def test_equal_program_boundaries_make_adapter_fail_closed():
+    config, states = _valid_setup()
+    states["time.program_2"].state = states["time.program_1"].state
+
+    capability = _adapter(config, states).capability()
+
+    assert capability.available is False
+    assert "unique" in capability.reason
+
+
+@pytest.mark.asyncio
+async def test_work_mode_is_snapshotted_written_and_restored():
+    adapter, _, states, store, events = _active_adapter(work_mode=True)
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert store.data["work_mode"] == "Load First"
+    assert states["select.work_mode"].state == "Battery First"
+    assert ("select.work_mode", "Battery First") in events
+
+    await adapter.command_stop_force_charge()
+
+    assert states["select.work_mode"].state == "Load First"
+    assert store.data is None
+
+
+@pytest.mark.asyncio
+async def test_work_mode_readback_mismatch_rolls_back_without_success():
+    adapter, _, states, store, _ = _active_adapter(
+        work_mode=True,
+        mismatch_pairs={("select.work_mode", "Battery First")},
+    )
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert adapter.last_intent is None
+    assert "rollback verified" in adapter.last_error
+    assert adapter.unsafe_latched is False
+    assert store.data is None
+    assert states["select.work_mode"].state == "Load First"
+
+
+BOUNDARIES = ("01:00", "05:00", "09:00", "13:00", "17:00", "21:00")
+
+
+def test_active_slot_is_deterministic_and_wraps_midnight():
+    assert active_deye_slot(
+        BOUNDARIES, datetime(2026, 8, 1, 0, 30, tzinfo=timezone.utc)
+    ) == 6
+    assert active_deye_slot(
+        BOUNDARIES, datetime(2026, 8, 1, 9, 0, tzinfo=timezone.utc)
+    ) == 3
+
+
+@pytest.mark.parametrize(
+    "boundaries",
+    [
+        BOUNDARIES[:5],
+        ("01:00", "05:00", "05:00", "13:00", "17:00", "21:00"),
+        ("01:00", "09:00", "05:00", "13:00", "17:00", "21:00"),
+        ("01:00", "05:00", "bad", "13:00", "17:00", "21:00"),
+    ],
+)
+def test_active_slot_rejects_invalid_or_ambiguous_schedules(boundaries):
+    with pytest.raises(DeyeScheduleError):
+        active_deye_slot(
+            boundaries, datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+        )
+
+
+def test_active_slot_requires_timezone_aware_now():
+    with pytest.raises(DeyeScheduleError, match="timezone-aware"):
+        active_deye_slot(BOUNDARIES, datetime(2026, 8, 1, 10, 0))
+
+
+def test_charge_window_compiler_changes_only_overlapping_slots():
+    daytime = compile_deye_charge_window(
+        BOUNDARIES,
+        datetime(2026, 8, 1, 12, 30, tzinfo=timezone.utc),
+        90,
+        80,
+    )
+    midnight = compile_deye_charge_window(
+        BOUNDARIES,
+        datetime(2026, 8, 1, 23, 30, tzinfo=timezone.utc),
+        120,
+        75,
+    )
+
+    assert daytime.slot_indices == (3, 4)
+    assert daytime.reserve_soc == 80
+    assert midnight.slot_indices == (1, 6)
+
+
+@pytest.mark.parametrize("duration", [0, -1, 1441, 1.5, True])
+def test_charge_window_compiler_rejects_unsafe_durations(duration):
+    with pytest.raises(DeyeScheduleError):
+        compile_deye_charge_window(
+            BOUNDARIES,
+            datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc),
+            duration,
+            80,
+        )
+
+
+@pytest.mark.parametrize(
+    ("duration", "reserve_soc"),
+    [(float("inf"), 80), (60, True)],
+)
+def test_charge_window_compiler_rejects_non_finite_or_boolean_inputs(
+    duration, reserve_soc
+):
+    with pytest.raises(DeyeScheduleError):
+        compile_deye_charge_window(
+            BOUNDARIES,
+            datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc),
+            duration,
+            reserve_soc,
+        )
+
+
+@pytest.mark.asyncio
+async def test_tampered_snapshot_with_ambiguous_times_is_never_restored():
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    assert store.data is not None
+    store.data["program_times"][1] = store.data["program_times"][0]
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, config)
+    writes_before = restarted_hass.services.async_call.await_count
+
+    await restarted.command_stop_force_charge()
+
+    assert restarted_hass.services.async_call.await_count == writes_before
+    assert restarted.last_intent is None
+    assert restarted.unsafe_latched is True
+    assert store.unsafe is True
+    assert "program times are invalid" in restarted.last_error

--- a/tests/test_deye_battery_adapter.py
+++ b/tests/test_deye_battery_adapter.py
@@ -1,0 +1,485 @@
+"""Fail-closed contract tests for the explicit Deye battery adapter."""
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.battery_adapters import (
+    DeyeBatteryAdapter,
+    GenericBatteryAdapter,
+    adapter_for,
+)
+
+
+class _States:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, entity_id):
+        return self._values.get(entity_id)
+
+
+class _Store:
+    def __init__(self, events=None):
+        self.data = None
+        self.unsafe = False
+        self.events = events if events is not None else []
+
+    async def async_save(self, data):
+        self.events.append("snapshot_saved")
+        self.data = data
+
+    async def async_load(self):
+        return self.data
+
+    async def async_clear(self):
+        self.events.append("snapshot_cleared")
+        self.data = None
+
+    async def async_set_unsafe(self, value):
+        self.unsafe = bool(value)
+
+
+class _Hass:
+    def __init__(self, values, *, events=None, mismatch_pairs=None, fail_pairs=None):
+        self.states = _States(values)
+        self.data = {}
+        self.config_entries = SimpleNamespace(async_entries=lambda _domain: [])
+        self.events = events if events is not None else []
+        self.mismatch_pairs = set(mismatch_pairs or ())
+        self.fail_pairs = set(fail_pairs or ())
+
+        async def _call(domain, service, data, blocking=True):
+            entity_id = data["entity_id"]
+            if "value" in data:
+                value = data["value"]
+            elif "option" in data:
+                value = data["option"]
+            elif "time" in data:
+                value = data["time"]
+            else:
+                value = service == "turn_on"
+            self.events.append((entity_id, value))
+            if (entity_id, value) in self.fail_pairs:
+                raise RuntimeError("simulated service failure")
+            if (entity_id, value) in self.mismatch_pairs:
+                return
+            state = values[entity_id]
+            if domain == "switch":
+                state.state = "on" if value else "off"
+            else:
+                state.state = str(value)
+
+        self.services = SimpleNamespace(async_call=AsyncMock(side_effect=_call))
+
+
+def _state(value, *, age_s=1, **attributes):
+    return SimpleNamespace(
+        state=str(value),
+        attributes=attributes,
+        last_updated=datetime.now(timezone.utc) - timedelta(seconds=age_s),
+        last_changed=datetime.now(timezone.utc) - timedelta(seconds=age_s),
+    )
+
+
+def _valid_setup(*, program_control=True):
+    config = {
+        "battery_charge_platform": "deye",
+        "deye_grid_charge_switch": "switch.grid_charge",
+        "deye_charge_current_entity": "number.grid_charge_current",
+        "deye_battery_voltage_entity": "sensor.battery_voltage",
+        "deye_battery_voltage_max_age_s": 60,
+        "deye_max_charge_current_a": 25,
+        "deye_bms_max_charge_current_a": 20,
+        "deye_max_discharge_power": 5000,
+        "deye_program_control": program_control,
+        "deye_program_groups": [],
+    }
+    states = {
+        "switch.grid_charge": _state("off"),
+        "number.grid_charge_current": _state(
+            0, unit_of_measurement="A", min=0, max=32,
+        ),
+        "sensor.battery_voltage": _state(53.35),
+    }
+    for index in range(1, 7):
+        time_entity = f"time.program_{index}"
+        soc_entity = f"number.program_{index}_soc"
+        charge_entity = f"select.program_{index}_charging"
+        config["deye_program_groups"].append(
+            {"time": time_entity, "soc": soc_entity, "charge": charge_entity}
+        )
+        states[time_entity] = _state("00:00:00")
+        states[soc_entity] = _state(
+            21, unit_of_measurement="%", min=0, max=100,
+        )
+        states[charge_entity] = _state(
+            "Disabled", options=["Disabled", "Grid", "Generator", "Both"],
+        )
+    return config, states
+
+
+def _adapter(config=None, states=None, *, hass=None):
+    if config is None or states is None:
+        config, states = _valid_setup()
+    return DeyeBatteryAdapter(hass or _Hass(states), config)
+
+
+def _active_adapter(*, mismatch_pairs=None, fail_pairs=None, store=None, events=None):
+    config, states = _valid_setup()
+    shared_events = events if events is not None else []
+    snapshot_store = store or _Store(shared_events)
+    config.update(
+        config_entry_id="entry-1",
+        battery_id="battery-1",
+        deye_snapshot_store=snapshot_store,
+        deye_observer_mode=False,
+        deye_actuation_enabled=True,
+        deye_readback_attempts=1,
+    )
+    hass = _Hass(
+        states,
+        events=shared_events,
+        mismatch_pairs=mismatch_pairs,
+        fail_pairs=fail_pairs,
+    )
+    return DeyeBatteryAdapter(hass, config), config, states, snapshot_store, shared_events
+
+
+def test_complete_capability_is_available_and_serialisable():
+    adapter = _adapter()
+
+    capability = adapter.capability()
+
+    assert capability.available is True
+    assert capability.reason == "ok"
+    assert capability.max_charge_current_a == 20
+    assert 0 <= capability.battery_voltage_age_s < 10
+    assert capability.snapshot_supported is False
+    assert capability.readback_supported is False
+    assert capability.restore_supported is False
+    assert adapter.supports_forced_charge is False
+    assert adapter.max_charge_power_w == pytest.approx(20 * 53.35)
+    assert asdict(capability)["available"] is True
+
+
+def test_explicit_factory_selects_deye_but_auto_never_does():
+    config, states = _valid_setup()
+    hass = _Hass(states)
+
+    assert isinstance(adapter_for(hass, config), DeyeBatteryAdapter)
+    auto_config = dict(config)
+    auto_config["battery_charge_platform"] = "auto"
+    assert isinstance(adapter_for(hass, auto_config), GenericBatteryAdapter)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason_fragment"),
+    [
+        (lambda c, s: c.update(deye_grid_charge_switch="number.grid_charge_current"), "switch.*"),
+        (lambda c, s: setattr(s["switch.grid_charge"], "state", "unavailable"), "switch state"),
+        (lambda c, s: s["number.grid_charge_current"].attributes.update(unit_of_measurement="W"), "unit A"),
+        (lambda c, s: s["number.grid_charge_current"].attributes.update(min=-1), "0 <= min"),
+        (lambda c, s: setattr(s["number.grid_charge_current"], "state", "unknown"), "current state"),
+        (lambda c, s: setattr(s["sensor.battery_voltage"], "state", "nan"), "voltage state"),
+        (lambda c, s: setattr(s["sensor.battery_voltage"], "state", "0"), "at least 40"),
+        (lambda c, s: setattr(s["sensor.battery_voltage"], "state", "39.9"), "at least 40"),
+        (lambda c, s: setattr(s["sensor.battery_voltage"], "last_updated", datetime.now(timezone.utc) - timedelta(seconds=120)), "stale"),
+        (lambda c, s: c.pop("deye_max_charge_current_a"), "safe max"),
+        (lambda c, s: c.update(deye_max_charge_current_a=float("inf")), "safe max"),
+        (lambda c, s: c.update(deye_bms_max_charge_current_a=-1), "BMS max"),
+        (lambda c, s: c.update(deye_battery_voltage_max_age_s="bad"), "max age"),
+        (lambda c, s: c["deye_program_groups"].pop(), "requires 6"),
+        (lambda c, s: s["number.program_1_soc"].attributes.update(max=99), "SOC range"),
+        (lambda c, s: s["number.program_1_soc"].attributes.update(max=float("inf")), "finite"),
+        (lambda c, s: s["select.program_1_charging"].attributes.update(options=["Disabled"]), "Disabled and Grid"),
+        (lambda c, s: setattr(s["select.program_1_charging"], "state", "unavailable"), "select state"),
+        (lambda c, s: c["deye_program_groups"][0].update(time="select.wrong_time_domain"), "time entity"),
+    ],
+)
+def test_capability_fail_closed(mutate, reason_fragment):
+    config, states = _valid_setup()
+    mutate(config, states)
+
+    capability = _adapter(config, states).capability()
+
+    assert capability.available is False
+    assert capability.max_charge_current_a == 0
+    assert reason_fragment.lower() in capability.reason.lower()
+
+
+def test_program_entities_are_optional_only_when_program_control_is_disabled():
+    config, states = _valid_setup(program_control=False)
+    config["deye_program_groups"] = []
+
+    capability = _adapter(config, states).capability()
+
+    assert capability.available is True
+
+
+def test_default_voltage_freshness_is_30_seconds():
+    config, states = _valid_setup()
+    config.pop("deye_battery_voltage_max_age_s")
+    states["sensor.battery_voltage"].last_updated = (
+        datetime.now(timezone.utc) - timedelta(seconds=31)
+    )
+
+    capability = _adapter(config, states).capability()
+
+    assert capability.available is False
+    assert "stale" in capability.reason
+
+
+@pytest.mark.asyncio
+async def test_observer_mode_is_no_write_and_never_records_force_charge():
+    adapter = _adapter()
+
+    await adapter.command_force_charge(80, 3000, 60)
+
+    adapter._hass.services.async_call.assert_not_awaited()
+    assert adapter.last_intent is None
+    assert "observer mode" in adapter.last_error
+
+
+def test_invalid_discharge_config_falls_back_to_zero():
+    config, states = _valid_setup()
+    config["deye_max_discharge_power"] = float("nan")
+
+    assert _adapter(config, states).max_discharge_power_w == 0
+
+
+def test_active_writes_require_store_scope_and_explicit_operator_gates():
+    adapter, _, _, _, _ = _active_adapter()
+    assert adapter.capability().snapshot_supported is True
+    assert adapter.supports_forced_charge is True
+
+
+@pytest.mark.asyncio
+async def test_string_false_never_opens_actuation_gate():
+    _, config, states, _, _ = _active_adapter()
+    config = dict(config)
+    config["deye_actuation_enabled"] = "false"
+    hass = _Hass(states)
+    adapter = DeyeBatteryAdapter(hass, config)
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert adapter.supports_forced_charge is False
+    hass.services.async_call.assert_not_awaited()
+    assert adapter.last_intent is None
+    assert "explicitly enabled" in adapter.last_error
+
+
+def test_non_string_scope_ids_never_enable_writes():
+    _, config, states, _, _ = _active_adapter()
+    config = dict(config)
+    config["config_entry_id"] = None
+    config["battery_id"] = 123
+
+    adapter = DeyeBatteryAdapter(_Hass(states), config)
+
+    assert adapter.supports_forced_charge is False
+
+
+def test_store_without_unsafe_persistence_never_enables_writes():
+    _, config, states, _, _ = _active_adapter()
+    config = dict(config)
+    config["deye_snapshot_store"] = SimpleNamespace(
+        async_save=AsyncMock(),
+        async_load=AsyncMock(return_value=None),
+        async_clear=AsyncMock(),
+    )
+
+    adapter = DeyeBatteryAdapter(_Hass(states), config)
+
+    assert adapter.supports_forced_charge is False
+
+
+@pytest.mark.asyncio
+async def test_snapshot_must_read_back_from_store_before_first_write():
+    class _NonPersistingStore(_Store):
+        async def async_save(self, data):
+            self.events.append("snapshot_save_attempted")
+
+    config, states = _valid_setup()
+    events = []
+    store = _NonPersistingStore(events)
+    config.update(
+        config_entry_id="entry-1",
+        battery_id="battery-1",
+        deye_snapshot_store=store,
+        deye_observer_mode=False,
+        deye_actuation_enabled=True,
+        deye_readback_attempts=1,
+    )
+    hass = _Hass(states, events=events)
+    adapter = DeyeBatteryAdapter(hass, config)
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    hass.services.async_call.assert_not_awaited()
+    assert adapter.last_intent is None
+    assert "persistence failed" in adapter.last_error
+
+
+@pytest.mark.asyncio
+async def test_snapshot_is_persisted_before_first_write_and_stop_restores_in_safe_order():
+    adapter, _, states, store, events = _active_adapter()
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert events[0] == "snapshot_saved"
+    assert store.data is not None
+    assert store.data["config_entry_id"] == "entry-1"
+    assert store.data["battery_id"] == "battery-1"
+    assert len(store.data["program_times"]) == 6
+    assert store.data["created_at"] <= adapter._session_first_write_at
+    assert adapter.last_intent.name == "FORCE_CHARGE"
+    assert states["number.grid_charge_current"].state == "20.0"
+    assert states["number.program_1_soc"].state == "80.0"
+    assert states["select.program_1_charging"].state == "Grid"
+    assert states["switch.grid_charge"].state == "on"
+
+    stop_start = len(events)
+    await adapter.command_stop_force_charge()
+    stop_events = events[stop_start:]
+
+    assert stop_events[0] == ("number.grid_charge_current", 0.0)
+    assert stop_events[1] == ("switch.grid_charge", False)
+    assert stop_events[-2] == ("switch.grid_charge", False)
+    assert stop_events[-1] == "snapshot_cleared"
+    assert store.data is None
+    assert adapter.last_intent.name == "STOP_FORCE_CHARGE"
+    assert states["number.grid_charge_current"].state == "0.0"
+    assert states["number.program_1_soc"].state == "21.0"
+    assert states["select.program_1_charging"].state == "Disabled"
+    assert states["switch.grid_charge"].state == "off"
+
+
+@pytest.mark.asyncio
+async def test_readback_mismatch_rolls_back_and_does_not_record_success():
+    adapter, _, states, store, _ = _active_adapter(
+        mismatch_pairs={("select.program_1_charging", "Grid")},
+    )
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert adapter.last_intent is None
+    assert "rollback verified" in adapter.last_error
+    assert adapter.unsafe_latched is False
+    assert store.data is None
+    assert states["number.grid_charge_current"].state == "0.0"
+    assert states["number.program_1_soc"].state == "21.0"
+    assert states["switch.grid_charge"].state == "off"
+
+
+@pytest.mark.asyncio
+async def test_rollback_readback_failure_persists_unsafe_latch():
+    adapter, _, states, store, events = _active_adapter(
+        mismatch_pairs={
+            ("select.program_1_charging", "Grid"),
+            ("number.grid_charge_current", 0.0),
+        },
+    )
+    # Pre-existing external charging: failed safe-zero must still switch off
+    # and must never restore 5 A / re-enable the switch.
+    states["switch.grid_charge"].state = "on"
+    states["number.grid_charge_current"].state = "5"
+
+    await adapter.command_force_charge(80, 1067, 60)
+
+    assert adapter.last_intent is None
+    assert adapter.unsafe_latched is True
+    assert store.unsafe is True
+    assert store.data is not None
+    assert "rollback FAILED" in adapter.last_error
+    assert adapter.supports_forced_charge is False
+    rollback_start = events.index(("number.grid_charge_current", 0.0))
+    rollback_events = events[rollback_start:]
+    assert len(rollback_events) == 2
+    assert rollback_events[1] == ("switch.grid_charge", False)
+    assert ("number.grid_charge_current", 5.0) not in rollback_events
+    assert ("switch.grid_charge", True) not in rollback_events
+    assert states["switch.grid_charge"].state == "off"
+    assert adapter.unsafe_latched is True
+    assert store.unsafe is True
+
+
+@pytest.mark.asyncio
+async def test_unsafe_latch_without_snapshot_never_reports_normal_success():
+    adapter, _, _, store, _ = _active_adapter()
+    adapter._unsafe_latched = True
+    store.unsafe = True
+
+    await adapter.command_normal()
+
+    assert adapter.last_intent is None
+    assert "unsafe latch" in adapter.last_error
+
+
+@pytest.mark.asyncio
+async def test_persisted_snapshot_can_be_restored_after_adapter_restart():
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    assert store.data is not None
+
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, config)
+    await restarted.command_normal()
+
+    assert restarted.last_intent.name == "NORMAL"
+    assert restarted.unsafe_latched is False
+    assert store.data is None
+    assert states["switch.grid_charge"].state == "off"
+
+
+@pytest.mark.asyncio
+async def test_snapshot_scope_or_entity_mapping_mismatch_blocks_restore_and_latches():
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    config = dict(config)
+    config["battery_id"] = "different-battery"
+    mismatched = DeyeBatteryAdapter(_Hass(states, events=events), config)
+
+    await mismatched.command_stop_force_charge()
+
+    assert mismatched.last_intent is None
+    assert mismatched.unsafe_latched is True
+    assert store.unsafe is True
+    assert "scope mismatch" in mismatched.last_error
+
+
+@pytest.mark.asyncio
+async def test_stale_persisted_snapshot_is_never_overwritten_by_new_session():
+    adapter, config, states, store, events = _active_adapter()
+    await adapter.command_force_charge(80, 1067, 60)
+    saved_session = store.data["session_id"]
+    store.data["created_at"] -= 3600
+    restarted = DeyeBatteryAdapter(_Hass(states, events=events), config)
+
+    await restarted.command_force_charge(90, 1500, 60)
+
+    assert restarted.last_intent is None
+    assert "pending Deye snapshot" in restarted.last_error
+    assert store.data["session_id"] == saved_session
+
+
+@pytest.mark.asyncio
+async def test_corrupt_snapshot_never_reports_successful_stop_or_writes():
+    _, config, states, store, events = _active_adapter()
+    store.data = {"grid_charge_enabled": "false"}
+    restarted_hass = _Hass(states, events=events)
+    restarted = DeyeBatteryAdapter(restarted_hass, config)
+
+    await restarted.command_stop_force_charge()
+
+    restarted_hass.services.async_call.assert_not_awaited()
+    assert restarted.last_intent is None
+    assert restarted.unsafe_latched is True
+    assert store.unsafe is True
+    assert store.data == {"grid_charge_enabled": "false"}
+    assert "snapshot load failed" in restarted.last_error

--- a/tests/test_deye_config_flow.py
+++ b/tests/test_deye_config_flow.py
@@ -1,0 +1,277 @@
+"""#709 — Deye config/options flow + diagnostics for a real SEM install.
+
+This slice ships the options-flow surface that lets an operator wire a
+Deye hybrid inverter (forced grid charging) in a real Home Assistant
+install WITHOUT hand-editing YAML. It also exposes read-only Deye
+diagnostics.
+
+Config shape produced by the flow (matches the DeyeBatteryAdapter
+contract in ``battery_adapters/deye.py``):
+
+    battery_charge_platform: deye
+    deye_grid_charge_switch: switch.*
+    deye_charge_current_entity: number.*            # unit A
+    deye_battery_voltage_entity: sensor.*
+    deye_max_charge_current_a: float                # safe ceiling
+    deye_bms_max_charge_current_a: float|None       # optional BMS max
+    deye_program_control: true
+    deye_program_groups: [ {time, soc, charge} x6 ]
+    deye_work_mode_control: bool
+    deye_work_mode_entity: select.*
+    deye_work_mode_load_first_option: str
+    deye_work_mode_battery_first_option: str        # distinct from load_first
+    deye_force_charge_work_mode: load_first|battery_first
+    deye_observer_mode: true   # DEFAULT true — no writes until operator opts out
+    deye_actuation_enabled: false  # DEFAULT false — exact bool required to write
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.config_flow import (
+    OptionsFlowHandler,
+)
+
+
+def _flow(mock_hass, config_entry):
+    flow = OptionsFlowHandler(config_entry)
+    flow.hass = mock_hass
+    flow.hass.data = {"_entry": config_entry}  # used by _run_step patch
+    return flow
+
+
+async def _run_step(flow, step_name, *args):
+    """Invoke an options-flow step with the ``config_entry`` property patched
+    to return the mock (newer HA resolves ``self.config_entry`` through the
+    configured-entry registry; tests supply a plain MagicMock)."""
+    from unittest.mock import patch
+
+    entry = flow.hass.data.get("_entry")
+    step = getattr(flow, step_name)
+    with patch.object(
+        type(flow),
+        "config_entry",
+        new_callable=lambda: property(lambda self: entry if entry is not None else MagicMock()),
+    ):
+        return await step(*args)
+
+
+def _deye_platform_input():
+    """A complete, valid Deye options submission (the happy path)."""
+    data = {
+        "battery_charge_platform": "deye",
+        "deye_grid_charge_switch": "switch.deye_grid_charge",
+        "deye_charge_current_entity": "number.deye_charge_current",
+        "deye_battery_voltage_entity": "sensor.deye_battery_voltage",
+        "deye_max_charge_current_a": 25,
+        "deye_bms_max_charge_current_a": 30,
+        "deye_program_control": True,
+        "deye_work_mode_control": True,
+        "deye_work_mode_entity": "select.deye_energy_pattern",
+        "deye_work_mode_load_first_option": "Load First",
+        "deye_work_mode_battery_first_option": "Battery First",
+        "deye_force_charge_work_mode": "battery_first",
+        "deye_observer_mode": False,
+        "deye_actuation_enabled": True,
+    }
+    for n in range(1, 7):
+        data[f"deye_program_{n}_time"] = f"select.deye_slice_{n}_time"
+        data[f"deye_program_{n}_soc"] = f"number.deye_slice_{n}_soc"
+        data[f"deye_program_{n}_charge"] = f"select.deye_slice_{n}_charge"
+    return data
+
+
+def _assert_deye_keys(payload: dict):
+    """Assert the saved payload matches the documented Deye contract."""
+    assert payload.get("battery_charge_platform") == "deye"
+    assert payload["deye_grid_charge_switch"] == "switch.deye_grid_charge"
+    assert payload["deye_charge_current_entity"] == "number.deye_charge_current"
+    assert payload["deye_battery_voltage_entity"] == "sensor.deye_battery_voltage"
+    assert payload["deye_max_charge_current_a"] == 25
+    assert payload["deye_bms_max_charge_current_a"] == 30
+    # Booleans must remain REAL bools — never strings.
+    assert payload["deye_program_control"] is True
+    assert payload["deye_work_mode_control"] is True
+    assert payload["deye_work_mode_load_first_option"] == "Load First"
+    assert payload["deye_work_mode_battery_first_option"] == "Battery First"
+    assert payload["deye_force_charge_work_mode"] == "battery_first"
+    assert payload["deye_observer_mode"] is False
+    assert payload["deye_actuation_enabled"] is True
+    # Exactly six complete program groups, each {time, soc, charge}.
+    groups = payload["deye_program_groups"]
+    assert isinstance(groups, list)
+    assert len(groups) == 6
+    for idx, group in enumerate(groups, start=1):
+        assert group["time"] == f"select.deye_slice_{idx}_time"
+        assert group["soc"] == f"number.deye_slice_{idx}_soc"
+        assert group["charge"] == f"select.deye_slice_{idx}_charge"
+
+
+class TestDeyeOptionsFlow:
+    @pytest.mark.asyncio
+    async def test_scheduler_only_opens_deye_step_when_selected(
+        self, mock_hass, config_entry
+    ):
+        generic = _flow(mock_hass, config_entry)
+        generic_result = await _run_step(
+            generic, "async_step_battery_scheduler",
+            {"battery_charge_platform": "generic"},
+        )
+        assert generic_result["step_id"] != "deye"
+
+        deye = _flow(mock_hass, config_entry)
+        deye_result = await _run_step(
+            deye, "async_step_battery_scheduler",
+            {"battery_charge_platform": "deye"},
+        )
+        assert deye_result["step_id"] == "deye"
+
+    @pytest.mark.asyncio
+    async def test_submit_complete_form_stores_full_contract(self, mock_hass, config_entry):
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", _deye_platform_input())
+        # Proceeds past Deye after a valid submission. With no configured PV
+        # strings the existing flow may immediately skip pv_naming.
+        assert result["type"] == "form"
+        assert result["step_id"] != "deye"
+        _assert_deye_keys(flow._data)
+
+    @pytest.mark.asyncio
+    async def test_defaults_observer_on_actuation_off(self, mock_hass, config_entry):
+        """Fresh form defaults: observer_mode True, actuation_enabled False —
+        so a bare Deye config never actuates until the operator opts in."""
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye")
+        assert result["type"] == "form"
+        schema = result["data_schema"]
+        def _default(name: str):
+            marker = next(k for k in schema.schema if str(k) == name)
+            return marker.default() if callable(marker.default) else marker.default
+
+        assert _default("deye_observer_mode") is True
+        assert _default("deye_actuation_enabled") is False
+        assert _default("deye_program_control") is True
+        assert _default("deye_work_mode_control") is False
+
+    @pytest.mark.asyncio
+    async def test_platform_not_deye_skips_work_mode_requirement(self, mock_hass, config_entry):
+        """Choosing a non-Deye platform doesn't demand Deye work-mode options."""
+        data = _deye_platform_input()
+        data["battery_charge_platform"] = "generic"
+        data.pop("deye_work_mode_entity", None)
+        data["deye_work_mode_control"] = False
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", data)
+        assert result["step_id"] != "deye"
+
+    @pytest.mark.asyncio
+    async def test_missing_sixth_program_group_is_validation_error(self, mock_hass, config_entry):
+        """Deye requires exactly six complete program groups — five is invalid."""
+        data = _deye_platform_input()
+        # Drop group 6 entirely.
+        for key in ("deye_program_6_time", "deye_program_6_soc", "deye_program_6_charge"):
+            data.pop(key, None)
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", data)
+        assert result["type"] == "form"
+        assert result["step_id"] == "deye"
+        assert result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_program_group_invalid(self, mock_hass, config_entry):
+        """A group missing one of time/soc/charge is incomplete → invalid."""
+        data = _deye_platform_input()
+        data.pop("deye_program_3_soc", None)
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", data)
+        assert result["step_id"] == "deye"
+        assert result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_work_mode_mappings_must_be_distinct(self, mock_hass, config_entry):
+        data = _deye_platform_input()
+        data["deye_work_mode_load_first_option"] = "Same"
+        data["deye_work_mode_battery_first_option"] = "Same"
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", data)
+        assert result["step_id"] == "deye"
+        assert result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_force_charge_mode_must_be_valid(self, mock_hass, config_entry):
+        data = _deye_platform_input()
+        data["deye_force_charge_work_mode"] = "bogus"
+        flow = _flow(mock_hass, config_entry)
+        result = await _run_step(flow, "async_step_deye", data)
+        assert result["step_id"] == "deye"
+        assert result["errors"]
+
+    @pytest.mark.asyncio
+    async def test_round_trip_payload_feeds_capability(self, mock_hass, config_entry):
+        """The saved options must be directly consumable by the real
+        DeyeBatteryAdapter config contract (list-of-6 groups resolve)."""
+        from custom_components.solar_energy_management.coordinator.battery_adapters.deye import (
+            DeyeBatteryAdapter,
+        )
+
+        flow = _flow(mock_hass, config_entry)
+        await _run_step(flow, "async_step_deye", _deye_platform_input())
+        payload = dict(flow._data)
+
+        class _States:
+            def __init__(self, mapping):
+                self._mapping = mapping
+            def get(self, eid):
+                return self._mapping.get(eid)
+
+        from datetime import datetime, timedelta, timezone
+        from types import SimpleNamespace
+
+        now = datetime.now(timezone.utc)
+
+        def st(value, **attrs):
+            return SimpleNamespace(
+                state=str(value), attributes=attrs,
+                last_updated=now - timedelta(seconds=1),
+                last_changed=now - timedelta(seconds=1),
+            )
+
+        states = {
+            "switch.deye_grid_charge": st("off"),
+            "number.deye_charge_current": st(0, unit_of_measurement="A", min=0, max=32),
+            "sensor.deye_battery_voltage": st(53.35),
+        }
+        groups = payload["deye_program_groups"]
+        for g in groups:
+            states[g["time"]] = st("01:00:00")
+            states[g["soc"]] = st(21, unit_of_measurement="%", min=0, max=100)
+            states[g["charge"]] = st("Disabled", options=["Disabled", "Grid"])
+
+        _hass = MagicMock()
+        _hass.states = _States(states)
+
+        adapter_config = {
+            **payload,
+            "deye_snapshot_store": MagicMock(),
+            "deye_max_charge_current_a": 25,
+            "deye_bms_max_charge_current_a": 30,
+        }
+        adapter = DeyeBatteryAdapter(_hass, adapter_config)
+        # The saved six groups must resolve to six complete slots.
+        slots = adapter._program_slots()
+        assert len(slots) == 6
+        assert all(slot is not None for slot in slots)
+
+    @pytest.mark.asyncio
+    async def test_no_store_in_options(self, mock_hass, config_entry):
+        """The runtime snapshot store must never be serialised into the
+        saved entry options (it is attached to the adapter, not the entry)."""
+        flow = _flow(mock_hass, config_entry)
+        await _run_step(flow, "async_step_deye", _deye_platform_input())
+        payload = dict(flow._data)
+        assert "deye_snapshot_store" not in payload
+        assert all(
+            not isinstance(v, type) for v in payload.values()
+        )  # nothing but plain data

--- a/tests/test_deye_diagnostics.py
+++ b/tests/test_deye_diagnostics.py
@@ -1,0 +1,169 @@
+"""#709 — read-only Deye diagnostics surface.
+
+The diagnostics dump must expose enough to triage a Deye forced-charge
+install from one payload: is forced charge currently available (and if
+not, WHICH configured/state gate tripped), is the scope safety-latched
+unsafe, and what the last recovery/actuation error was. This block is
+READ-ONLY — it never triggers a write and must not leak the runtime
+snapshot store or any secret.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+
+@pytest.fixture
+def _diag_hass(tmp_path):
+    h = MagicMock()
+    h.config = MagicMock()
+    h.config.config_dir = str(tmp_path)
+
+    async def _executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    h.async_add_executor_job = _executor
+    return h
+
+
+@pytest.fixture
+def _diag_entry():
+    e = MagicMock()
+    e.entry_id = "test_deye_diag"
+    e.version = 16
+    e.title = "Solar Energy Management"
+    e.domain = "solar_energy_management"
+    e.data = {"battery_charge_platform": "deye"}
+    e.options = {
+        "deye_observer_mode": False,
+        "deye_actuation_enabled": True,
+    }
+    return e
+
+
+@pytest.fixture
+def _diag_coordinator():
+    c = MagicMock()
+    c.last_update_success = True
+    c.update_interval = timedelta(seconds=10)
+    c._observer_mode = False
+    c._load_manager = None
+    c._energy_dashboard_config = None
+    c.data = {}
+    return c
+
+
+def _make_adapter(unsafe=False, avail=True, reason="ok", last_error=None):
+    cap = MagicMock()
+    cap.available = avail
+    cap.reason = reason
+    cap.max_charge_current_a = 25.0
+    cap.battery_voltage_age_s = 1.0
+    cap.snapshot_supported = True
+    cap.readback_supported = True
+    cap.restore_supported = True
+    adapter = MagicMock()
+    type(adapter).__name__ = "DeyeBatteryAdapter"
+    adapter.capability.return_value = cap
+    adapter.unsafe_latched = unsafe
+    adapter._last_error = last_error
+    adapter._observer_mode = False
+    adapter._actuation_enabled = True
+    adapter._config_entry_id = "entry-deye-1"
+    adapter._battery_id = "primary"
+    return adapter
+
+
+class TestDeyeDiagnostics:
+    @pytest.mark.asyncio
+    async def test_deye_block_surfaces_capability_and_latch(
+        self, _diag_hass, _diag_entry, _diag_coordinator,
+    ):
+        _diag_coordinator._battery_adapters = {"primary": _make_adapter(unsafe=False, avail=True)}
+        _diag_entry.runtime_data = _diag_coordinator
+        _diag_hass.data = {
+            "solar_energy_management": {_diag_entry.entry_id: _diag_coordinator},
+        }
+
+        result = await async_get_config_entry_diagnostics(_diag_hass, _diag_entry)
+
+        deye_block = result["battery_control"]["deye"]
+        assert deye_block["available"] is True
+        assert deye_block["reason"] == "ok"
+        assert deye_block["unsafe_latched"] is False
+        assert deye_block["max_charge_current_a"] == 25.0
+
+    @pytest.mark.asyncio
+    async def test_unsafe_latched_and_reason_surface(
+        self, _diag_hass, _diag_entry, _diag_coordinator,
+    ):
+        # A latched-unsafe scope: capability reports unavailable with the
+        # gate reason and the recovery error is visible.
+        _diag_coordinator._battery_adapters = {
+            "primary": _make_adapter(
+                unsafe=True, avail=False, reason="grid-charge switch state unavailable",
+                last_error="Deye unsafe latch is set",
+            )
+        }
+        _diag_entry.runtime_data = _diag_coordinator
+        _diag_hass.data = {
+            "solar_energy_management": {_diag_entry.entry_id: _diag_coordinator},
+        }
+
+        result = await async_get_config_entry_diagnostics(_diag_hass, _diag_entry)
+        deye_block = result["battery_control"]["deye"]
+        assert deye_block["unsafe_latched"] is True
+        assert deye_block["available"] is False
+        assert deye_block["reason"] == "grid-charge switch state unavailable"
+        assert deye_block["recovery_error"] == "Deye unsafe latch is set"
+
+    @pytest.mark.asyncio
+    async def test_observer_and_actuation_gates_are_readonly(self, _diag_hass, _diag_entry, _diag_coordinator):
+        _diag_coordinator._battery_adapters = {
+            "primary": _make_adapter(),
+        }
+        _diag_entry.runtime_data = _diag_coordinator
+        _diag_hass.data = {
+            "solar_energy_management": {_diag_entry.entry_id: _diag_coordinator},
+        }
+
+        result = await async_get_config_entry_diagnostics(_diag_hass, _diag_entry)
+        deye_block = result["battery_control"]["deye"]
+        assert deye_block["observer_mode"] is False
+        assert deye_block["actuation_enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_no_store_leak_in_deye_block(self, _diag_hass, _diag_entry, _diag_coordinator):
+        _diag_coordinator._battery_adapters = {
+            "primary": _make_adapter(),
+        }
+        _diag_entry.runtime_data = _diag_coordinator
+        _diag_hass.data = {
+            "solar_energy_management": {_diag_entry.entry_id: _diag_coordinator},
+        }
+
+        result = await async_get_config_entry_diagnostics(_diag_hass, _diag_entry)
+        deye_block = result["battery_control"]["deye"]
+        # The runtime store object / any secret must never be emitted.
+        json_serialisable = {"available", "reason", "unsafe_latched",
+                             "recovery_error", "observer_mode", "actuation_enabled",
+                             "max_charge_current_a"}
+        assert json_serialisable == set(deye_block.keys())
+        assert "deye_snapshot_store" not in deye_block
+
+    @pytest.mark.asyncio
+    async def test_no_deye_adapters_omits_block(self, _diag_hass, _diag_entry, _diag_coordinator):
+        _diag_coordinator._battery_adapters = {}
+        _diag_entry.runtime_data = _diag_coordinator
+        _diag_hass.data = {
+            "solar_energy_management": {_diag_entry.entry_id: _diag_coordinator},
+        }
+
+        result = await async_get_config_entry_diagnostics(_diag_hass, _diag_entry)
+        assert "deye" not in result["battery_control"]

--- a/tests/test_deye_snapshot_store.py
+++ b/tests/test_deye_snapshot_store.py
@@ -1,0 +1,536 @@
+"""Production Deye snapshot-store + coordinator wiring (#709).
+
+PR #709 ships ``DeyeBatteryAdapter`` with a fully implemented transactional
+snapshot/restore protocol, but the *production* persistent store and the
+coordinator runtime-injection that connects the adapter to a real
+Home Assistant ``Store`` were missing — the contract only ran against an
+in-memory stand-in in tests.
+
+This module locks in the first production slice:
+
+- ``DeyeSnapshotStore`` wraps Home Assistant's persistent ``Store`` and
+  implements the exact interface the adapter already talks to
+  (``async_save`` / ``async_load`` / ``async_clear`` / ``async_set_unsafe``
+  plus the ``unsafe`` property). It is scope-safe: the underlying Store key
+  embeds ``config_entry_id`` + ``battery_id`` so two batteries / two entries
+  never share data, and the runtime store object is never serialised into
+  entry ``data``/``options`` — it is attached to the adapter only.
+- ``SEMCoordinator._battery_adapter_context`` injects the store plus the
+  ``config_entry_id`` and ``battery_id`` when the Deye adapter is built by
+  the real coordinator wiring, without touching other brands (no drift).
+- Startup recovery of a pending snapshot runs fail-closed: a corrupt
+  persisted snapshot never reaches the inverter (no service writes) and
+  latches unsafe; a valid pending snapshot is restored and cleared.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.battery_adapters import (
+    DeyeBatteryAdapter,
+)
+from custom_components.solar_energy_management.coordinator.battery_adapters.deye_snapshot_store import (
+    DeyeSnapshotStore,
+    _snapshot_store_key,
+    _unsafe_store_key,
+)
+
+
+# ─────────────────────────── fake HA Store ───────────────────────────
+
+# Shared per-key backend so a "restart" (a NEW DeyeSnapshotStore scoped to
+# the same entry+battery → the same Store key) actually observes the data
+# written by an earlier instance — exactly what Home Assistant's persistent
+# Store does across coordinator restarts. Keyed by the Store ``key``, so two
+# different scopes never alias each other's snapshot or safety latch.
+_FAKE_STORE_BACKEND: dict[str, dict] = {}
+
+
+class _FakeHAStore:
+    """In-memory stand-in for ``homeassistant.helpers.storage.Store``.
+
+    Data is shared across Store instances that carry the same ``key`` (i.e.
+    the same config-entry/battery scope), simulating disk persistence across
+    a coordinator restart. ``async_remove`` clears only this store's key.
+    """
+
+    def __init__(self, hass, version, key):
+        self.hass = hass
+        self.version = version
+        self.key = key
+        self.data = _FAKE_STORE_BACKEND.setdefault(key, {"_data": None})
+
+    async def async_load(self):
+        return self.data["_data"]
+
+    async def async_save(self, data):
+        self.data["_data"] = data
+
+    async def async_remove(self):
+        self.data["_data"] = None
+
+
+@pytest.fixture
+def fake_store_class():
+    with patch(
+        "custom_components.solar_energy_management.coordinator."
+        "battery_adapters.deye_snapshot_store.Store",
+        _FakeHAStore,
+    ) as _cls:
+        # Fresh persistence backend per test — no leakage between tests.
+        _FAKE_STORE_BACKEND.clear()
+        yield _cls
+        _FAKE_STORE_BACKEND.clear()
+
+
+class _States:
+    def __init__(self, values):
+        self._values = values
+
+    def get(self, entity_id):
+        return self._values.get(entity_id)
+
+
+def _state(value, *, age_s=1, **attributes):
+    now = datetime.now(timezone.utc)
+    return SimpleNamespace(
+        state=str(value),
+        attributes=attributes,
+        last_updated=now - timedelta(seconds=age_s),
+        last_changed=now - timedelta(seconds=age_s),
+    )
+
+
+def _valid_deye_config():
+    config = {
+        "battery_charge_platform": "deye",
+        "deye_grid_charge_switch": "switch.grid_charge",
+        "deye_charge_current_entity": "number.grid_charge_current",
+        "deye_battery_voltage_entity": "sensor.battery_voltage",
+        "deye_battery_voltage_max_age_s": 60,
+        "deye_max_charge_current_a": 25,
+        "deye_bms_max_charge_current_a": 20,
+        "deye_max_discharge_power": 5000,
+        "deye_program_control": True,
+        "deye_program_groups": [],
+        "deye_observer_mode": False,
+        "deye_actuation_enabled": True,
+        "deye_readback_attempts": 1,
+    }
+    states = {
+        "switch.grid_charge": _state("off"),
+        "number.grid_charge_current": _state(
+            0, unit_of_measurement="A", min=0, max=32
+        ),
+        "sensor.battery_voltage": _state(53.35),
+    }
+    program_times = ("01:00:00", "05:00:00", "09:00:00", "13:00:00", "17:00:00", "21:00:00")
+    for index in range(1, 7):
+        time_entity = f"time.program_{index}"
+        soc_entity = f"number.program_{index}_soc"
+        charge_entity = f"select.program_{index}_charging"
+        config["deye_program_groups"].append(
+            {"time": time_entity, "soc": soc_entity, "charge": charge_entity}
+        )
+        states[time_entity] = _state(program_times[index - 1])
+        states[soc_entity] = _state(21, unit_of_measurement="%", min=0, max=100)
+        states[charge_entity] = _state(
+            "Disabled", options=["Disabled", "Grid", "Generator", "Both"]
+        )
+    return config, states
+
+
+# ─────────────────────────── store unit tests ───────────────────────────
+
+class TestDeyeSnapshotStore:
+    async def test_save_load_round_trip_persists_dict(self, fake_store_class):
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+
+        await store.async_save({"schema_version": 2, "value": 1})
+        loaded = await store.async_load()
+
+        assert loaded == {"schema_version": 2, "value": 1}
+
+    async def test_clear_removes_persisted_snapshot(self, fake_store_class):
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+        await store.async_save({"schema_version": 2})
+        assert await store.async_load() == {"schema_version": 2}
+
+        await store.async_clear()
+
+        assert await store.async_load() is None
+
+    async def test_set_unsafe_persists_and_updates_property(self, fake_store_class):
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+        assert store.unsafe is False
+
+        await store.async_set_unsafe(True)
+
+        assert store.unsafe is True
+
+    async def test_unsafe_latch_survives_restart_fail_closed(self, fake_store_class):
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+        await store.async_set_unsafe(True)
+
+        restarted = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+        await restarted.async_load_latch()
+
+        assert restarted.unsafe is True
+
+    async def test_corrupt_unsafe_latch_payload_fails_closed(self, fake_store_class):
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+        await store._unsafe_store.async_save({"unsafe": 0})
+
+        await store.async_load_latch()
+
+        assert store.unsafe is True
+
+    def test_scope_safe_keys_embed_config_entry_and_battery(self):
+        a = _snapshot_store_key("entry-1", "battery-1")
+        b = _snapshot_store_key("entry-1", "battery-2")
+        c = _snapshot_store_key("entry-2", "battery-1")
+
+        assert a != b
+        assert a != c
+        assert _unsafe_store_key("entry-1", "battery-1") != a
+
+    def test_store_is_never_serialised_into_entry_data(self, fake_store_class):
+        """The runtime store object must never leak into entry data/options."""
+        store = DeyeSnapshotStore(MagicMock(), "entry-1", "battery-1")
+
+        entry_data = {"deye_grid_charge_switch": "switch.grid_charge"}
+        entry_data_serialisable = dict(entry_data)
+
+        # The store is a runtime-only attachment; nothing in the entry
+        # data/options may reference it. Assert it is not reachable.
+        assert all(
+            not isinstance(v, DeyeSnapshotStore) for v in entry_data_serialisable.values()
+        )
+        assert store not in entry_data_serialisable.values()
+
+
+# ─────────────────────────── coordinator wiring ───────────────────────────
+
+class TestCoordinatorWiring:
+    def _coordinator(self, hass, config, entry_id="entry-deye-1"):
+        from custom_components.solar_energy_management.coordinator.coordinator import (
+            SEMCoordinator,
+        )
+
+        coord = SEMCoordinator(MagicMock(), config)
+        coord.hass = hass
+        coord.config_entry = SimpleNamespace(entry_id=entry_id)
+        return coord
+
+    def _hass(self, states):
+        hass = MagicMock()
+        hass.states = _States(states)
+        hass.services = SimpleNamespace(
+            async_call=AsyncMock(return_value=None)
+        )
+        return hass
+
+    def test_battery_adapter_context_injects_store_and_scope(self):
+        config, states = _valid_deye_config()
+        coord = self._coordinator(self._hass(states), config)
+
+        pbc = coord._battery_adapter_context("battery-1")
+
+        assert pbc["config_entry_id"] == "entry-deye-1"
+        assert pbc["battery_id"] == "battery-1"
+        assert isinstance(pbc["deye_snapshot_store"], DeyeSnapshotStore)
+        assert pbc["deye_snapshot_store"].config_entry_id == "entry-deye-1"
+        assert pbc["deye_snapshot_store"].battery_id == "battery-1"
+
+    def test_real_wiring_gives_deye_adapter_full_snapshot_capability(self, fake_store_class):
+        from custom_components.solar_energy_management.coordinator.battery_adapters import (
+            adapter_for,
+        )
+
+        config, states = _valid_deye_config()
+        hass = self._hass(states)
+        coord = self._coordinator(hass, config)
+
+        pbc = coord._battery_adapter_context("battery-1")
+        adapter = adapter_for(hass, pbc)
+
+        assert isinstance(adapter, DeyeBatteryAdapter)
+        capability = adapter.capability()
+        assert capability.available is True
+        assert capability.snapshot_supported is True
+        assert capability.readback_supported is True
+        assert capability.restore_supported is True
+        assert adapter._config_entry_id == "entry-deye-1"
+        assert adapter._battery_id == "battery-1"
+
+    def test_empty_config_entry_scope_keeps_deye_fail_closed(self):
+        config, states = _valid_deye_config()
+        coord = self._coordinator(self._hass(states), config)
+        coord.config_entry = None
+
+        context = coord._battery_adapter_context("primary")
+        adapter = DeyeBatteryAdapter(coord.hass, context)
+
+        assert context["config_entry_id"] == ""
+        assert context["deye_snapshot_store"] is None
+        assert adapter.supports_forced_charge is False
+
+    def test_injection_is_deye_only_no_drift_for_other_brands(self, fake_store_class):
+        from custom_components.solar_energy_management.coordinator.battery_adapters import (
+            adapter_for,
+        )
+
+        config, states = _valid_deye_config()
+        config["battery_charge_platform"] = "generic"
+        config.pop("deye_observer_mode", None)
+        config.pop("deye_actuation_enabled", None)
+        hass = self._hass(states)
+        coord = self._coordinator(hass, config)
+
+        pbc = coord._battery_adapter_context("battery-1")
+        adapter = adapter_for(hass, pbc)
+
+        # Generic adapter must NOT carry a Deye store / Deye keys.
+        assert not isinstance(adapter, DeyeBatteryAdapter)
+        assert "deye_snapshot_store" not in vars(adapter)
+        assert adapter._config_entry_id == "entry-deye-1"
+        assert adapter._battery_id == "battery-1"
+
+    async def test_run_battery_pipeline_builds_capable_deye(self, fake_store_class):
+        """Drive the real pipeline once and inspect the cached adapter."""
+        from custom_components.solar_energy_management.coordinator import (
+            battery_adapters as ba_mod,
+        )
+        from custom_components.solar_energy_management.coordinator.actuate_battery import (
+            actuate_battery,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryDecision,
+            BatteryIntent,
+        )
+        from custom_components.solar_energy_management.coordinator.decide_battery import (
+            decide_battery,
+        )
+
+        config, states = _valid_deye_config()
+        hass = self._hass(states)
+        coord = self._coordinator(hass, config)
+        # Disable scheduler so the loop skips _maybe_run_scheduler_evaluation.
+        # ``enabled`` is a read-only property backed by ``_config.enabled``
+        # (SchedulerConfig dataclass field) — configure it, don't assign it.
+        coord._battery_charge_scheduler._config.enabled = False
+        # A MagicMock-backed hass can't drive the real TimeManager's solar
+        # lookups — stub night-mode off so the pipeline's FleetContext builds.
+        coord.time_manager = SimpleNamespace(is_night_mode=lambda: False)
+
+        power = SimpleNamespace(
+            batteries={},
+            battery_soc=50.0,
+            battery_power=-200.0,
+            solar_power=500.0,
+            home_consumption_power=300.0,
+            ev_charging=False,
+            ev_connected=False,
+            battery_soc_unavailable=False,
+        )
+        energy = SimpleNamespace()
+
+        with patch(
+            "custom_components.solar_energy_management.coordinator.decide_battery.decide_battery",
+            return_value=BatteryDecision(
+                battery_id="primary",
+                intent=BatteryIntent.NORMAL,
+                reason="test",
+            ),
+        ), patch(
+            "custom_components.solar_energy_management.coordinator.actuate_battery.actuate_battery",
+            new=AsyncMock(),
+        ):
+            await coord._run_battery_pipeline(power, energy, "idle")
+
+        adapter = coord._battery_adapters["primary"]
+        assert isinstance(adapter, DeyeBatteryAdapter)
+        assert adapter._snapshot_supported is True
+        assert adapter._config_entry_id == "entry-deye-1"
+        assert adapter._battery_id == "primary"
+
+    # ─── startup recovery (#709): a NEW Deye adapter built by the real
+    # coordinator must load the persisted safety latch and handle any
+    # pending snapshot BEFORE the first actuation. These are behaviour tests
+    # on the coordinator wiring (not the adapter's direct unit tests). ──────
+
+    async def _run_pipeline(self, coord, *, decision):
+        """Drive ``_run_battery_pipeline`` once with a canned decision."""
+        from custom_components.solar_energy_management.coordinator.decide_battery import (
+            decide_battery,
+        )
+
+        power = SimpleNamespace(
+            batteries={},
+            battery_soc=50.0,
+            battery_power=-200.0,
+            solar_power=500.0,
+            home_consumption_power=300.0,
+            ev_charging=False,
+            ev_connected=False,
+            battery_soc_unavailable=False,
+        )
+        with patch(
+            "custom_components.solar_energy_management.coordinator.decide_battery.decide_battery",
+            return_value=decision,
+        ):
+            await coord._run_battery_pipeline(power, SimpleNamespace(), "idle")
+
+    async def test_new_deye_adapter_loads_persisted_unsafe_latch_fail_closed(
+        self, fake_store_class
+    ):
+        """RED→GREEN: a persisted unsafe latch is honoured at startup.
+
+        A previous run latched the scope unsafe. A NEW coordinator (e.g. after
+        a restart) builds a fresh Deye adapter from the SAME persisted store.
+        Without a startup recovery call, the in-memory latch defaults open and
+        the adapter would happily force-charge. After recovery the adapter must
+        come up latched-unsafe so actuation is fail-closed (no writes).
+        """
+        from custom_components.solar_energy_management.coordinator.battery_adapters.deye_snapshot_store import (
+            DeyeSnapshotStore,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryDecision,
+            BatteryIntent,
+        )
+
+        # Persist an unsafe latch for the SAME scope the coordinator will use
+        # (config-entry "entry-deye-1" + single-battery fallback "primary").
+        previous = DeyeSnapshotStore(MagicMock(), "entry-deye-1", "primary")
+        await previous.async_set_unsafe(True)
+
+        config, states = _valid_deye_config()
+        coord = self._coordinator(self._hass(states), config)
+        coord._battery_charge_scheduler._config.enabled = False
+        coord.time_manager = SimpleNamespace(is_night_mode=lambda: False)
+
+        await self._run_pipeline(
+            coord,
+            decision=BatteryDecision(
+                battery_id="primary",
+                intent=BatteryIntent.NORMAL,
+                reason="test",
+            ),
+        )
+
+        adapter = coord._battery_adapters["primary"]
+        assert isinstance(adapter, DeyeBatteryAdapter)
+        # Startup recovery must latch unsafe before any actuation…
+        assert adapter.unsafe_latched is True
+        # …so forced charge (and any snapshot replay) is fail-closed.
+        assert adapter.supports_forced_charge is False
+
+    async def test_new_deye_adapter_reloads_valid_pending_snapshot_before_actuation(
+        self, fake_store_class
+    ):
+        """RED→GREEN: a valid pending snapshot is recovered by the new adapter.
+
+        A previous run left a pending (un-cleared) snapshot. The coordinator
+        builds a fresh Deye adapter that must load it — so a normal actuation
+        restores the inverter to the pre-session state and clears the snapshot,
+        instead of silently ignoring it and leaving the inverter in a
+        force-charge state across the restart.
+        """
+        from custom_components.solar_energy_management.coordinator.battery_adapters.deye_snapshot_store import (
+            DeyeSnapshotStore,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryDecision,
+            BatteryIntent,
+        )
+
+        config, states = _valid_deye_config()
+        # Build a pre-restart adapter against the shared backend, force-charge
+        # once so a snapshot is persisted (mirrors the earlier unit test), then
+        # throw the adapter away — only the persisted snapshot survives.
+        previous_hass = self._hass(states)
+        previous = DeyeBatteryAdapter(
+            previous_hass,
+            {
+                **config,
+                "config_entry_id": "entry-deye-1",
+                "battery_id": "primary",
+                "deye_observer_mode": False,
+                "deye_actuation_enabled": True,
+                "deye_readback_attempts": 1,
+                "deye_snapshot_store": DeyeSnapshotStore(
+                    previous_hass, "entry-deye-1", "primary"
+                ),
+            },
+        )
+        snapshot = await previous._take_snapshot("pre-restart-session")
+        assert snapshot is not None
+        del previous
+
+        coord = self._coordinator(self._hass(states), config)
+        coord._battery_charge_scheduler._config.enabled = False
+        coord.time_manager = SimpleNamespace(is_night_mode=lambda: False)
+
+        # NORMAL actuation should recover the pending snapshot (writes occur,
+        # snapshot cleared) — NOT be a silent no-op.
+        await self._run_pipeline(
+            coord,
+            decision=BatteryDecision(
+                battery_id="primary",
+                intent=BatteryIntent.NORMAL,
+                reason="test",
+            ),
+        )
+
+        adapter = coord._battery_adapters["primary"]
+        assert isinstance(adapter, DeyeBatteryAdapter)
+        assert adapter.last_intent is BatteryIntent.NORMAL
+        assert adapter.unsafe_latched is False
+        # The pending snapshot was restored and cleared by recovery.
+        restored = DeyeSnapshotStore(MagicMock(), "entry-deye-1", "primary")
+        assert await restored.async_load() is None
+
+    async def test_corrupt_persisted_snapshot_fail_closed_zero_writes(
+        self, fake_store_class
+    ):
+        """A corrupt persisted snapshot must latch unsafe and write nothing."""
+        from custom_components.solar_energy_management.coordinator.battery_adapters.deye_snapshot_store import (
+            DeyeSnapshotStore,
+        )
+        from custom_components.solar_energy_management.coordinator.charger_types import (
+            BatteryDecision,
+            BatteryIntent,
+        )
+
+        # Persist a corrupt payload (non-boolean grid_charge_enabled) for the
+        # coordinator's scope.
+        previous = DeyeSnapshotStore(MagicMock(), "entry-deye-1", "primary")
+        await previous.async_save({"grid_charge_enabled": "false"})
+
+        config, states = _valid_deye_config()
+        hass = self._hass(states)
+        coord = self._coordinator(hass, config)
+        coord._battery_charge_scheduler._config.enabled = False
+        coord.time_manager = SimpleNamespace(is_night_mode=lambda: False)
+
+        await self._run_pipeline(
+            coord,
+            decision=BatteryDecision(
+                battery_id="primary",
+                intent=BatteryIntent.NORMAL,
+                reason="test",
+            ),
+        )
+
+        adapter = coord._battery_adapters["primary"]
+        assert isinstance(adapter, DeyeBatteryAdapter)
+        assert adapter.unsafe_latched is True
+        assert adapter.supports_forced_charge is False
+        # Zero HA service writes on the corrupt path.
+        assert hass.services.async_call.await_count == 0

--- a/tests/test_inverter_battery_arch.py
+++ b/tests/test_inverter_battery_arch.py
@@ -18,6 +18,7 @@ from custom_components.solar_energy_management.coordinator.actuate_battery impor
     actuate_battery,
 )
 from custom_components.solar_energy_management.coordinator.battery_adapters import (
+    DeyeBatteryAdapter,
     GenericBatteryAdapter,
     GoodWeBatteryAdapter,
     HuaweiBatteryAdapter,
@@ -521,6 +522,11 @@ class TestEnergyTotalsViews:
 
 
 class TestAdapterFactory:
+    def test_explicit_deye(self):
+        hass = MagicMock()
+        a = adapter_for(hass, {"battery_charge_platform": "deye"})
+        assert isinstance(a, DeyeBatteryAdapter)
+
     def test_explicit_huawei(self):
         hass = MagicMock()
         a = adapter_for(hass, {"battery_charge_platform": "huawei"})

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -88,7 +88,8 @@
       "unknown": "Došlo k neočekávané chybě. Zkuste to prosím znovu.",
       "entity_not_found": "Entita nebyla nalezena. Ověřte prosím, že dané ID entity existuje.",
       "service_not_found": "Služba oznámení nebyla nalezena. Zkontrolujte název služby (např. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready vyžaduje OBĚ entity relé. Nastavte obě relé — nebo ponechte obě prázdná a nakonfigurujte pouze entitu climate pro navýšení cílové teploty v režimu pouze climate."
+      "heat_pump_partial_relays": "SG-Ready vyžaduje OBĚ entity relé. Nastavte obě relé — nebo ponechte obě prázdná a nakonfigurujte pouze entitu climate pro navýšení cílové teploty v režimu pouze climate.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management je již nakonfigurován. Povolena je pouze jedna instance.",

--- a/translations/da.json
+++ b/translations/da.json
@@ -88,7 +88,8 @@
       "unknown": "Der opstod en uventet fejl. Prøv venligst igen.",
       "entity_not_found": "Entiteten blev ikke fundet. Kontrollér venligst, at entitets-ID'et findes.",
       "service_not_found": "Notifikationstjenesten blev ikke fundet. Kontrollér tjenestenavnet (f.eks. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready kræver BEGGE relæentiteter. Angiv begge relæer — eller lad begge stå tomme og konfigurer kun klimaentiteten til setpunkt-boost i klima-kun-tilstand."
+      "heat_pump_partial_relays": "SG-Ready kræver BEGGE relæentiteter. Angiv begge relæer — eller lad begge stå tomme og konfigurer kun klimaentiteten til setpunkt-boost i klima-kun-tilstand.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management er allerede konfigureret. Kun én instans er tilladt.",

--- a/translations/de.json
+++ b/translations/de.json
@@ -88,7 +88,8 @@
       "unknown": "Ein unerwarteter Fehler ist aufgetreten. Bitte versuchen Sie es erneut.",
       "entity_not_found": "Entität nicht gefunden. Bitte überprüfen Sie die Entity-ID.",
       "service_not_found": "Benachrichtigungsdienst nicht gefunden. Bitte überprüfen Sie den Dienstnamen (z. B. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready benötigt BEIDE Relais-Entitäten. Setze beide Relais — oder lasse beide leer und konfiguriere nur die climate-Entität für den climate-only Setpoint-Boost."
+      "heat_pump_partial_relays": "SG-Ready benötigt BEIDE Relais-Entitäten. Setze beide Relais — oder lasse beide leer und konfiguriere nur die climate-Entität für den climate-only Setpoint-Boost.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management ist bereits konfiguriert. Nur eine Instanz erlaubt.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -88,7 +88,8 @@
       "unknown": "An unexpected error occurred. Please try again.",
       "entity_not_found": "Entity not found. Please verify the entity ID exists.",
       "service_not_found": "Notification service not found. Please check the service name (e.g., notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready needs BOTH relay entities. Set both relays — or leave both empty and configure only the climate entity for climate-only setpoint boost."
+      "heat_pump_partial_relays": "SG-Ready needs BOTH relay entities. Set both relays — or leave both empty and configure only the climate entity for climate-only setpoint boost.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management is already configured. Only one instance is allowed.",

--- a/translations/es.json
+++ b/translations/es.json
@@ -88,7 +88,8 @@
       "unknown": "Se ha producido un error inesperado. Inténtelo de nuevo.",
       "entity_not_found": "Entidad no encontrada. Comprueba que el ID de entidad existe.",
       "service_not_found": "No se ha encontrado el servicio de notificaciones. Compruebe el nombre del servicio (p. ej. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready necesita AMBAS entidades de relé. Configure los dos relés — o deje ambos vacíos y configure solo la entidad climate para el boost de consigna en modo solo-climate."
+      "heat_pump_partial_relays": "SG-Ready necesita AMBAS entidades de relé. Configure los dos relés — o deje ambos vacíos y configure solo la entidad climate para el boost de consigna en modo solo-climate.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management ya está configurado. Solo se permite una instancia.",

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -88,7 +88,8 @@
       "unknown": "Odottamaton virhe. Yritä uudelleen.",
       "entity_not_found": "Entiteettiä ei löytynyt. Tarkista, että entiteettitunnus on olemassa.",
       "service_not_found": "Ilmoituspalvelua ei löytynyt. Tarkista palvelun nimi (esim. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready vaatii MOLEMMAT releentiteetit. Aseta molemmat releet — tai jätä molemmat tyhjiksi ja määritä vain ilmastointientiteetti pelkän ilmastoinnin asetusarvon boostia varten."
+      "heat_pump_partial_relays": "SG-Ready vaatii MOLEMMAT releentiteetit. Aseta molemmat releet — tai jätä molemmat tyhjiksi ja määritä vain ilmastointientiteetti pelkän ilmastoinnin asetusarvon boostia varten.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management on jo määritetty. Vain yksi instanssi sallittu.",

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -88,7 +88,8 @@
       "unknown": "Une erreur inattendue s'est produite. Veuillez réessayer.",
       "entity_not_found": "Entité introuvable. Vérifiez que l'ID d'entité existe.",
       "service_not_found": "Service de notification introuvable. Veuillez vérifier le nom du service (par ex. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready nécessite les DEUX entités relais. Renseignez les deux relais — ou laissez-les vides et configurez uniquement l'entité climate pour un boost de consigne climate seul."
+      "heat_pump_partial_relays": "SG-Ready nécessite les DEUX entités relais. Renseignez les deux relais — ou laissez-les vides et configurez uniquement l'entité climate pour un boost de consigne climate seul.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management est déjà configuré. Une seule instance est autorisée.",

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -88,7 +88,8 @@
       "unknown": "Váratlan hiba történt. Kérjük, próbálja újra.",
       "entity_not_found": "Az entitás nem található. Ellenőrizze, hogy az entitásazonosító létezik-e.",
       "service_not_found": "Az értesítési szolgáltatás nem található. Ellenőrizze a szolgáltatás nevét (pl. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "Az SG-Ready MINDKÉT relé entitást igényli. Állítsa be mindkét relét — vagy hagyja mindkettőt üresen, és csak a climate entitást konfigurálja a kizárólag climate alapú célhőmérséklet-emeléshez."
+      "heat_pump_partial_relays": "Az SG-Ready MINDKÉT relé entitást igényli. Állítsa be mindkét relét — vagy hagyja mindkettőt üresen, és csak a climate entitást konfigurálja a kizárólag climate alapú célhőmérséklet-emeléshez.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "A Solar Energy Management már konfigurálva van. Csak egy példány engedélyezett.",

--- a/translations/it.json
+++ b/translations/it.json
@@ -88,7 +88,8 @@
       "unknown": "Si è verificato un errore imprevisto. Riprova.",
       "entity_not_found": "Entità non trovata. Verifica che l'ID entità esista.",
       "service_not_found": "Servizio di notifica non trovato. Verifica il nome del servizio (ad es. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready richiede ENTRAMBE le entità relè. Imposta entrambi i relè — oppure lasciali entrambi vuoti e configura solo l'entità climate per il boost del setpoint in modalità solo-climate."
+      "heat_pump_partial_relays": "SG-Ready richiede ENTRAMBE le entità relè. Imposta entrambi i relè — oppure lasciali entrambi vuoti e configura solo l'entità climate per il boost del setpoint in modalità solo-climate.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management è già configurato. È consentita una sola istanza.",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -88,7 +88,8 @@
       "unknown": "Er is een onverwachte fout opgetreden. Probeer het opnieuw.",
       "entity_not_found": "Entiteit niet gevonden. Controleer of de entiteit-ID bestaat.",
       "service_not_found": "Notificatieservice niet gevonden. Controleer de servicenaam (bijv. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready heeft BEIDE relais-entiteiten nodig. Stel beide relais in — of laat beide leeg en configureer alleen de klimaat-entiteit voor een klimaat-only instelpunt-boost."
+      "heat_pump_partial_relays": "SG-Ready heeft BEIDE relais-entiteiten nodig. Stel beide relais in — of laat beide leeg en configureer alleen de klimaat-entiteit voor een klimaat-only instelpunt-boost.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management is al geconfigureerd. Slechts één instantie is toegestaan.",

--- a/translations/no.json
+++ b/translations/no.json
@@ -88,7 +88,8 @@
       "unknown": "En uventet feil oppstod. Vennligst prøv igjen.",
       "entity_not_found": "Entiteten ble ikke funnet. Kontroller at entitets-ID-en finnes.",
       "service_not_found": "Varslingstjenesten ble ikke funnet. Kontroller tjenestenavnet (f.eks. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready krever BEGGE reléentitetene. Angi begge reléene — eller la begge stå tomme og konfigurer kun klimaentiteten for settpunkt-boost i kun-klima-modus."
+      "heat_pump_partial_relays": "SG-Ready krever BEGGE reléentitetene. Angi begge reléene — eller la begge stå tomme og konfigurer kun klimaentiteten for settpunkt-boost i kun-klima-modus.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management er allerede konfigurert. Bare én instans er tillatt.",

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -88,7 +88,8 @@
       "unknown": "Wystąpił nieoczekiwany błąd. Spróbuj ponownie.",
       "entity_not_found": "Nie znaleziono encji. Sprawdź, czy podany identyfikator encji istnieje.",
       "service_not_found": "Nie znaleziono usługi powiadomień. Sprawdź nazwę usługi (np. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready wymaga OBU encji przekaźników. Ustaw oba przekaźniki — albo pozostaw oba puste i skonfiguruj tylko encję climate, aby korzystać z podbicia nastawy w trybie climate-only."
+      "heat_pump_partial_relays": "SG-Ready wymaga OBU encji przekaźników. Ustaw oba przekaźniki — albo pozostaw oba puste i skonfiguruj tylko encję climate, aby korzystać z podbicia nastawy w trybie climate-only.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management jest już skonfigurowany. Dozwolona jest tylko jedna instancja.",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -88,7 +88,8 @@
       "unknown": "Ocorreu um erro inesperado. Tente novamente.",
       "entity_not_found": "Entidade não encontrada. Verifique se o ID da entidade existe.",
       "service_not_found": "Serviço de notificação não encontrado. Verifique o nome do serviço (p. ex. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "O SG-Ready necessita de AMBAS as entidades de relé. Defina os dois relés — ou deixe ambos vazios e configure apenas a entidade climate para o boost de setpoint em modo apenas-climate."
+      "heat_pump_partial_relays": "O SG-Ready necessita de AMBAS as entidades de relé. Defina os dois relés — ou deixe ambos vazios e configure apenas a entidade climate para o boost de setpoint em modo apenas-climate.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management já está configurado. Apenas uma instância é permitida.",

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -88,7 +88,8 @@
       "unknown": "A apărut o eroare neașteptată. Vă rugăm să încercați din nou.",
       "entity_not_found": "Entitatea nu a fost găsită. Verificați dacă ID-ul entității există.",
       "service_not_found": "Serviciul de notificare nu a fost găsit. Verificați numele serviciului (de ex. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready necesită AMBELE entități de releu. Setați ambele relee — sau lăsați-le pe ambele goale și configurați doar entitatea climate pentru stimularea punctului de referință doar prin climate."
+      "heat_pump_partial_relays": "SG-Ready necesită AMBELE entități de releu. Setați ambele relee — sau lăsați-le pe ambele goale și configurați doar entitatea climate pentru stimularea punctului de referință doar prin climate.",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "Solar Energy Management este deja configurat. Este permisă o singură instanță.",

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -88,7 +88,8 @@
       "unknown": "Ett oväntat fel uppstod. Försök igen.",
       "entity_not_found": "Entiteten hittades inte. Kontrollera att entitets-ID:t finns.",
       "service_not_found": "Aviseringstjänsten hittades inte. Kontrollera tjänstens namn (t.ex. notify.mobile_app_your_phone).",
-      "heat_pump_partial_relays": "SG-Ready kräver BÅDA reläentiteterna. Ange båda reläerna — eller lämna båda tomma och konfigurera endast klimatentiteten för börvärdesboost i klimatläge."
+      "heat_pump_partial_relays": "SG-Ready kräver BÅDA reläentiteterna. Ange båda reläerna — eller lämna båda tomma och konfigurera endast klimatentiteten för börvärdesboost i klimatläge.",
+      "deye_program_groups_incomplete": "Alla sex Deye-programgrupper måste ha entiteter för tid, SOC och nätladdning."
     },
     "abort": {
       "already_configured": "Solar Energy Management är redan konfigurerat. Bara en instans tillåts.",

--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -88,7 +88,8 @@
       "unknown": "发生了未知错误。请重试。",
       "entity_not_found": "未找到实体。请确认该实体 ID 确实存在。",
       "service_not_found": "未找到通知服务。请检查服务名称（例如 notify.mobile_app_your_phone）。",
-      "heat_pump_partial_relays": "SG-Ready 需要【两个】继电器实体。请同时设置两个继电器 —— 或者将两者都留空，仅配置 climate 实体以使用仅温控设定值增强模式。"
+      "heat_pump_partial_relays": "SG-Ready 需要【两个】继电器实体。请同时设置两个继电器 —— 或者将两者都留空，仅配置 climate 实体以使用仅温控设定值增强模式。",
+      "deye_program_groups_incomplete": "All six Deye program groups must define time, SOC, and grid-charge entities."
     },
     "abort": {
       "already_configured": "太阳能消纳管理 (SEM) 已经配置过了。只允许存在一个实例。",


### PR DESCRIPTION
## Summary

Add observer-first, runtime-integrated Deye battery support with persistent recovery, deterministic TOU slot compilation, explicit Work Mode control, Home Assistant options flow, and read-only diagnostics.

The adapter is registered in the battery-adapter factory but remains read-only by default. Active writes require explicit operator gates, complete entity mappings, fresh and finite inverter data, valid safety limits, scoped persistent storage, and successful snapshot read-back before the first inverter write.

## Runtime integration

- Deye can be selected and fully mapped in the SEM options flow.
- Stable `config_entry_id` and battery identity are injected by the coordinator.
- Snapshots and the unsafe latch use scoped Home Assistant `Store` persistence.
- Startup recovery loads the persisted latch before actuation and restores a valid pending snapshot.
- Missing scope, corrupt persistence, malformed snapshots, or failed recovery remain fail-closed.
- Diagnostics expose capability, observer/actuation gates, unsafe state, pending snapshot metadata, and last error without exposing entity values or secrets.
- Non-Deye installations skip the Deye form and retain existing behavior.

## Deye support

- Observer mode is the default; missing, malformed, stale, non-finite, or ambiguous state fails closed.
- Effective charge current is capped by the minimum of entity, configured safety, and BMS limits.
- A scoped snapshot is persisted and read back before actuation; every write uses bounded read-back verification.
- Failed actuation rolls back in safe order. Rollback failure persists an unsafe latch; no public unsafe-reset is exposed.
- All six Deye TOU boundaries are validated and compiled deterministically, including charge windows that cross midnight.
- Optional Work Mode control requires explicit, distinct mappings for Load First and Battery First and is included in snapshot, read-back, and rollback.

## Safety gates

Active control requires all of the following:

- observer mode explicitly disabled with boolean `false`
- actuation explicitly enabled with boolean `true`
- complete and valid Deye entity mapping
- non-empty config-entry and battery scope IDs
- snapshot storage with save, load, clear, and unsafe-latch persistence
- fresh inverter voltage of at least 40 V
- valid entity, configured safety, and BMS current limits

String values such as `"false"` never enable actuation. Corrupt, stale, cross-device, or ambiguous snapshots are never restored.

## Verification

- Full repository suite, split deterministically by test file to avoid runner timeout: **5,586 passed, 2 skipped, 0 failed**
- Focused Deye/config/diagnostics/runtime suite: **93 passed** before final hardening additions
- Translation parity and JSON validation passed
- Orphan-method and options-owned-key architecture guards passed
- `git diff --check` passed
- Independent security and runtime-architecture reviews completed; findings were fixed before push

No Home Assistant production configuration was changed. Observer mode remains default-on, actuation remains default-off, and auto-merge is disabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring Deye battery inverters, including charging limits, schedules, work modes, and safety controls.
  * Added forced charging, charge stopping, recovery, and safe fallback behavior.
  * Added persistent recovery state and unsafe-status tracking across restarts.
  * Added read-only diagnostics for Deye capabilities, charging limits, recovery status, and safety state.

* **Bug Fixes**
  * Added validation for incomplete schedules, conflicting settings, invalid values, and unsafe inverter states.

* **Documentation**
  * Added translated configuration error messages for incomplete Deye program settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->