### PR TITLE
Release v1.7.5 — daily home is the reconciled residual (#628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [1.7.5] — 03.08.2026
+
+> **Stable release.** Consolidates the 1.7.5 beta line (beta.1 → beta.38, detailed
+> below). Headline: the **#628 meter-reconciliation arc** — SEM's seven daily
+> numbers now ADD UP, each pinned to your own hardware counters and home derived
+> as their exact residual — plus the **per-charger state retirement** (#589), the
+> **device goal model** for surplus loads (#620), a **zero-HACS-prerequisites
+> dashboard** (#617), a full **docs overhaul** (#618), and fail-closed community
+> hardware support for Deye, Zaptec and per-phase grid limits (by @tintinz).
+
+### 📏 Daily numbers that add up (#628)
+- ✨ **Daily home consumption is now the reconciled residual, not a stopwatch.**
+  Home is the one row nothing meters; SEM used to evaluate the energy balance
+  instantaneously in watts and integrate it, which magnifies every sensor's
+  small error into ±3–15 % on the home row (confirmed on two independent
+  installs). The daily row is now derived from the day's reconciled counters —
+  `solar + import − export + discharge − charge − EV` — exactly as lifetime and
+  yearly home always were. The integrator stays as the fallback whenever a
+  flowing term is not counter-backed. On the day you upgrade, the row keeps the
+  old behaviour for one calendar day (the EV midnight mirror needs a full day of
+  history first); it derives from the following midnight. (reported by
+  @jappish84 in #628)
+- ✨ **Solar, grid and battery daily rows reconcile against your own counters**
+  (beta.13 →): daily totals are cross-checked and corrected against the hardware
+  counters configured in your Energy Dashboard, so polling gaps and power blips
+  no longer drift the day. Night-time yield-counter movement on DC-coupled
+  hybrids is ignored (#681) — battery discharge in the dark is not solar.
+- 🛠️ **Sensor overrides on the Config card** (#628/#696): battery, grid and
+  solar power sources can be overridden per-install when autodetection picks the
+  wrong entity.
+
+### ⚡ EV charging: structural per-charger state (#589 arc)
+- 🏗️ Per-charger state lives on `PerChargerState` by reference — the legacy
+  snapshot/restore swap is gone, closing the whole reads-fleet-total-instead-of-
+  this-charger bug class structurally (beta.15). Ghost EV rows no longer appear
+  after a charger is removed (#595), and a charger that gives up re-offers on a
+  countdown instead of silently never trying again (#610, live-proven).
+- 🐛 KEBA UDP resilience: lost-datagram guard, ~1 Wh idle-session guard, and a
+  median-of-3 `ev_power` pre-filter absorb transport blips instead of flapping
+  the charger (beta.11 →).
+
+### 🎛️ Surplus loads: the device goal model (#620)
+- ✨ Every managed load gets Min/Max daily runtime, a daytime Mode, and a
+  "Finish overnight from" picker (Off / Battery / Grid) — live-proven on real
+  hardware (beta.22). The loads' day rolls on the same meter-day class the EV
+  uses (#704), and the goal engine is pinned by an invariant harness over the
+  full contract (#703).
+
+### 🖥️ Dashboard: zero HACS prerequisites (#617) + config redesign (#605/#606)
+- ✨ SEM's dashboard no longer requires mushroom, apexcharts, card-mod or
+  sankey-chart — glass styling is baked in, Chart.js is vendored, and the energy
+  flow falls back to the native sankey. Fresh installs render complete with zero
+  HACS cards.
+- ✨ Configuration tab redesigned around grouped cards with per-key help anchors
+  (#605/#606, reported by @tlinnet); device names localize per-user in the
+  system diagram (#615).
+
+### 🧹 Coherence audit + dead code (16 confirmed findings)
+- 🏗️ A systematic audit of decision coherence closed #639–#655: dead features
+  that could never run were removed (#651/#659/#664), the EV orchestration was
+  decomposed (#629), and the second (dead) EV surplus allocator was deleted with
+  coverage restored on the one that runs (#665).
+
+### 🔌 Community hardware (by @tintinz, @onkelfu and reporters)
+- ✨ Fail-closed Deye battery adapter with transactional TOU-register writes
+  (#709); read-only per-phase grid diagnostics with sign-safe current derivation
+  (#707, freshness fix in beta.38); Zaptec discovery persistence + phantom-plan
+  suppression (#706); JuiceBox EVSE no longer double-detected (#698); Open-Meteo
+  Solar Forecast autodetected (#687); fail-closed battery discharge controls
+  from the #702 review; Enphase IQ battery temperature (#583).
+
+### 🧪 Correctness & hardening across the line
+- 🐛 Atomic `power_snapshot` for coherent card rendering (#699), rate-limited
+  STOP-unenforceable warnings (#700), load-management day-boundary fixes
+  (#703/#704), pool-filter/load goal fixes from live soaks, and the full
+  pipeline-test matrix extended to every newly supported brand.
+
 # [1.7.5-beta.38] — 02.08.2026
 
 ### 🐛 Fixes

--- a/coordinator/energy_calculator.py
+++ b/coordinator/energy_calculator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from datetime import datetime, date, timedelta
-from typing import Dict, Any, Optional
+from typing import Dict, Any, Optional, Set
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -53,6 +53,36 @@ _EV_KEY_PREFIX = f"{EV_CATEGORY}_"
 # The pre-#666 name, still found in stored accumulators on upgrade.
 _LEGACY_EV_CATEGORY = "ev_daily_sun"
 _LEGACY_EV_KEY_PREFIX = f"{_LEGACY_EV_CATEGORY}_"
+
+# (#628) Midnight-keyed mirror of the EV daily bucket, used ONLY by the home
+# balance. ``EV_CATEGORY``'s day key rolls at the charge deadline (#279) while
+# daily home is a CALENDAR-day quantity, and composing a midnight row out of a
+# deadline row is exactly the day-boundary class closed in #703/#704. The mirror
+# is DAILY-ONLY — monthly, yearly and lifetime EV stay on the one deadline-keyed
+# bucket, so there is still a single EV total in the system. The name
+# deliberately does not start with ``ev_``: that prefix means "survives the
+# midnight rollover" (``_check_rollover``), and this bucket must roll at midnight.
+MIDNIGHT_EV_CATEGORY = "midnight_ev"
+
+# (#628) A balance term with no counter of its own may still take part in the
+# home balance while it is physically ABSENT — an install with no battery
+# integrates 0 kWh of battery charge all day, and demanding a BMS counter of it
+# would disable the balance for no reason. Above this the term is present and
+# unmetered, and the balance stands down rather than inherit its error.
+UNMETERED_TERM_EPSILON_KWH = 0.05
+
+# (#628) The daily home residual, spelled out. Same identity as
+# ``PowerReadings.calculate_derived`` uses in watts, applied to the day's
+# reconciled kWh rows instead of to one 10-second sample. EV is NOT here: it is
+# subtracted separately from ``MIDNIGHT_EV_CATEGORY``, because it is the only
+# term whose own bucket rolls on a different boundary.
+_HOME_BALANCE_TERMS = (
+    ("solar", 1.0),
+    ("grid_import", 1.0),
+    ("grid_export", -1.0),
+    ("battery_discharge", 1.0),
+    ("battery_charge", -1.0),
+)
 
 
 def _as_float(value: Any, default: float = 0.0) -> float:
@@ -153,6 +183,19 @@ class EnergyCalculator:
         self._meter_counter_enabled: bool = False
         self._meter_counter_logged: bool = False
         self._meter_baselines: Dict[str, Dict[str, Any]] = {}
+        # (#628) Which categories' daily values are COUNTER-BACKED this cycle —
+        # the precondition for ``_reconcile_home_energy``. Rebuilt from scratch
+        # every cycle and never persisted: it describes THIS cycle's reads, not
+        # accumulated state, and a stale membership would let the home balance
+        # run on an integrator nobody checked.
+        self._counter_backed: Set[str] = set()
+        self._home_balance_logged: bool = False
+        # Baselines for the midnight EV mirror — same delta model as
+        # ``_ev_counter_baselines``, keyed on the calendar day instead.
+        self._midnight_ev_baselines: Dict[str, Any] = {}
+        # First calendar day the midnight EV mirror was tracking. The balance
+        # refuses to run on that day — see ``_reconcile_home_energy``.
+        self._midnight_ev_since: Optional[date] = None
         self._lifetime_seeded: bool = False
         self._yearly_seeded: bool = False
         self._yearly_seed_attempts: int = 0
@@ -256,6 +299,11 @@ class EnergyCalculator:
         # Check for day/month/year rollover and reset accumulators
         self._check_rollover(today, month_key, year_key)
 
+        # (#628) This cycle's counter-backing starts empty — each reconciler
+        # below records its own category only when it actually read a COMPLETE
+        # counter set. ``_reconcile_home_energy`` reads the result.
+        self._counter_backed = set()
+
         # Integrate power to energy
         energy = EnergyTotals()
 
@@ -271,13 +319,13 @@ class EnergyCalculator:
         energy.yearly_solar = self._get_yearly("solar", year_key)
         energy.lifetime_solar = self._get_lifetime("solar")  # #573
 
-        # Home consumption
+        # Home consumption. The integral runs unconditionally — it is the
+        # fallback and the anchor — but the READ moved below every other
+        # category (#628): home is a residual of those categories, so it can
+        # only be reconciled once they have been.
         if power.home_consumption_power >= MIN_POWER_THRESHOLD:
             home_increment = (power.home_consumption_power * interval_hours) / 1000
             self._accumulate("home", today, month_key, year_key, home_increment)
-        energy.daily_home = self._get_daily("home", today)
-        energy.monthly_home = self._get_monthly("home", month_key)
-        energy.yearly_home = self._get_yearly("home", year_key)
 
         # EV charging. The sunrise/deadline reset lives entirely in the DAY KEY
         # (``ev_day``) — the category is plain ``ev`` like every other category.
@@ -297,10 +345,20 @@ class EnergyCalculator:
         if power.ev_power >= MIN_POWER_THRESHOLD:
             ev_increment = (power.ev_power * interval_hours) / 1000  # FLEET-READ: same fleet integration as the gate above.
             self._accumulate(EV_CATEGORY, ev_day, month_key, year_key, ev_increment)
+            # (#628) …and into the CALENDAR-day mirror the home balance
+            # subtracts. Written straight to the daily accumulators rather than
+            # through ``_accumulate``: the mirror is daily-only by design, so
+            # the monthly/yearly/lifetime writes ``_accumulate`` also performs
+            # would double-count EV into every longer period.
+            mirror_key = f"{MIDNIGHT_EV_CATEGORY}_{today}"
+            self._daily_accumulators[mirror_key] = (
+                self._daily_accumulators.get(mirror_key, 0.0) + ev_increment
+            )
         # (#658) wallbox-counter reconciliation — recovers charging SEM was not
         # running to integrate; must run before the reads below, exactly like
         # its solar sibling.
         self._reconcile_ev_energy(ev_day, month_key, year_key)
+        self._reconcile_midnight_ev_energy(today)  # (#628)
 
         energy.daily_ev = self._get_daily(EV_CATEGORY, ev_day)
         energy.monthly_ev = self._get_monthly(EV_CATEGORY, month_key)
@@ -356,6 +414,49 @@ class EnergyCalculator:
         energy.monthly_battery_discharge = self._get_monthly("battery_discharge", month_key)
         energy.yearly_battery_discharge = self._get_yearly("battery_discharge", year_key)
 
+        # Sanity checks — warn and cap if values exceed physical limits.
+        # These run BEFORE the home balance (#628 review W1): the caps are the
+        # sanity net for the metered rows, and home is derived FROM those rows.
+        # Capping after the derivation would let one corrupt BMS counter push a
+        # bogus figure into the home row for a cycle before the net caught it.
+        battery_capacity = self.config.get("battery_capacity_kwh", 15)
+        max_daily_battery = battery_capacity * 3  # 3 full cycles/day is generous limit
+        inverter_kwp = self.config.get("system_size_kwp", 10)
+        max_daily_solar = inverter_kwp * 16  # 16 peak sun hours is extreme max
+
+        if energy.daily_battery_discharge > max_daily_battery:
+            _LOGGER.warning(
+                "Battery discharge %.1f kWh exceeds %.0f kWh daily limit (3x %.0f kWh capacity) — capping",
+                energy.daily_battery_discharge, max_daily_battery, battery_capacity,
+            )
+            self._daily_accumulators[f"battery_discharge_{today}"] = max_daily_battery
+            energy.daily_battery_discharge = max_daily_battery
+
+        if energy.daily_battery_charge > max_daily_battery:
+            _LOGGER.warning(
+                "Battery charge %.1f kWh exceeds %.0f kWh daily limit — capping",
+                energy.daily_battery_charge, max_daily_battery,
+            )
+            self._daily_accumulators[f"battery_charge_{today}"] = max_daily_battery
+            energy.daily_battery_charge = max_daily_battery
+
+        if energy.daily_solar > max_daily_solar:
+            _LOGGER.warning(
+                "Solar %.1f kWh exceeds %.0f kWh daily limit (%d kWp × 16h) — capping",
+                energy.daily_solar, max_daily_solar, inverter_kwp,
+            )
+            self._daily_accumulators[f"solar_{today}"] = max_daily_solar
+            energy.daily_solar = max_daily_solar
+
+        # Home consumption — LAST (#628). Home is the residual of every row
+        # above, so it can only be derived once they have all been reconciled
+        # AND capped; its integral ran at the top of the cycle as the fallback
+        # and the anchor. Reading it here is the whole point of the move.
+        self._reconcile_home_energy(today, month_key, year_key)
+        energy.daily_home = self._get_daily("home", today)
+        energy.monthly_home = self._get_monthly("home", month_key)
+        energy.yearly_home = self._get_yearly("home", year_key)
+
         # Solar self-consumption savings (incremental, rate-weighted for dynamic tariff accuracy)
         # Only tracks savings from solar — battery discharge savings are in cost_batt_savings.
         #
@@ -387,36 +488,6 @@ class EnergyCalculator:
             solar_self_consumed = max(0.0, (home_incr + ev_incr) - import_incr - discharge_incr)
         if solar_self_consumed > 0.0:
             self._accumulate_cost("cost_savings", today, month_key, year_key, solar_self_consumed * self._import_rate)
-
-        # Sanity checks — warn and cap if values exceed physical limits
-        battery_capacity = self.config.get("battery_capacity_kwh", 15)
-        max_daily_battery = battery_capacity * 3  # 3 full cycles/day is generous limit
-        inverter_kwp = self.config.get("system_size_kwp", 10)
-        max_daily_solar = inverter_kwp * 16  # 16 peak sun hours is extreme max
-
-        if energy.daily_battery_discharge > max_daily_battery:
-            _LOGGER.warning(
-                "Battery discharge %.1f kWh exceeds %.0f kWh daily limit (3x %.0f kWh capacity) — capping",
-                energy.daily_battery_discharge, max_daily_battery, battery_capacity,
-            )
-            self._daily_accumulators[f"battery_discharge_{today}"] = max_daily_battery
-            energy.daily_battery_discharge = max_daily_battery
-
-        if energy.daily_battery_charge > max_daily_battery:
-            _LOGGER.warning(
-                "Battery charge %.1f kWh exceeds %.0f kWh daily limit — capping",
-                energy.daily_battery_charge, max_daily_battery,
-            )
-            self._daily_accumulators[f"battery_charge_{today}"] = max_daily_battery
-            energy.daily_battery_charge = max_daily_battery
-
-        if energy.daily_solar > max_daily_solar:
-            _LOGGER.warning(
-                "Solar %.1f kWh exceeds %.0f kWh daily limit (%d kWp × 16h) — capping",
-                energy.daily_solar, max_daily_solar, inverter_kwp,
-            )
-            self._daily_accumulators[f"solar_{today}"] = max_daily_solar
-            energy.daily_solar = max_daily_solar
 
         return energy
 
@@ -481,6 +552,13 @@ class EnergyCalculator:
             # re-anchors on the current daily value instead of attributing a new
             # charger's whole lifetime counter to today.
             self._ev_counter_baselines = {}
+            # ...and the calendar-day mirror the home balance subtracts, which
+            # tracks the SAME entity set (#628 review W2). Per-entity
+            # ``setdefault`` anchoring already makes a new charger harmless, but
+            # leaving the mirror behind would silently break that symmetry the
+            # day the two stop sharing ``_ev_counter_entities``. Mutate in
+            # place — ``_reconcile_ev_bucket`` holds this dict by reference.
+            self._midnight_ev_baselines.clear()
         self._ev_counter_entities = new_entities
         self._ev_counter_enabled = bool(enabled) and bool(self._ev_counter_entities)
         if self._ev_counter_enabled and not self._ev_counter_logged:
@@ -1022,6 +1100,17 @@ class EnergyCalculator:
         if not readings:
             return
 
+        # (#628) A COMPLETE counter set makes today's solar row counter-backed,
+        # which is what lets it take part in the home balance. Completeness
+        # matters here for the same reason it does in
+        # ``_reconcile_metered_energy``: on a two-inverter install with one
+        # inverter unavailable the row is only partly the hardware's, and the
+        # home residual would silently absorb the difference. Marked in
+        # darkness too — the counter is not CREDITED at night (#681), but the
+        # value it established by sunset still stands and PV is zero.
+        if len(readings) == len(self._solar_counter_entities):
+            self._counter_backed.add("solar")
+
         if self._sun_is_down():
             # Darkness: absorb the counter's movement into the baseline
             # instead of crediting it as production (#681). Rolling the
@@ -1128,19 +1217,66 @@ class EnergyCalculator:
         flows, so those figures for counter-recovered energy stay approximate —
         SEM knows the energy arrived but not what it was made of.
         """
+        self._reconcile_ev_bucket(
+            EV_CATEGORY, ev_day, self._ev_counter_baselines,
+            periods=(
+                (self._monthly_accumulators, f"{EV_CATEGORY}_{month_key}"),
+                (self._yearly_accumulators, f"{EV_CATEGORY}_{year_key}"),
+                (self._lifetime_accumulators, f"lifetime_{EV_CATEGORY}"),
+            ),
+        )
+
+    def _reconcile_midnight_ev_energy(self, today: date) -> None:
+        """Reconcile the CALENDAR-day EV mirror the home balance subtracts (#628).
+
+        Identical model to ``_reconcile_ev_energy`` — same counters, same
+        wallboxes, same delta arithmetic — differing in exactly two things, and
+        both of them are the point:
+
+        - the day key is the calendar day, not ``_ev_reset_day``; and
+        - it is DAILY-ONLY. Monthly, yearly and lifetime EV are owned by the
+          deadline-keyed bucket, so there is still one EV total in the system
+          and this mirror can never double-count into a longer period.
+
+        It exists because daily home is a calendar-day quantity and its EV term
+        has to be one too. Composing a midnight row out of a deadline row is the
+        day-boundary bug class closed in #703/#704; a car charging 04:00–06:00
+        belongs to the calendar day it charged on, whatever bucket the EV
+        counter puts it in.
+        """
+        self._reconcile_ev_bucket(
+            MIDNIGHT_EV_CATEGORY, today, self._midnight_ev_baselines,
+        )
+
+    def _reconcile_ev_bucket(
+        self,
+        category: str,
+        day: date,
+        baselines: Dict[str, Any],
+        periods: tuple = (),
+    ) -> None:
+        """Shared body of the two EV counter reconciliations (#658, #628).
+
+        One class, two instances: the deadline-keyed fleet bucket and the
+        calendar-day mirror the home balance needs. They differ only in their
+        day key and in which longer periods they feed, so they are parameters —
+        a second hand-written copy of a delta model is how the two drift apart.
+
+        ``baselines`` is mutated IN PLACE (never rebound) so the caller's
+        attribute keeps pointing at the live dict across a day rollover.
+        """
         if not self._ev_counter_enabled or not self._hass:
             return
 
-        day_str = str(ev_day)
-        bl = self._ev_counter_baselines
+        day_str = str(day)
+        bl = baselines
         if bl.get("date") != day_str or "base" not in bl or "last" not in bl:
-            # EV-day rollover (or first run / legacy or damaged shape):
-            # fresh baselines for the new EV day.
-            bl = self._ev_counter_baselines = {
-                "date": day_str, "base": {}, "last": {},
-            }
+            # Day rollover (or first run / legacy or damaged shape):
+            # fresh baselines for the new day.
+            bl.clear()
+            bl.update({"date": day_str, "base": {}, "last": {}})
 
-        daily_key = f"{EV_CATEGORY}_{ev_day}"
+        daily_key = f"{category}_{day}"
         integrated = self._daily_accumulators.get(daily_key, 0.0)
 
         readings: Dict[str, float] = {}
@@ -1200,16 +1336,12 @@ class EnergyCalculator:
             return  # Upward-only; small drift stays with the integrator.
 
         _LOGGER.info(
-            "EV energy reconciliation: counter=%.2f kWh > integrated=%.2f kWh "
+            "%s energy reconciliation: counter=%.2f kWh > integrated=%.2f kWh "
             "— adopting counter value (+%.2f kWh)",
-            target, integrated, delta,
+            category, target, integrated, delta,
         )
         self._daily_accumulators[daily_key] = target
-        for accumulators, key in (
-            (self._monthly_accumulators, f"{EV_CATEGORY}_{month_key}"),
-            (self._yearly_accumulators, f"{EV_CATEGORY}_{year_key}"),
-            (self._lifetime_accumulators, f"lifetime_{EV_CATEGORY}"),
-        ):
+        for accumulators, key in periods:
             accumulators[key] = accumulators.get(key, 0.0) + delta
 
     def _reconcile_metered_energy(
@@ -1294,6 +1426,10 @@ class EnergyCalculator:
             # unavailable, and its delta is still owed once it returns.
             return
 
+        # (#628) Complete read — this category's daily row is the hardware's
+        # this cycle, so the home balance may build on it.
+        self._counter_backed.add(category)
+
         # A counter that went BACKWARDS since its last reading (meter reboot,
         # a daily-type register resetting at midnight) invalidates the whole
         # baseline set for this category: its past contribution is already
@@ -1357,6 +1493,142 @@ class EnergyCalculator:
                 (self._yearly_cost_accumulators, f"{cost_key}_{year_key}"),
             ):
                 accumulators[key] = max(0.0, accumulators.get(key, 0.0) + cost_delta)
+
+    def _reconcile_home_energy(
+        self, today: date, month_key: str, year_key: str
+    ) -> None:
+        """Daily home consumption follows the balance, not a stopwatch (#628).
+
+        Home is the one row nothing meters. Every other row has hardware behind
+        it; home is by definition what is left when the metered rows are
+        subtracted from each other::
+
+            home = solar + import − export + discharge − charge − EV
+
+        SEM has always evaluated that identity INSTANTANEOUSLY — in watts, every
+        cycle — and integrated the result. That is where the last #628 column
+        goes wrong, and it is not a mistake in any single place: home is a
+        SMALL difference of LARGE terms, so it inherits their relative error
+        magnified by the ratio between them. Measured on the developer's own
+        PROD hardware for 25–31 July 2026, where solar, grid and battery each
+        agree with their meters to ≤0.5 %, daily home still landed −8 % to
+        +15 % off the meter-derived figure, in both directions. Five registers
+        updating asynchronously cannot be sampled into agreement with a day's
+        reconciled totals; on 31 July a 1 % skew on 53.8 kWh of solar alone is
+        ±0.5 kWh of a 34.8 kWh residual.
+
+        So the daily row stops being sampled and starts being derived — from the
+        rows this cycle has already reconciled. That is not a new idea in this
+        file: lifetime home (``seed_lifetime_from_hardware``) and yearly home
+        (``seed_yearly_from_statistics``) are ALREADY seeded from exactly this
+        balance. Only the daily row was still a stopwatch, and only the daily
+        row was wrong.
+
+        The invariant this buys is worth stating plainly, because it is stronger
+        than "home is more accurate": SEM's seven daily numbers now ADD UP. Home
+        is the exact residual of the six rows SEM publishes beside it, each of
+        which is independently pinned to the user's own counters. Today they do
+        not add up, which is what every numbers-don't-match report is really
+        reporting.
+
+        The gate is #628's own rule applied to a residual: derive only when
+        every term that is actually flowing is counter-backed THIS cycle;
+        otherwise stand down and let the integrator keep the row, exactly as
+        before. Standing down is continuous, not a jump — the integrator simply
+        resumes from wherever the balance left the accumulator.
+
+        Two terms get special handling:
+
+        - A term with NO counter but no flow either (an install with no battery,
+          a day with no export) is not an unverified number, it is the absence
+          of a flow, and it may enter the balance as the zero it is. Above
+          ``UNMETERED_TERM_EPSILON_KWH`` it is present-and-unmetered and the
+          balance stands down.
+        - EV stays on the integrator when the wallbox counters are not
+          configured. It is the one term where that is defensible: charger power
+          is a DIRECT measurement, not a residual, so its error enters home at
+          1:1 rather than magnified. It is subtracted from
+          ``MIDNIGHT_EV_CATEGORY`` — the calendar-day mirror — because
+          ``EV_CATEGORY`` rolls at the charge deadline (#279) and composing a
+          midnight row out of a deadline row is the bug class closed in
+          #703/#704.
+        """
+        if not self._meter_counter_enabled or not self._hass:
+            return
+
+        # The EV mirror only knows the charging it has watched. On the first
+        # cycle after an upgrade it is born mid-day while every other row
+        # already holds the whole day, so subtracting it would credit the car's
+        # morning charge to the house — a 20 kWh error on exactly the day
+        # people look. One calendar day of the old behaviour is the cheapest
+        # correct answer; from tomorrow the mirror spans the day.
+        if self._midnight_ev_since is None:
+            self._midnight_ev_since = today
+        if today <= self._midnight_ev_since:
+            return
+
+        values: Dict[str, float] = {}
+        balance = 0.0
+        for category, sign in _HOME_BALANCE_TERMS:
+            value = self._daily_accumulators.get(f"{category}_{today}", 0.0)
+            values[category] = value
+            if (
+                category not in self._counter_backed
+                and value > UNMETERED_TERM_EPSILON_KWH
+            ):
+                return  # Present and unmetered — see above.
+            balance += sign * value
+
+        values["ev"] = self._daily_accumulators.get(
+            f"{MIDNIGHT_EV_CATEGORY}_{today}", 0.0
+        )
+        raw = balance - values["ev"]
+        # The house always draws ≥ 0. The clamp stays (a negative residual is
+        # not a negative consumption), but what it REMOVED is recorded: a
+        # sustained engagement here means one of the six rows is signed wrong,
+        # and that is a finding, not a number to hide (#660).
+        target = self._record_clamp("daily_home_balance", raw, max(0.0, raw), 0.01)
+
+        if target > MAX_PLAUSIBLE_DAILY_KWH:
+            _LOGGER.warning(
+                "Home balance target %.1f kWh exceeds the %.0f kWh/day sanity "
+                "ceiling — ignoring this cycle (unit mismatch?)",
+                target, MAX_PLAUSIBLE_DAILY_KWH,
+            )
+            return
+
+        daily_key = f"home_{today}"
+        integrated = self._daily_accumulators.get(daily_key, 0.0)
+        delta = target - integrated
+        if abs(delta) <= METER_RECONCILIATION_THRESHOLD:
+            return  # Already there; small drift stays with the integrator.
+
+        if not self._home_balance_logged:
+            self._home_balance_logged = True
+            _LOGGER.info(
+                "Daily home consumption now follows the reconciled energy "
+                "balance (#628): solar %.2f + import %.2f − export %.2f + "
+                "discharge %.2f − charge %.2f − EV %.2f = %.2f kWh "
+                "(was integrating %.2f kWh)",
+                values["solar"], values["grid_import"], values["grid_export"],
+                values["battery_discharge"], values["battery_charge"],
+                values["ev"], target, integrated,
+            )
+        else:
+            _LOGGER.debug(
+                "Home balance: %.2f kWh vs integrated %.2f kWh (%+.2f)",
+                target, integrated, delta,
+            )
+
+        self._daily_accumulators[daily_key] = target
+        for accumulators, key in (
+            (self._monthly_accumulators, f"home_{month_key}"),
+            (self._yearly_accumulators, f"home_{year_key}"),
+            (self._lifetime_accumulators, "lifetime_home"),
+        ):
+            # max(0.0) — the delta is bidirectional, and a longer period must
+            # never be dragged below zero by one day's correction.
+            accumulators[key] = max(0.0, accumulators.get(key, 0.0) + delta)
 
     def _max_daily_ev_kwh(self) -> float:
         """Physical ceiling for one day of fleet EV charging.
@@ -1893,6 +2165,14 @@ class EnergyCalculator:
             "meter_baselines": {
                 cat: dict(bl) for cat, bl in self._meter_baselines.items()
             },
+            # (#628) The calendar-day EV mirror the home balance subtracts.
+            # ``midnight_ev_since`` must survive a restart or every restart
+            # would look like the upgrade day and suppress the balance forever.
+            "midnight_ev_baselines": dict(self._midnight_ev_baselines),
+            "midnight_ev_since": (
+                self._midnight_ev_since.isoformat()
+                if self._midnight_ev_since else None
+            ),
         }
 
     @staticmethod
@@ -1986,6 +2266,18 @@ class EnergyCalculator:
                     cat: bl for cat, bl in meter_baselines.items()
                     if isinstance(bl, dict)
                 }
+            midnight_ev = state.get("midnight_ev_baselines")
+            if isinstance(midnight_ev, dict):
+                self._midnight_ev_baselines = midnight_ev
+            since = state.get("midnight_ev_since")
+            if since:
+                try:
+                    self._midnight_ev_since = date.fromisoformat(str(since))
+                except ValueError:
+                    _LOGGER.warning(
+                        "Discarding unparseable midnight_ev_since %r — the home "
+                        "balance re-arms for one day", since,
+                    )
             last_update = state.get("last_update")
             if last_update:
                 self._last_update = datetime.fromisoformat(last_update)

--- a/coordinator/storage.py
+++ b/coordinator/storage.py
@@ -61,6 +61,11 @@ CALCULATOR_STATE_KEYS: tuple[str, ...] = (
     "ev_counter_baselines",
     # (#628) grid/battery meter baselines, keyed by category
     "meter_baselines",
+    # (#628) the CALENDAR-day EV mirror the home balance subtracts, and the
+    # first day it was tracking. The latter must persist, or every restart
+    # would look like the upgrade day and suppress the balance for good.
+    "midnight_ev_baselines",
+    "midnight_ev_since",
     # (#668) lifetime running totals, summed at each day rollover. Dropped
     # since they were introduced, so ``lifetime_total_savings`` fell back to a
     # 7-day-average-rate ESTIMATE of the entire history after every restart

--- a/docs/KNOWN_LIMITATIONS.md
+++ b/docs/KNOWN_LIMITATIONS.md
@@ -30,6 +30,8 @@ Battery → grid export arbitrage (selling stored energy to the grid when the dy
 
 SEM deliberately uses three day boundaries: daily ENERGY totals (solar / home / grid / battery) reset at **midnight**, matching HA's Energy Dashboard and utility billing. The EV daily counter rolls at the charger's **Charge-by deadline** (default 07:00) so an overnight charge lands in one bucket — it will not match a calendar-day comparison. Load **runtime targets** roll at **sunrise**, so an overnight top-up finishes yesterday's hours. Comparing any of the three against a source with a different boundary shows expected offsets, not drift.
 
+Since v1.7.5 the daily **home** row is derived from the day's reconciled counters rather than integrated (#628) — see the [Troubleshooting entry](TROUBLESHOOTING.md#daily-home-consumption-doesnt-match-my-meter-or-the-other-daily-rows). One consequence worth knowing: **on the day you upgrade to v1.7.5**, the home row keeps the old behaviour for that single calendar day and switches to the balance from the following midnight.
+
 ## Financial tracking
 
 Cost tracking uses either statically configured rates (HT/NT) or a dynamic tariff entity (Tibber, Nordpool, aWATTar). There is no automatic rate detection from utility providers. Export (feed-in) rates must be manually configured.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -493,6 +493,30 @@ so inflated solar inflates it 1:1.
 **Note:** the day the fix lands, the affected day's figures are already banked. Daily values are
 correct from the following midnight; monthly/yearly/lifetime keep the historic inflation.
 
+## Daily home consumption doesn't match my meter (or the other daily rows)
+
+**Cause (fixed in v1.7.5):** home is the one row nothing meters — it is by definition what is left
+when the metered rows are subtracted from each other. SEM used to evaluate that balance
+*instantaneously* (in watts, every cycle) and integrate the result. Because home is a small
+difference of large terms, every sensor's tiny error lands on the home row magnified: installs
+whose solar/grid/battery rows each matched their meters to ≤0.5 % still saw daily home off by
+−8 % to +15 %, in both directions.
+
+**Since v1.7.5** the daily home row is derived from the day's *reconciled* counters
+(`solar + import − export + discharge − charge − EV`), the same way lifetime and yearly home were
+already computed. The practical consequence: SEM's seven daily numbers now add up — home is the
+exact residual of the six rows published beside it.
+
+**Notes:**
+- **The day you upgrade**, the home row keeps the old behaviour for one calendar day (the internal
+  midnight EV mirror needs a full day of history before it can enter the balance). It derives from
+  the following midnight.
+- The balance only takes over when every flowing term is backed by a hardware counter from your
+  Energy Dashboard; otherwise the old integrator keeps the row. If home still drifts, check that
+  solar, grid and battery counters are configured in **Settings → Dashboards → Energy**.
+- The *instantaneous* `sensor.sem_home_consumption_power` is unchanged (see ADR 0004) — only the
+  daily energy row moved to the balance.
+
 ## Energy values spiked after integration update or restart
 
 **Cause:** When a hardware integration (e.g. Huawei Solar) restarts or updates, its sensors go `unavailable` briefly. When they come back, SEM's energy integrator could multiply the returned power value by the entire gap duration, producing unrealistic energy spikes (e.g. 40+ kWh battery discharge on a 15 kWh battery).

--- a/docs/adr/0004-home-consumption-clamp.md
+++ b/docs/adr/0004-home-consumption-clamp.md
@@ -50,3 +50,13 @@ real bugs upstream.
 Code path: `coordinator/types.py:PowerReadings.calculate_derived` (line 206).
 Do **not** add a `if balance < 0: return None` branch — that
 explicitly inverts this decision.
+
+## Scope note (v1.7.5, #628)
+
+This ADR covers the **instantaneous power sensor** only. Since v1.7.5 the
+**daily energy row** for home is no longer the integral of this sensor — it is
+derived from the day's reconciled counters
+(`coordinator/energy_calculator.py:_reconcile_home_energy`), with the integral
+kept as fallback and anchor. The daily clamp there records what it removed
+(`daily_home_balance` clamp telemetry, #660) instead of hiding it. Neither
+change touches this sensor's behaviour.

--- a/manifest.json
+++ b/manifest.json
@@ -22,5 +22,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.5-beta.37"
+  "version": "1.7.5"
 }

--- a/tests/test_628_home_balance.py
+++ b/tests/test_628_home_balance.py
@@ -1,0 +1,510 @@
+"""#628 — daily home consumption is the reconciled residual, not a stopwatch.
+
+Home is the one row nothing meters. Every other row has hardware behind it;
+home is *by definition* what is left when the metered rows are subtracted from
+each other::
+
+    home = solar + import − export + discharge − charge − EV
+
+SEM evaluated that identity INSTANTANEOUSLY — in watts, every cycle — and
+integrated the result. That is the last open column of #628, and it is not a
+mistake in any single place: home is a SMALL difference of LARGE terms, so it
+inherits their relative error magnified by the ratio between them.
+
+Two independent installs say the same thing. On the developer's own PROD
+hardware (Huawei SUN2000 + LUNA2000 + KEBA), where solar, grid and battery each
+agree with their meters to ≤0.5 %, daily home for 25–31 July 2026 still landed
+−8 % to +15 % off the meter-derived figure — in BOTH directions, which rules out
+a one-way clamp or a missing sample. On #628's reporter's install, solar/import/
+export all match to ~1.0× while home reads 28.7 vs 36.3 kWh.
+
+So the daily row stops being sampled and starts being derived. Lifetime home
+(``seed_lifetime_from_hardware``) and yearly home (``seed_yearly_from_statistics``)
+were ALREADY seeded from exactly this balance; only the daily row was still a
+stopwatch, and only the daily row was wrong.
+
+The property these tests pin is stronger than "home is more accurate": SEM's
+seven daily numbers now ADD UP. Home is the exact residual of the six rows
+published beside it, each independently pinned to the user's own counters.
+"""
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import Mock
+
+import pytest
+from freezegun import freeze_time
+
+from custom_components.solar_energy_management.coordinator.energy_calculator import (
+    EV_CATEGORY,
+    MIDNIGHT_EV_CATEGORY,
+    MAX_PLAUSIBLE_DAILY_KWH,
+    EnergyCalculator,
+)
+from custom_components.solar_energy_management.coordinator.types import PowerReadings
+from custom_components.solar_energy_management.utils.time_manager import TimeManager
+
+DAY = date(2026, 7, 15)
+
+SOLAR = "sensor.inverter_total_yield"
+IMPORT = "sensor.p1_import"
+EXPORT = "sensor.p1_export"
+BATT_IN = "sensor.bms_charged"
+BATT_OUT = "sensor.bms_discharged"
+WALLBOX = "sensor.wallbox_total_energy"
+
+METERS = {
+    "solar": SOLAR,
+    "grid_import": IMPORT,
+    "grid_export": EXPORT,
+    "battery_charge": BATT_IN,
+    "battery_discharge": BATT_OUT,
+}
+ALL_CATEGORIES = tuple(METERS)
+
+
+def _hass(values: dict) -> Mock:
+    """Mock hass whose states track ``values`` LIVE, so a test can move a
+    counter between cycles the way real hardware does."""
+    hass = Mock()
+    hass.data = {}
+    hass.config = Mock()
+    hass.config.config_dir = "/config"
+
+    def _get(entity_id):
+        if entity_id not in values:
+            return None
+        state = Mock()
+        state.state = str(values[entity_id])
+        state.attributes = {"unit_of_measurement": "kWh"}
+        return state
+
+    hass.states.get = _get
+    return hass
+
+
+def _rig(
+    rows: dict,
+    *,
+    metered=ALL_CATEGORIES,
+    enabled: bool = True,
+    ev_counter: bool = False,
+    ev_kwh: float = 0.0,
+    update_interval: int = 10,
+):
+    """A calculator whose daily rows already hold ``rows``, with counters wired
+    for ``metered``.
+
+    Seeding the rows and leaving the counters at 0 is the honest shape of a
+    mid-day cycle: the first reconcile anchors each category on the value the
+    integrator already had, its counter delta is 0, and the row is unchanged —
+    but now COUNTER-BACKED, which is the precondition the home balance reads.
+    """
+    values = {METERS[cat]: 0.0 for cat in metered}
+    hass = _hass(values)
+    calc = EnergyCalculator({"update_interval": update_interval}, TimeManager(hass))
+    calc.configure_solar_counters(
+        hass, [SOLAR] if "solar" in metered else [], enabled
+    )
+    calc.configure_meter_counters(
+        hass,
+        {cat: [METERS[cat]] for cat in metered if cat != "solar"},
+        enabled,
+    )
+    if ev_counter:
+        values[WALLBOX] = 0.0
+        calc.configure_ev_counters(hass, [WALLBOX], enabled)
+    for category, kwh in rows.items():
+        calc._daily_accumulators[f"{category}_{DAY}"] = kwh
+    if ev_kwh:
+        calc._daily_accumulators[f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] = ev_kwh
+    # Past the upgrade day — see ``TestUpgradeDay`` for the guard itself.
+    calc._midnight_ev_since = DAY - timedelta(days=1)
+    return calc, values
+
+
+def _cycle(calc: EnergyCalculator, **power):
+    """One cycle. ``_last_update`` is cleared so the configured interval is
+    used: these tests compress hours into consecutive statements, and a >120 s
+    apparent gap would make ``calculate_energy`` skip the cycle entirely
+    (accumulator-spike guard) — silently skipping the code under test."""
+    calc._last_update = None
+    readings = PowerReadings(**power)
+    readings.calculate_derived()
+    return calc.calculate_energy(readings)
+
+
+# A day with the shape that breaks the stopwatch: a 34 kWh residual carried by
+# a 53 kWh solar term. Numbers rounded from the developer's PROD hardware,
+# 31 July 2026, where SEM's integrated home came back 3.2 kWh (−9 %) low.
+BIG_DAY = {
+    "solar": 53.80,
+    "grid_import": 1.20,
+    "grid_export": 20.30,
+    "battery_charge": 8.00,
+    "battery_discharge": 6.90,
+}
+BIG_DAY_HOME = 53.80 + 1.20 - 20.30 + 6.90 - 8.00  # 33.60
+
+
+@pytest.mark.unit
+@freeze_time("2026-07-15 12:00:00")
+class TestTheBalance628:
+    def test_the_balance_can_actually_fire(self):
+        """Bug class 8 at birth: every assertion below would pass vacuously if
+        the balance never ran, so first prove the switch has two positions. The
+        OFF position is not hypothetical — it is what shipped until now, and it
+        is still what an install without ``prefer_hardware_energy`` gets."""
+        off, _ = _rig({**BIG_DAY, "home": 30.0}, enabled=False)
+        assert _cycle(off).daily_home == 30.0, "disabled balance overrode the row"
+
+        on, _ = _rig({**BIG_DAY, "home": 30.0})
+        assert _cycle(on).daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+
+    def test_home_is_the_residual_of_the_reconciled_rows(self):
+        """THE issue. Whatever the integrator sampled its way to, the published
+        row is the balance of the six rows beside it."""
+        calc, _ = _rig({**BIG_DAY, "home": 30.42})
+        energy = _cycle(calc)
+
+        assert energy.daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+        assert (
+            energy.daily_solar
+            + energy.daily_grid_import
+            - energy.daily_grid_export
+            + energy.daily_battery_discharge
+            - energy.daily_battery_charge
+            - energy.daily_home
+        ) == pytest.approx(0.0, abs=0.01), "the seven published rows do not add up"
+
+    def test_the_residual_no_longer_inherits_the_integrator(self):
+        """The magnification property, stated as a test: two installs whose
+        integrators drifted in OPPOSITE directions land on the same number,
+        because the number no longer comes from the integrator at all."""
+        low, _ = _rig({**BIG_DAY, "home": 30.40})   # −9 %, the 31 Jul shape
+        high, _ = _rig({**BIG_DAY, "home": 38.60})  # +15 %, the 27 Jul shape
+        assert _cycle(low).daily_home == _cycle(high).daily_home
+
+    def test_a_material_correction_moves_month_year_and_lifetime(self):
+        """One call writes the daily row, so one call corrects every period —
+        the #666 lesson. A month that keeps the old daily sum is a month that
+        disagrees with the days inside it."""
+        calc, _ = _rig({**BIG_DAY, "home": 30.00})
+        for accumulators, key in (
+            (calc._monthly_accumulators, "home_2026_7"),
+            (calc._yearly_accumulators, "home_2026"),
+            (calc._lifetime_accumulators, "lifetime_home"),
+        ):
+            accumulators[key] = 100.0
+
+        _cycle(calc)
+
+        delta = BIG_DAY_HOME - 30.00  # +3.60
+        assert calc._monthly_accumulators["home_2026_7"] == pytest.approx(100 + delta)
+        assert calc._yearly_accumulators["home_2026"] == pytest.approx(100 + delta)
+        assert calc._lifetime_accumulators["lifetime_home"] == pytest.approx(100 + delta)
+
+    def test_a_longer_period_is_never_dragged_below_zero(self):
+        """The delta is bidirectional now. One day's downward correction must
+        not push a month negative — the same guard the metered rows carry."""
+        calc, _ = _rig({**BIG_DAY, "home": 90.00})  # wildly over
+        calc._monthly_accumulators["home_2026_7"] = 1.0
+        _cycle(calc)
+        assert calc._monthly_accumulators["home_2026_7"] == 0.0
+
+
+@pytest.mark.unit
+@freeze_time("2026-07-15 12:00:00")
+class TestTheGate628:
+    def test_a_present_unmetered_term_stands_the_balance_down(self):
+        """#628's own rule applied to a residual. With no battery counters, a
+        real 6.9 kWh of discharge is a number nobody checked — deriving home
+        from it would launder the integrator's error into a figure that LOOKS
+        meter-backed. The integrator keeps the row instead."""
+        calc, _ = _rig(
+            {**BIG_DAY, "home": 30.00},
+            metered=("solar", "grid_import", "grid_export"),
+        )
+        assert _cycle(calc).daily_home == 30.00
+
+    def test_an_absent_term_does_not_stand_the_balance_down(self):
+        """The other half, and the reason for the epsilon: an install with no
+        battery integrates 0 kWh of charge all day. That zero is not an
+        unverified number, it is the absence of a flow, and demanding a BMS
+        counter of it would disable the balance on every battery-less install
+        for nothing."""
+        rows = {
+            "solar": 40.0, "grid_import": 5.0, "grid_export": 12.0,
+            "battery_charge": 0.0, "battery_discharge": 0.0, "home": 28.0,
+        }
+        calc, _ = _rig(rows, metered=("solar", "grid_import", "grid_export"))
+        assert _cycle(calc).daily_home == pytest.approx(33.0, abs=0.01)
+
+    def test_a_partial_counter_set_is_not_counter_backed(self):
+        """Completeness, not availability. A two-string install with one
+        inverter unavailable has a solar row that is only PARTLY the
+        hardware's; the home residual would silently absorb the difference."""
+        values = {SOLAR: 0.0, "sensor.inverter_b_total_yield": 0.0}
+        hass = _hass(values)
+        calc = EnergyCalculator({"update_interval": 10}, TimeManager(hass))
+        calc.configure_solar_counters(
+            hass, [SOLAR, "sensor.inverter_b_total_yield"], True
+        )
+        calc.configure_meter_counters(
+            hass,
+            {c: [METERS[c]] for c in ALL_CATEGORIES if c != "solar"},
+            True,
+        )
+        for cat, kwh in {**BIG_DAY, "home": 30.0}.items():
+            calc._daily_accumulators[f"{cat}_{DAY}"] = kwh
+        calc._midnight_ev_since = DAY - timedelta(days=1)
+        for entity in (IMPORT, EXPORT, BATT_IN, BATT_OUT):
+            values[entity] = 0.0
+
+        del values["sensor.inverter_b_total_yield"]  # one inverter drops out
+        assert _cycle(calc).daily_home == 30.0
+
+    def test_the_balance_stands_down_continuously_not_with_a_jump(self):
+        """Standing down hands the row back to the integrator — which resumes
+        from wherever the balance left the accumulator, not from some stale
+        parallel total. A discontinuity here would be a visible step in a
+        TOTAL sensor and read as a new bug."""
+        calc, values = _rig({**BIG_DAY, "home": 30.00})
+        assert _cycle(calc).daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+
+        del values[IMPORT]  # the P1 meter goes unavailable
+        resumed = _cycle(calc, solar_power=1000.0, grid_export_power=1000.0)
+        assert resumed.daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+
+    def test_a_negative_balance_clamps_and_says_so(self):
+        """The house always draws ≥ 0, so the clamp stays — but what it REMOVED
+        is recorded (#660). A sustained engagement means one of the six rows is
+        signed wrong, and that is a finding, not a number to hide."""
+        rows = {
+            "solar": 1.0, "grid_import": 0.0, "grid_export": 20.0,
+            "battery_charge": 0.0, "battery_discharge": 0.0, "home": 5.0,
+        }
+        calc, _ = _rig(rows)
+        assert _cycle(calc).daily_home == 0.0
+        assert calc.clamp_engagement["daily_home_balance"] == pytest.approx(19.0)
+
+    def test_an_implausible_balance_is_refused_not_published(self):
+        """A counter in the wrong magnitude (Wh read as kWh) must not become a
+        1000× home figure. Refusing the cycle leaves the integrator's row.
+
+        Probed through GRID IMPORT deliberately: solar and battery are already
+        held to a physical ceiling derived from the configured hardware before
+        the balance ever reads them, so they cannot carry an absurd term in.
+        Grid has no such ceiling — a house can legitimately import any amount —
+        which makes it the one leg where this guard is still the last line."""
+        rows = {**BIG_DAY, "grid_import": MAX_PLAUSIBLE_DAILY_KWH - 1, "home": 30.0}
+        calc, _ = _rig(rows)
+        assert _cycle(calc).daily_home == 30.0
+
+    def test_a_row_already_on_the_balance_is_left_alone(self):
+        """Dead band. Once adopted the balance recomputes every cycle, and
+        rewriting the accumulator for a 0.01 kWh difference would be pure
+        churn on a value that is already right."""
+        calc, _ = _rig({**BIG_DAY, "home": BIG_DAY_HOME + 0.02})
+        assert _cycle(calc).daily_home == pytest.approx(BIG_DAY_HOME + 0.02, abs=0.005)
+
+
+@pytest.mark.unit
+class TestTheEvTerm628:
+    """The day-boundary half. ``EV_CATEGORY`` rolls at the charge deadline
+    (#279); daily home is a CALENDAR-day quantity. Composing a midnight row out
+    of a deadline row is exactly the bug class closed in #703/#704."""
+
+    @freeze_time("2026-07-15 03:00:00")
+    def test_the_ev_term_is_the_calendar_mirror_not_the_deadline_bucket(self):
+        """A car charging at 03:00 belongs to the calendar day it is charging
+        on. The deadline bucket still holds last evening's session too — and
+        subtracting THAT from today's balance would eat 10 kWh of the house's
+        consumption."""
+        rows = {
+            "solar": 0.0, "grid_import": 20.0, "grid_export": 0.0,
+            "battery_charge": 0.0, "battery_discharge": 0.0, "home": 0.0,
+        }
+        calc, _ = _rig(rows, update_interval=3600)
+        ev_day = calc._ev_reset_day(__import__(
+            "homeassistant.util.dt", fromlist=["now"]).now())
+        assert ev_day != DAY, "harness broken — the two day keys must differ here"
+        calc._daily_accumulators[f"{EV_CATEGORY}_{ev_day}"] = 10.0  # last evening
+
+        energy = _cycle(calc, ev_power=7000.0)  # one hour at 7 kW
+
+        assert calc._daily_accumulators[f"{EV_CATEGORY}_{ev_day}"] == pytest.approx(17.0)
+        assert calc._daily_accumulators[
+            f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] == pytest.approx(7.0)
+        # 20 imported, 7 into the car → 13 for the house. Not 3.
+        assert energy.daily_home == pytest.approx(13.0, abs=0.01)
+
+    @freeze_time("2026-07-15 03:00:00")
+    def test_the_mirror_never_reaches_a_longer_period(self):
+        """DAILY-ONLY by design. Monthly, yearly and lifetime EV are owned by
+        the one deadline-keyed bucket, so there is still a single EV total in
+        the system and the mirror cannot double-count into any of them."""
+        calc, _ = _rig({}, update_interval=3600)
+        _cycle(calc, ev_power=7000.0)
+
+        assert calc._daily_accumulators[
+            f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] == pytest.approx(7.0)
+        for accumulators in (
+            calc._monthly_accumulators,
+            calc._yearly_accumulators,
+            calc._lifetime_accumulators,
+        ):
+            assert not [
+                k for k in accumulators if MIDNIGHT_EV_CATEGORY in k
+            ], f"the daily-only mirror leaked into {accumulators}"
+        assert calc._monthly_accumulators["ev_2026_7"] == pytest.approx(7.0)
+
+    @freeze_time("2026-07-15 12:00:00")
+    def test_the_mirror_name_survives_the_midnight_rollover_rule(self):
+        """``_check_rollover`` keeps any key starting ``ev_`` across midnight,
+        because those roll at the deadline. The mirror MUST roll at midnight,
+        which is the whole reason its category is not spelled ``ev_midnight``.
+        A rename that forgot this would silently freeze the term for a day."""
+        calc, _ = _rig({})
+        calc._daily_accumulators[f"{MIDNIGHT_EV_CATEGORY}_{DAY - timedelta(days=1)}"] = 9.0
+        _cycle(calc)
+        assert f"{MIDNIGHT_EV_CATEGORY}_{DAY - timedelta(days=1)}" not in (
+            calc._daily_accumulators
+        )
+
+    @freeze_time("2026-07-15 12:00:00")
+    def test_the_mirror_recovers_charging_sem_did_not_see(self):
+        """The mirror carries the same counter reconciliation as its sibling —
+        otherwise a charge during SEM downtime would be missing from the EV
+        term and land in the house's column instead."""
+        calc, values = _rig({}, ev_counter=True)
+        _cycle(calc)                      # baseline at 0
+        values[WALLBOX] = 6.0             # charged while SEM was not integrating
+        _cycle(calc)
+        assert calc._daily_accumulators[
+            f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] == pytest.approx(6.0)
+
+
+@pytest.mark.unit
+@freeze_time("2026-07-15 12:00:00")
+class TestUpgradeDay628:
+    def test_the_upgrade_day_keeps_the_integrator(self):
+        """The mirror only knows the charging it has watched. On the first
+        cycle after an upgrade it is born mid-day while every other row already
+        holds the whole day, so subtracting it would credit the car's morning
+        charge to the house — a 20 kWh error on exactly the day people look."""
+        calc, _ = _rig({**BIG_DAY, "home": 30.00})
+        calc._midnight_ev_since = None  # as an upgraded install arrives
+        assert _cycle(calc).daily_home == 30.00
+        assert calc._midnight_ev_since == DAY
+
+    def test_the_day_after_the_upgrade_derives(self):
+        calc, _ = _rig({**BIG_DAY, "home": 30.00})
+        calc._midnight_ev_since = DAY - timedelta(days=1)
+        assert _cycle(calc).daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+
+    def test_a_restart_is_not_an_upgrade(self):
+        """``midnight_ev_since`` must survive the store, or every restart would
+        look like the upgrade day and suppress the balance forever."""
+        calc, _ = _rig({**BIG_DAY, "home": 30.00})
+        calc._midnight_ev_baselines = {"date": str(DAY), "base": {WALLBOX: 3.0}}
+        state = calc.get_state()
+
+        restored, _ = _rig({**BIG_DAY, "home": 30.00})
+        restored._midnight_ev_since = None
+        restored.restore_state(state)
+
+        assert restored._midnight_ev_since == DAY - timedelta(days=1)
+        assert restored._midnight_ev_baselines["base"] == {WALLBOX: 3.0}
+        assert _cycle(restored).daily_home == pytest.approx(BIG_DAY_HOME, abs=0.01)
+
+
+@pytest.mark.unit
+@freeze_time("2026-07-15 12:00:00")
+class TestReviewFindings628:
+    """Cases raised by review of this change, kept because each one pins a
+    property the implementation could lose again silently."""
+
+    def test_the_battery_cap_lands_before_the_balance_reads_it(self):
+        """The physical-limit caps are the sanity net for the metered rows, and
+        home is DERIVED from those rows — so the net has to be in place before
+        the derivation, not after it. Ordered the other way, one corrupt BMS
+        register publishes a bogus house figure for a cycle before the cap that
+        exists to prevent exactly that gets its turn."""
+        calc, _ = _rig({**BIG_DAY, "battery_discharge": 90.00, "home": 30.00})
+        calc.config["battery_capacity_kwh"] = 15  # → 45 kWh/day ceiling
+        capped = 53.80 + 1.20 - 20.30 + 45.00 - 8.00
+
+        for _ in range(2):  # stable, not a one-cycle coincidence
+            energy = _cycle(calc)
+            assert energy.daily_battery_discharge == 45.00
+            assert energy.daily_home == pytest.approx(capped, abs=0.01)
+
+    def test_a_charger_change_drops_the_mirror_baselines_in_place(self):
+        """A charger added mid-run re-anchors the fleet bucket; the mirror
+        tracks the SAME entity set and has to follow, or the two drift. And it
+        must be emptied IN PLACE — ``_reconcile_ev_bucket`` holds this dict by
+        reference, so rebinding would leave it writing to an orphan."""
+        calc, _ = _rig({}, ev_counter=True)
+        calc._midnight_ev_baselines.update(
+            {"date": str(DAY), "base": {WALLBOX: 4.0}, "last": {WALLBOX: 4.0}}
+        )
+        held = calc._midnight_ev_baselines
+
+        calc.configure_ev_counters(
+            _hass({}), [WALLBOX, "sensor.second_wallbox"], True
+        )
+
+        assert calc._midnight_ev_baselines is held, "rebound, not cleared"
+        assert held == {}
+
+    def test_a_mid_day_restart_credits_the_counter_advance(self):
+        """The gap a restart leaves is the mirror's whole reason to carry a
+        counter: charging SEM did not watch still has to leave the house's
+        column. Pins the delta across the store, not just the anchor."""
+        calc, values = _rig({}, ev_counter=True)
+        _cycle(calc)
+        values[WALLBOX] = 4.0
+        _cycle(calc)
+        assert calc._daily_accumulators[
+            f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] == pytest.approx(4.0)
+        state = calc.get_state()
+
+        restored, rvalues = _rig({}, ev_counter=True)
+        restored.restore_state(state)
+        rvalues[WALLBOX] = 6.5  # kept charging while SEM was down
+        _cycle(restored)
+
+        assert restored._daily_accumulators[
+            f"{MIDNIGHT_EV_CATEGORY}_{DAY}"] == pytest.approx(6.5)
+
+    def test_a_mirror_counter_that_resets_re_anchors(self):
+        """Plenty of wallboxes expose a DAILY counter that returns to zero on
+        its own schedule. Read as a delta that is a large negative number, and
+        the EV term — which the balance SUBTRACTS — would hand the car's whole
+        day to the house."""
+        calc, values = _rig({}, ev_counter=True)
+        mirror = f"{MIDNIGHT_EV_CATEGORY}_{DAY}"
+        _cycle(calc)
+        values[WALLBOX] = 5.0
+        _cycle(calc)
+        assert calc._daily_accumulators[mirror] == pytest.approx(5.0)
+
+        values[WALLBOX] = 0.0  # the counter rolls
+        _cycle(calc)
+        assert calc._daily_accumulators[mirror] == pytest.approx(5.0)
+
+        values[WALLBOX] = 2.0  # and carries on from there
+        _cycle(calc)
+        assert calc._daily_accumulators[mirror] == pytest.approx(7.0)
+
+    def test_real_export_without_an_export_meter_stands_the_balance_down(self):
+        """The likeliest partial install: everything declared in the Energy
+        Dashboard except the export leg. Export is genuinely happening, so it
+        is present-and-unmetered — the balance must stand down rather than
+        treat a 20 kWh term it cannot verify as zero."""
+        calc, _ = _rig(
+            {**BIG_DAY, "home": 30.00},
+            metered=("solar", "grid_import", "battery_charge", "battery_discharge"),
+        )
+        assert _cycle(calc).daily_home == 30.00


### PR DESCRIPTION
## v1.7.5 stable prep — daily home from the reconciled balance (#628)

**Do not merge before the 2026-08-03 ~02:00 CEST gate check** (Aug 2→3 midnight
crossing on PROD must be clean — first night the balance method owns the home
row end-to-end).

### What this carries

- **`9dbf278`** — the #628 fix: the daily home row is derived from the day's
  reconciled counters (`solar + import − export + discharge − charge − EV`)
  instead of integrating the instantaneous balance. Gated on every flowing term
  being counter-backed; integrator kept as fallback+anchor; calendar-day EV
  mirror (`midnight_ev`) so the #279 deadline-day EV counter never leaks into a
  midnight row (#703/#704 class); upgrade-day suppression via persisted
  `midnight_ev_since`.
- **develop merged in** (beta.38 state) — no conflicts.
- **Release prep**: CHANGELOG v1.7.5 stable consolidation entry, manifest
  `1.7.5`, docs (TROUBLESHOOTING "daily home doesn't match my meter" section,
  KNOWN_LIMITATIONS upgrade-day note, ADR 0004 scope note).

### Evidence

- TEST: reconciled balance matches SEM's own six rows to the cent.
- PROD (own hardware, Huawei SUN2000 + LUNA2000 + KEBA): solar/grid/battery
  daily rows each ≤0.5 % vs meters; pre-fix home was −8 %…+15 % off in both
  directions — the residual-of-large-terms error this PR removes.
- 24 new tests in `tests/test_628_home_balance.py`; full suite green locally.

### Merge plan (Guido-authorized 2026-08-02)

2am gate check clean → merge this → PR develop → main → tag `v1.7.5` stable.
No TEST deploy (branch soak active) and no PROD deploy (PROD already runs this
code via the #638 soak branch working tree).

Fixes #628
