### PR TITLE
fix(#708): SOC-lag overshoot — energy-accounted ceiling beside the stale sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [1.7.6-beta.1] — 03.08.2026 *(unreleased — entries land at merge; header renumbers at tag if the 1.8 line opens first)*
 
+### 🐛 Fixes
+
+- 🚗 **EV no longer overshoots the SOC target on slow/polled car sensors** (#708, reported by
+  @Azlinon) — OnStar-class integrations poll the vehicle SOC as rarely as every 30 minutes, and
+  SEM steered on the last value as if it were live: overshoot = sensor lag × charge power (60 %
+  target → 67 % on an 85 kWh pack at 11.5 kW). The stop decision now uses an energy-accounted
+  ceiling beside the sensor: the pack cannot be emptier than the last reading plus what the
+  session measurably delivered (× 0.92 charge efficiency), so the charge stops at the target even
+  while the sensor sleeps. The sensor stays primary — every fresh reading re-anchors and wins,
+  and if it lands below target SEM auto-resumes for the difference (resumes are spaced by the
+  sensor's own update interval and shrink each round). A mobile notification and a card info line
+  ("Car: 55 % (28 min ago) · est. now ~59 %") explain both the early stop and any resume. The
+  virtual/estimated SOC display is untouched, and the #446 wall (no speculative SOC in budgets)
+  is re-pinned by an extended AST guard. Zero new config keys.
+
 ### ✨ Features
 
 - ⚡ **Dual-source phase guard now enforces in the EV write path** (by @tintinz in #712) —

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -5665,6 +5665,55 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                         mins_to_full, charger_name=charger_name
                     )
 
+                # #708 — estimate-stop / auto-resume announcements. The
+                # decision itself lives in _calculate_remaining_need
+                # (effective SOC = max(sensor, energy-accounted)); this
+                # block only detects the two user-visible transitions:
+                # the estimate ends a charge the stale sensor would have
+                # kept running, and a fresh reading below target makes
+                # SEM resume. Latch lives on the per-charger detector
+                # (session-scoped, cleared on disconnect).
+                det_708 = self._ev_taper_detectors.get(cid)
+                cfg_708 = cfg_for_cid or {}
+                type_708 = (
+                    cfg_708.get("ev_target_type") or cfg_708.get("ev_target_mode")
+                    or self.config.get("ev_target_type")
+                    or self.config.get("ev_target_mode", "kwh")
+                )
+                ea_708 = intel.get("energy_accounted_soc")
+                soc_708 = intel.get("vehicle_soc")
+                if (det_708 is not None and charger_connected
+                        and type_708 == "soc"
+                        and ea_708 is not None and soc_708 is not None):
+                    cap_708 = (
+                        cfg_708.get("ev_battery_capacity_kwh")
+                        or self.config.get("ev_battery_capacity_kwh", 40)
+                    )
+                    for bound_708 in ("min", "max"):
+                        tgt = self._resolve_target(
+                            cfg_708, "ev_target_soc", bound_708, 80, 100
+                        )
+                        sensor_rem = max(0.0, (tgt - soc_708) / 100 * cap_708)
+                        eff_rem = max(
+                            0.0, (tgt - max(soc_708, ea_708)) / 100 * cap_708
+                        )
+                        if (not det_708._estimate_stop_active
+                                and sensor_rem > 0.1 and eff_rem <= 0.1):
+                            det_708._estimate_stop_active = True
+                            await self._notification_manager.notify_ev_estimate_stop(
+                                target_soc=tgt, sensor_soc=soc_708,
+                                sensor_age_min=intel.get("vehicle_soc_age_min") or 0,
+                                charger_name=charger_name, flag_key=cid,
+                            )
+                            break
+                        if det_708._estimate_stop_active and eff_rem > 0.1:
+                            det_708._estimate_stop_active = False
+                            await self._notification_manager.notify_ev_estimate_resume(
+                                sensor_soc=soc_708, target_soc=tgt,
+                                charger_name=charger_name, flag_key=cid,
+                            )
+                            break
+
         except (ValueError, TypeError) as e:
             _LOGGER.debug("Event notification failed: %s", e)
         except HomeAssistantError as e:
@@ -5900,14 +5949,39 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
         if ev_target_type == "soc":
             # Pre-condition guaranteed by GUI gate + v10→v11 migration:
             # a real ``vehicle_soc_entity`` is configured for this charger.
-            # If its current value is unavailable (network blip etc.),
-            # return the full capacity so SEM keeps charging — taper
-            # detection will eventually stop it on car-full. Never use
-            # estimated_soc.
+            #
+            # #708 — the sensor value may be MINUTES old (OnStar polls every
+            # 30; overshoot = lag × power). The pack cannot be emptier than
+            # the last reading plus what this session measurably delivered
+            # since, so the effective SOC is ``max(sensor, energy-accounted)``.
+            # The sensor stays primary: every fresh value re-anchors the
+            # estimate and wins (this is a CAP, not the #446-forbidden
+            # substitution — the virtual/estimated SOC is still never used
+            # here). When a later reading lands below target, the need goes
+            # positive again and charging auto-resumes — the resumes are
+            # spaced by the sensor's own update interval, and each round
+            # shrinks, so the floor promise is kept without flapping.
+            ceiling_soc = None
+            detectors = getattr(self, "_ev_taper_detectors", None)
+            det = detectors.get(cfg.get("id")) if (detectors and cfg) else None
+            if det is None and detectors:
+                det = self._ev_taper_detector  # primary (single-charger installs)
+            if det is not None:
+                ceiling_soc = det.energy_accounted_soc()
             if vehicle_soc is None:
-                return float(ev_capacity)
+                # Sensor momentarily unavailable: pre-#708 this returned the
+                # full capacity (keep charging until taper). With an anchor
+                # from earlier in the session the estimate keeps counting —
+                # strictly better than charging blind. Never estimated_soc.
+                if ceiling_soc is None:
+                    return float(ev_capacity)
+                soc_target = self._resolve_target(cfg, "ev_target_soc", bound, 80, 100)
+                return max(0, (soc_target - ceiling_soc) / 100 * ev_capacity)
             soc_target = self._resolve_target(cfg, "ev_target_soc", bound, 80, 100)
-            return max(0, (soc_target - vehicle_soc) / 100 * ev_capacity)
+            effective_soc = (
+                max(vehicle_soc, ceiling_soc) if ceiling_soc is not None else vehicle_soc
+            )
+            return max(0, (soc_target - effective_soc) / 100 * ev_capacity)
 
         # kWh branch — the default mode for installs without a SOC sensor.
         daily_target = self._resolve_target(cfg, "daily_ev_target", bound, 10, 100)
@@ -6971,6 +7045,19 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
             # (#440) Per-charger skip-decision latch removed alongside the
             # skip-decision wiring — charge mode is the sole authority
             # on whether to charge at night now.
+            # #708 — sensor age for the card's staleness display. From
+            # ``last_changed`` deliberately: a poll that re-publishes the
+            # same value bumps only ``last_reported``, and for steering a
+            # value that hasn't CHANGED in 28 minutes of charging is
+            # exactly as stale as one that wasn't re-published.
+            soc_age_min: Optional[float] = None
+            if per_charger_soc_entity:
+                _soc_state = self.hass.states.get(per_charger_soc_entity)
+                if _soc_state is not None and _soc_state.last_changed is not None:
+                    soc_age_min = round(
+                        (dt_util.utcnow() - _soc_state.last_changed).total_seconds() / 60
+                    )
+
             result[cid] = {
                 "estimated_soc": round(soc, 1) if soc is not None else None,
                 # #383: surface the real per-charger vehicle SOC reading
@@ -6985,6 +7072,16 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                 ),
                 "minutes_to_full": taper_data.minutes_to_full if taper_data else None,
                 "battery_health": detector.battery_health_pct,
+                # #708 — measurement-only session estimate + sensor age,
+                # for the charger card's stale-sensor info line. NOT a
+                # SOC display value: the gauge keeps showing the sensor.
+                "energy_accounted_soc": (
+                    round(det_ea, 1)
+                    if (det_ea := detector.energy_accounted_soc()) is not None
+                    else None
+                ),
+                "vehicle_soc_age_min": soc_age_min,
+                "estimate_stop_active": detector._estimate_stop_active,
             }
 
         return result

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -1640,6 +1640,31 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
         # detectors exist the getter still resolves the primary from them.
         self._ev_taper_detector_default = value
 
+    def _reset_per_charger_estimate_state(self, cid: str, was_connected: bool) -> None:
+        """#708 — clear THIS charger's energy-accounted-SOC anchor and
+        estimate-stop/resume flags on ITS OWN disconnect transition.
+
+        ``_update_ev_intelligence`` resets the taper detector too, but only
+        the PRIMARY charger's (``self._ev_taper_detector`` is computed from
+        ``_ev_taper_detectors[primary_id]``), gated on the fleet-wide OR of
+        every charger's connection state. #708 added steering-critical
+        session fields (the SOC anchor) to the same detector class, so a
+        secondary charger's stale anchor could otherwise survive into its
+        next session and falsely cap the SOC target as already met. Call
+        this from inside the per-charger loop, where ``was_connected`` /
+        ``self._last_ev_connected`` are already swapped to THIS charger's
+        values, so the reset is scoped correctly regardless of which
+        charger is primary.
+        """
+        if not (was_connected and not self._last_ev_connected):
+            return
+        det = (getattr(self, "_ev_taper_detectors", None) or {}).get(cid)
+        if det is not None:
+            det.reset_session()
+        nm = getattr(self, "_notification_manager", None)
+        if nm is not None:
+            nm.clear_estimate_flags(flag_key=cid)
+
     @property
     def _ev_stalled_since(self) -> Optional[float]:
         """#589 Surface-A — this charger's stall timestamp, backed by the
@@ -2561,7 +2586,9 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
                         pc_chg_map = getattr(power, "ev_charging_per_charger", None) or {}
                         if cid in pc_chg_map:
                             power.ev_charging = bool(pc_chg_map[cid])
+                    was_connected_this_cid = self._last_ev_connected
                     self._update_session_tracking(power, charger_flows)
+                    self._reset_per_charger_estimate_state(cid, was_connected_this_cid)
                     # Save back per-charger state
                     self._session_data_per_charger[cid] = self._session_data
                     self._last_ev_connected_per_charger[cid] = self._last_ev_connected

--- a/coordinator/ev_taper_detector.py
+++ b/coordinator/ev_taper_detector.py
@@ -55,6 +55,14 @@ FULL_SESSION_ENERGY_FRAC_OF_CAPACITY = 0.025  # 2.5 % of pack capacity. Below
                                               # noise, not a completed charge.
 TAPER_RATIO_NEARLY_FULL = 50   # % — below this = nearly full
 TAPER_RATIO_DETECTED = 70     # % — below this + declining = taper confirmed
+CHARGE_EFFICIENCY = 0.92       # #708 — AC-side delivered → DC-pack fraction for
+                               # the energy-accounted SOC. Deliberately at the
+                               # optimistic end of the realistic 0.85–0.95 band:
+                               # over-estimating pack gain stops the charge AT or
+                               # slightly ABOVE the target, so "Min is a floor"
+                               # stays honest, while the stale-sensor overshoot
+                               # (lag × power, 7 % on the #708 report) is gone.
+                               # Hard-coded by decision — no config knob.
 MAX_ETA_MINUTES = 60           # Cap completion estimate
 MAX_HEALTH_SAMPLES = 20        # Bounded battery health sample buffer
 
@@ -116,6 +124,19 @@ class EVTaperDetector:
         self._last_real_soc: Optional[float] = None
         # Session SOC tracking for partial-charge health estimates
         self._session_start_soc: Optional[float] = None
+        # #708 — energy-accounted SOC anchor: the last sensor VALUE and the
+        # session-energy reading at the moment that value arrived. Between
+        # sensor updates the pack can only be FULLER than the anchor by what
+        # we measurably delivered — that bound is the overshoot guard for
+        # slow/polled SOC sensors (OnStar: 30-min poll ⇒ 7 % overshoot at
+        # 11.5 kW). Session-scoped: cleared on disconnect, never persisted —
+        # after a restart the ceiling stays inactive until the next anchor,
+        # which is the pre-#708 behaviour (fail-open to the known state).
+        self._soc_anchor_value: Optional[float] = None
+        self._soc_anchor_session_kwh: Optional[float] = None
+        # #708 — session latch: the estimate (not the sensor) ended a charge.
+        # Read by the notification layer; cleared on resume or disconnect.
+        self._estimate_stop_active: bool = False
         # Hardware counter tracking for drift-free energy accounting
         self._hw_total_at_full: Optional[float] = None  # Charger total kWh when SOC was 100%
         self._hw_total_last: Optional[float] = None  # Last known charger total kWh
@@ -374,6 +395,20 @@ class EVTaperDetector:
                     "SOC calibrated from vehicle: %.1f%% (energy_since_full=%.1f kWh)",
                     vehicle_soc, self._energy_since_full,
                 )
+                # #708 — every fresh sensor value re-anchors the
+                # energy-accounted SOC; the sensor always wins.
+                self._soc_anchor_value = vehicle_soc
+                self._soc_anchor_session_kwh = self._current_session_energy_kwh
+            elif self._soc_anchor_value is None:
+                # #708 — session-start bootstrap: after a disconnect cleared
+                # the anchor, the first present reading anchors even without
+                # a value change. While the car is not charging its SOC does
+                # not move, so a reading that is minutes old is still the
+                # truth at plug-in — without this, a session whose target
+                # lies inside the sensor's first polling window would run
+                # entirely unguarded.
+                self._soc_anchor_value = vehicle_soc
+                self._soc_anchor_session_kwh = self._current_session_energy_kwh
             self._last_real_soc = vehicle_soc
             self._soc_anchored = True
             # Track session start SOC for health calculation
@@ -395,6 +430,35 @@ class EVTaperDetector:
             min(100.0, 100.0 - (self._energy_since_full / capacity * 100.0)),
         )
         return self._estimated_soc
+
+    def energy_accounted_soc(self) -> Optional[float]:
+        """The pack cannot be emptier than the last reading plus what we
+        measurably delivered since — the #708 overshoot guard.
+
+        ``anchor + delivered_since_anchor × CHARGE_EFFICIENCY / capacity``,
+        capped at 100. Returns ``None`` when no anchor exists (no sensor
+        reading this session, capacity unconfigured, or just after a
+        restart) — callers fall back to pre-#708 behaviour.
+
+        This is deliberately NOT the virtual SOC: ``get_virtual_soc``
+        carries speculative terms (daily driving decay, temperature,
+        self-heal) and is walled off from steering (#440/#446). This
+        estimate contains only measured quantities from the current
+        plugged session, which is what makes it safe to let it CAP —
+        never replace — the sensor in the stop decision.
+        """
+        if self._soc_anchor_value is None or self._soc_anchor_session_kwh is None:
+            return None
+        capacity = float(self._config.get("ev_battery_capacity_kwh", 40) or 0)
+        if capacity <= 0:
+            return None
+        delivered = max(
+            0.0, self._current_session_energy_kwh - self._soc_anchor_session_kwh
+        )
+        return min(
+            100.0,
+            self._soc_anchor_value + delivered * CHARGE_EFFICIENCY / capacity * 100.0,
+        )
 
     def on_session_end(self, session_energy_kwh: float, end_soc: Optional[float] = None) -> None:
         """Record completed session for battery health tracking.
@@ -493,6 +557,12 @@ class EVTaperDetector:
         self._settling_counter = 0
         self._last_setpoint = 0.0
         self._session_start_soc = None
+        # #708 — the anchor is meaningless across sessions (unknown car,
+        # unknown driving in between); the bootstrap in get_virtual_soc
+        # re-arms it from the first reading of the next session.
+        self._soc_anchor_value = None
+        self._soc_anchor_session_kwh = None
+        self._estimate_stop_active = False
         # #438 — reset session-energy accumulator + integration state
         self._current_session_energy_kwh = 0.0
         self._last_energy_timestamp = None

--- a/coordinator/notifications.py
+++ b/coordinator/notifications.py
@@ -822,6 +822,14 @@ class NotificationManager:
         if flag in self._notified_flags:
             return
         self._notified_flags.add(flag)
+        # The opposite (stop) flag is released too — mirrors notify_ev_estimate_stop
+        # releasing resume — so a second estimate-based stop later in the SAME
+        # session (e.g. the resumed top-up itself re-crosses the ceiling while
+        # the sensor is still stale) can announce itself instead of being
+        # silently swallowed.
+        self._notified_flags.discard(
+            f"ev_estimate_stop_{key}" if key else "ev_estimate_stop"
+        )
 
         label = charger_name or "EV"
         self.hass.bus.async_fire(f"{DOMAIN}_notification", {
@@ -886,6 +894,25 @@ class NotificationManager:
         key = flag_key or charger_name
         flag = f"ev_deadline_unreachable_{key}" if key else "ev_deadline_unreachable"
         self._notified_flags.discard(flag)
+
+    def clear_estimate_flags(
+        self, charger_name: str | None = None, flag_key: str | None = None,
+    ) -> None:
+        """Clear both #708 estimate flags on disconnect.
+
+        ``reset()`` (below) exists but is never called in the running
+        coordinator, so without this the stop/resume flags never clear on
+        their own — call this at the same per-charger disconnect
+        transition that resets the taper detector's session anchor, so a
+        NEW session can announce its own stop/resume from a clean slate.
+        """
+        key = flag_key or charger_name
+        self._notified_flags.discard(
+            f"ev_estimate_stop_{key}" if key else "ev_estimate_stop"
+        )
+        self._notified_flags.discard(
+            f"ev_estimate_resume_{key}" if key else "ev_estimate_resume"
+        )
 
     def reset(self) -> None:
         """Reset notification state."""

--- a/coordinator/notifications.py
+++ b/coordinator/notifications.py
@@ -769,6 +769,78 @@ class NotificationManager:
     # longer load-bearing in any decision path. Tests of the old
     # behaviour are updated to assert the methods are absent.
 
+    async def notify_ev_estimate_stop(
+        self, target_soc: float, sensor_soc: float, sensor_age_min: float,
+        *, charger_name: str | None = None, flag_key: str | None = None,
+    ) -> None:
+        """The energy-accounted estimate ended a charge the stale sensor
+        would have run on (#708). Explains "why did SEM stop before my
+        target shows reached" before it becomes an issue report. Fires
+        once per session per charger; the opposite (resume) flag is
+        released so a later resume may announce itself.
+        """
+        key = flag_key or charger_name
+        flag = f"ev_estimate_stop_{key}" if key else "ev_estimate_stop"
+        if flag in self._notified_flags:
+            return
+        self._notified_flags.add(flag)
+        self._notified_flags.discard(
+            f"ev_estimate_resume_{key}" if key else "ev_estimate_resume"
+        )
+
+        label = charger_name or "EV"
+        self.hass.bus.async_fire(f"{DOMAIN}_notification", {
+            "category": "charging",
+            "event": "ev_estimate_stop",
+            "charger_name": label,
+            "target_soc": round(target_soc),
+            "sensor_soc": round(sensor_soc),
+            "sensor_age_min": round(sensor_age_min),
+        })
+        from ..utils.translate import get_text
+        await self._send_mobile_notification(
+            get_text(self.hass, "notif_ev_estimate_stop",
+                "{name}: stopped at ~{target:.0f}% (estimated) — car sensor is "
+                "{age:.0f} min old (last: {sensor:.0f}%). SEM measured the "
+                "delivered energy and stopped to protect your target.",
+                name=label, target=target_soc, sensor=sensor_soc,
+                age=sensor_age_min),
+            channel=_CHANNEL_CHARGING,
+            group="sem_charging",
+        )
+
+    async def notify_ev_estimate_resume(
+        self, sensor_soc: float, target_soc: float,
+        *, charger_name: str | None = None, flag_key: str | None = None,
+    ) -> None:
+        """A fresh sensor reading landed below target after an
+        estimate-based stop — SEM auto-resumes for the difference (#708).
+        Fires once per session per charger.
+        """
+        key = flag_key or charger_name
+        flag = f"ev_estimate_resume_{key}" if key else "ev_estimate_resume"
+        if flag in self._notified_flags:
+            return
+        self._notified_flags.add(flag)
+
+        label = charger_name or "EV"
+        self.hass.bus.async_fire(f"{DOMAIN}_notification", {
+            "category": "charging",
+            "event": "ev_estimate_resume",
+            "charger_name": label,
+            "target_soc": round(target_soc),
+            "sensor_soc": round(sensor_soc),
+        })
+        from ..utils.translate import get_text
+        await self._send_mobile_notification(
+            get_text(self.hass, "notif_ev_estimate_resume",
+                "{name}: car reported {sensor:.0f}% — topping up to your "
+                "{target:.0f}% target.",
+                name=label, sensor=sensor_soc, target=target_soc),
+            channel=_CHANNEL_CHARGING,
+            group="sem_charging",
+        )
+
     async def notify_ev_deadline_unreachable(
         self, remaining_kwh: float, hours_left: float, deadline: str,
         *, charger_name: str | None = None, flag_key: str | None = None,

--- a/coordinator/types.py
+++ b/coordinator/types.py
@@ -1311,6 +1311,21 @@ class SEMData:
                     # clobbered across the per-charger update loop.
                     f"charger_{cid}_vehicle_soc": intel.get("vehicle_soc"),
                     f"charger_{cid}_taper_minutes_to_full": intel.get("minutes_to_full"),
+                    # #708 — session energy-accounted SOC (the overshoot
+                    # guard) + whether it is what currently holds the
+                    # charge stopped. Surfaced as ATTRIBUTES of the
+                    # estimated_soc sensor, not as new entities.
+                    # Integer-rounded so the attribute only moves every
+                    # few minutes of charging — a per-cycle decimal would
+                    # re-arm the #581 recorder churn.
+                    f"charger_{cid}_energy_accounted_soc": (
+                        round(_ea708)
+                        if (_ea708 := intel.get("energy_accounted_soc")) is not None
+                        else None
+                    ),
+                    f"charger_{cid}_estimate_stop_active": bool(
+                        intel.get("estimate_stop_active")
+                    ),
                 })
         except Exception as e:
             _LOGGER.warning("Per-charger intelligence to_dict failed: %s", e)

--- a/dashboard/card/dist/sem-cards.js
+++ b/dashboard/card/dist/sem-cards.js
@@ -3159,16 +3159,16 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                         </span>
                     `:q}
                 </div>
-            </div>`}_rangeHandleStart(e,t,i,s,r,a){e.stopPropagation(),e.preventDefault();const o=e.currentTarget.closest(".range-track");if(!o)return;const n="min"===t?i:s,l="min"===t?s:i,c=this._hass?.states[n],d=parseFloat(c?.attributes?.step)||(a>50?1:.5),p=a-r||1,h=e=>{const i=o.getBoundingClientRect();let s=(e-i.left)/(i.width||1);s=Math.max(0,Math.min(1,s));let n=Math.round((r+s*p)/d)*d;const c=this._entityVal(l,"min"===t?a:r);return n="min"===t?Math.min(n,c):Math.max(n,c),Math.max(r,Math.min(a,n))},_=e=>{this._freezeEntity(n,h(e.clientX)),this.requestUpdate()},g=e=>{window.removeEventListener("pointermove",_),window.removeEventListener("pointerup",g),window.removeEventListener("pointercancel",g),this._setNumber(n,h(e.clientX))};window.addEventListener("pointermove",_),window.addEventListener("pointerup",g),window.addEventListener("pointercancel",g)}_renderChargerSection(e,t){const i=dt[t%dt.length],s=this._val(`charger_${e}_power`,0),r=this._val(`charger_${e}_session_energy_external`,0),a=this._val(`charger_${e}_session_energy`,0),o=r>0?r:a,n=this._val(`charger_${e}_daily_energy`,0),l=this._val("energy_ev_solar_percentage",0),{soc:c,isEstimate:d}=function(e,t,i,s){const r=null!=e?e:s<=1?t??null:null;return null!=r?{soc:r,isEstimate:!1}:null!=i?{soc:i,isEstimate:!0}:{soc:null,isEstimate:!1}}(this._val(`charger_${e}_vehicle_soc`,null),this._val("vehicle_soc",null),this._val(`charger_${e}_estimated_soc`,null),this._chargers.length),p=this._chargerName(e),h=this._hass?.states[`binary_sensor.sem_charger_${e}_connected`],_="on"===h?.state,g=s>50,u=g?this._t("charging"):_?this._t("connected"):this._t("idle"),f=this._val(`charger_${e}_commanded_current`,0),m=this._entityVal(`number.sem_charger_${e}_minimum_current`,6),y=this._entityVal(`number.sem_charger_${e}_ev_battery_capacity_kwh`,40),v=this._entityVal(`number.sem_charger_${e}_ev_kwh_per_100km`,18),x=`select.sem_charger_${e}_charge_mode`,b=this._stateAttrs(x),$=this._stateStr(x)||"min_plus_solar",w=b.options||["solar_only","min_plus_solar","always_max","off"],k={solar_only:this._t("charge_mode_solar_only"),solar_plus_cheap:this._t("charge_mode_solar_plus_cheap"),min_plus_solar:this._t("charge_mode_min_plus_solar"),always_max:this._t("charge_mode_always_max"),off:this._t("charge_mode_off")},S=Math.round(this._entityVal("number.sem_battery_buffer_soc",70)),C=Math.round(this._entityVal("number.sem_battery_priority_soc",30)),z=e=>(this._t(e)||"").replace(/\{buffer\}/g,S).replace(/\{priority\}/g,C),M=z(`charge_mode_hint_${$}_surplus`),E=z(`charge_mode_hint_${$}_overnight`),D=z(`charge_mode_hint_${$}_battery`),F=`select.sem_charger_${e}_ev_target_type`,I=this._stateStr(F)||"kwh",B=this._stateAttrs(F).options||["kwh"],N="soc"===I,P=N?`number.sem_charger_${e}_target_soc`:`number.sem_charger_${e}_daily_ev_target`,A=N?`number.sem_charger_${e}_target_soc_max`:`number.sem_charger_${e}_daily_ev_target_max`,T=`time.sem_charger_${e}_target_time`,R=this._stateStr(T),L=R?R.slice(0,5):"—",O=this._stateAttrs(`${this._prefix}charging_state`),U=!1===O.ev_deadline_reachable,H=O.ev_next_cheap_window;let j="";if(H)try{const e=new Date(H);isNaN(e)||(j=e.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:this._hass?.config?.time_zone||void 0}))}catch(e){}const G="solar_plus_cheap"===$&&j,K=this._entityVal(P,N?80:10),V=N?Math.max(0,(K-c)/100*y):Math.max(0,K-n),Y=v>0?Math.round(V/v*100):null,X=B.length>1?W`<select class="ct-unit" .value=${I}
+            </div>`}_rangeHandleStart(e,t,i,s,r,a){e.stopPropagation(),e.preventDefault();const o=e.currentTarget.closest(".range-track");if(!o)return;const n="min"===t?i:s,l="min"===t?s:i,c=this._hass?.states[n],d=parseFloat(c?.attributes?.step)||(a>50?1:.5),p=a-r||1,h=e=>{const i=o.getBoundingClientRect();let s=(e-i.left)/(i.width||1);s=Math.max(0,Math.min(1,s));let n=Math.round((r+s*p)/d)*d;const c=this._entityVal(l,"min"===t?a:r);return n="min"===t?Math.min(n,c):Math.max(n,c),Math.max(r,Math.min(a,n))},_=e=>{this._freezeEntity(n,h(e.clientX)),this.requestUpdate()},g=e=>{window.removeEventListener("pointermove",_),window.removeEventListener("pointerup",g),window.removeEventListener("pointercancel",g),this._setNumber(n,h(e.clientX))};window.addEventListener("pointermove",_),window.addEventListener("pointerup",g),window.addEventListener("pointercancel",g)}_renderChargerSection(e,t){const i=dt[t%dt.length],s=this._val(`charger_${e}_power`,0),r=this._val(`charger_${e}_session_energy_external`,0),a=this._val(`charger_${e}_session_energy`,0),o=r>0?r:a,n=this._val(`charger_${e}_daily_energy`,0),l=this._val("energy_ev_solar_percentage",0),{soc:c,isEstimate:d}=function(e,t,i,s){const r=null!=e?e:s<=1?t??null:null;return null!=r?{soc:r,isEstimate:!1}:null!=i?{soc:i,isEstimate:!0}:{soc:null,isEstimate:!1}}(this._val(`charger_${e}_vehicle_soc`,null),this._val("vehicle_soc",null),this._val(`charger_${e}_estimated_soc`,null),this._chargers.length),p=this._stateAttrs(`sensor.sem_charger_${e}_estimated_soc`),h=p.energy_accounted_soc,_=!0===p.estimate_stop_active,g=this._val(`charger_${e}_vehicle_soc`,null);let u=null;const f=this._hass?.states[`sensor.sem_charger_${e}_vehicle_soc`];f?.last_changed&&(u=Math.round((Date.now()-new Date(f.last_changed).getTime())/6e4));const m=e=>(this._t(e)||"").replace(/\{soc\}/g,null!=g?Math.round(g):"—").replace(/\{age\}/g,null!=u?u:"—").replace(/\{est\}/g,null!=h?Math.round(h):"—"),y=null!=g&&null!=h&&null!=u&&u>=5&&h-g>=1,v=this._chargerName(e),x=this._hass?.states[`binary_sensor.sem_charger_${e}_connected`],b="on"===x?.state,$=s>50,w=$?this._t("charging"):b?this._t("connected"):this._t("idle"),k=this._val(`charger_${e}_commanded_current`,0),S=this._entityVal(`number.sem_charger_${e}_minimum_current`,6),C=this._entityVal(`number.sem_charger_${e}_ev_battery_capacity_kwh`,40),z=this._entityVal(`number.sem_charger_${e}_ev_kwh_per_100km`,18),M=`select.sem_charger_${e}_charge_mode`,E=this._stateAttrs(M),D=this._stateStr(M)||"min_plus_solar",F=E.options||["solar_only","min_plus_solar","always_max","off"],I={solar_only:this._t("charge_mode_solar_only"),solar_plus_cheap:this._t("charge_mode_solar_plus_cheap"),min_plus_solar:this._t("charge_mode_min_plus_solar"),always_max:this._t("charge_mode_always_max"),off:this._t("charge_mode_off")},B=Math.round(this._entityVal("number.sem_battery_buffer_soc",70)),N=Math.round(this._entityVal("number.sem_battery_priority_soc",30)),P=e=>(this._t(e)||"").replace(/\{buffer\}/g,B).replace(/\{priority\}/g,N),A=P(`charge_mode_hint_${D}_surplus`),T=P(`charge_mode_hint_${D}_overnight`),R=P(`charge_mode_hint_${D}_battery`),L=`select.sem_charger_${e}_ev_target_type`,O=this._stateStr(L)||"kwh",U=this._stateAttrs(L).options||["kwh"],H="soc"===O,j=H?`number.sem_charger_${e}_target_soc`:`number.sem_charger_${e}_daily_ev_target`,G=H?`number.sem_charger_${e}_target_soc_max`:`number.sem_charger_${e}_daily_ev_target_max`,K=`time.sem_charger_${e}_target_time`,V=this._stateStr(K),Y=V?V.slice(0,5):"—",X=this._stateAttrs(`${this._prefix}charging_state`),Z=!1===X.ev_deadline_reachable,J=X.ev_next_cheap_window;let Q="";if(J)try{const e=new Date(J);isNaN(e)||(Q=e.toLocaleTimeString([],{hour:"2-digit",minute:"2-digit",timeZone:this._hass?.config?.time_zone||void 0}))}catch(e){}const ee="solar_plus_cheap"===D&&Q,te=this._entityVal(j,H?80:10),ie=H?Math.max(0,(te-c)/100*C):Math.max(0,te-n),se=z>0?Math.round(ie/z*100):null,re=U.length>1?W`<select class="ct-unit" .value=${O}
                     @click=${e=>e.stopPropagation()}
-                    @change=${e=>this._selectOption(F,e.target.value)}>
-                    ${B.map(e=>W`<option value=${e} ?selected=${e===I}>${"soc"===e?"%":"kWh"}</option>`)}
-                </select>`:W`<span class="ct-unit-static">${N?"%":"kWh"}</span>`;return W`
+                    @change=${e=>this._selectOption(L,e.target.value)}>
+                    ${U.map(e=>W`<option value=${e} ?selected=${e===O}>${"soc"===e?"%":"kWh"}</option>`)}
+                </select>`:W`<span class="ct-unit-static">${H?"%":"kWh"}</span>`;return W`
             <div class="charger-section">
                 <div class="charger-header">
                     <div class="charger-dot" style="background:${i}"></div>
-                    <span class="charger-name">${p}</span>
-                    <span class="charger-status" style="color:${g?i:""}">${u}${f>0?W` <span class="charger-set">(${Math.round(f)}&nbsp;A)</span>`:q}</span>
+                    <span class="charger-name">${v}</span>
+                    <span class="charger-status" style="color:${$?i:""}">${w}${k>0?W` <span class="charger-set">(${Math.round(k)}&nbsp;A)</span>`:q}</span>
                 </div>
 
                 <div class="charger-body">
@@ -3180,7 +3180,7 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                     <div class="charger-metrics">
                         <div class="cm-row">
                             <span class="cm-label">${this._t("power")}</span>
-                            <span class="cm-value" style="color:${g?i:""}">${ge(s)}</span>
+                            <span class="cm-value" style="color:${$?i:""}">${ge(s)}</span>
                         </div>
                         <div class="cm-row">
                             <span class="cm-label">${this._t("today")}</span>
@@ -3201,15 +3201,26 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                     </div>
                 </div>
 
+                ${_?W`
+                <div class="soc-info-708 soc-info-708-stop">
+                    <ha-icon icon="mdi:check-circle-outline" style="--mdc-icon-size:14px;color:#8DC892"></ha-icon>
+                    <span>${m("soc_target_reached_est")}<br>
+                        <small>${m("soc_confirms_next_update")}</small></span>
+                </div>`:y?W`
+                <div class="soc-info-708">
+                    <ha-icon icon="mdi:information-outline" style="--mdc-icon-size:14px;color:#5BC8D8"></ha-icon>
+                    <span>${m("soc_info_line")}</span>
+                </div>`:q}
+
                 <div class="charge-target-group">
                     <div class="ct-title">
                         <ha-icon icon="mdi:target" style="--mdc-icon-size:14px;color:#8DC892"></ha-icon>
                         ${this._t("charge_target")}
-                        ${null!=Y&&Y>0?W`<span class="ct-range">· +${Y} km</span>`:q}
+                        ${null!=se&&se>0?W`<span class="ct-range">· +${se} km</span>`:q}
                         <span class="ct-spacer"></span>
-                        ${X}
+                        ${re}
                     </div>
-                    ${this._renderRangeSlider(P,A,N)}
+                    ${this._renderRangeSlider(j,G,H)}
                     <!-- #277 Phase B.2: one named Charge mode selector
                          replaces the legacy ev_grid_charging + nested
                          ev_tariff_mode toggles. Options come from the HA
@@ -3222,12 +3233,12 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                         <span class="ct-label">${this._t("charge_mode")}</span>
                         <span class="ct-ctl">
                             <select class="ct-mode-select"
-                                    .value=${$}
+                                    .value=${D}
                                     @click=${e=>e.stopPropagation()}
-                                    @change=${e=>this._selectOption(x,e.target.value)}>
-                                ${w.map(e=>W`
-                                    <option value=${e} ?selected=${e===$}>
-                                        ${k[e]||e}
+                                    @change=${e=>this._selectOption(M,e.target.value)}>
+                                ${F.map(e=>W`
+                                    <option value=${e} ?selected=${e===D}>
+                                        ${I[e]||e}
                                     </option>`)}
                             </select>
                         </span>
@@ -3236,38 +3247,38 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                     <div class="ct-subhint">
                         <div class="ct-hint-row">
                             <span class="ct-hint-label">${this._t("hint_label_surplus")}:</span>
-                            <span class="ct-hint-text">${M}</span>
+                            <span class="ct-hint-text">${A}</span>
                         </div>
                         <div class="ct-hint-row">
                             <span class="ct-hint-label">${this._t("hint_label_overnight")}:</span>
-                            <span class="ct-hint-text">${E}</span>
+                            <span class="ct-hint-text">${T}</span>
                         </div>
                         <div class="ct-hint-row">
                             <span class="ct-hint-label">${this._t("hint_label_battery")}:</span>
-                            <span class="ct-hint-text">${D}</span>
+                            <span class="ct-hint-text">${R}</span>
                         </div>
-                        ${G?W`
+                        ${ee?W`
                             <div class="ct-hint-row ct-hint-extra">
                                 <span class="ct-hint-label">${this._t("ev_next_cheap")}:</span>
-                                <span class="ct-hint-text"><b style="color:#8DC892">${j}</b></span>
+                                <span class="ct-hint-text"><b style="color:#8DC892">${Q}</b></span>
                             </div>
                         `:q}
                     </div>
-                    `:G?W`
+                    `:ee?W`
                         <div class="ct-cheap-hint">
                             <span class="ct-hint-label">${this._t("ev_next_cheap")}:</span>
-                            <b style="color:#8DC892">${j}</b>
+                            <b style="color:#8DC892">${Q}</b>
                         </div>
                     `:q}
                     <div class="ct-row clickable"
-                        @click=${()=>this.dispatchEvent(new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:T}}))}>
+                        @click=${()=>this.dispatchEvent(new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:K}}))}>
                         <span class="ct-label">${this._t("ev_charge_by")}</span>
                         <span class="ct-ctl ct-time">
                             <ha-icon icon="mdi:clock-end" style="--mdc-icon-size:13px;color:#5BC8D8"></ha-icon>
-                            ${L}
+                            ${Y}
                         </span>
                     </div>
-                    ${U?W`
+                    ${Z?W`
                         <div class="ct-warn">
                             <ha-icon icon="mdi:clock-alert" style="--mdc-icon-size:14px;color:#f06292"></ha-icon>
                             <span>${this._t("ev_deadline_unreachable_short")}</span>
@@ -3284,7 +3295,7 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                             @click=${()=>{const t=new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:`number.sem_charger_${e}_minimum_current`}});this.dispatchEvent(t)}}
                         >
                             <ha-icon icon="mdi:speedometer-slow" style="--mdc-icon-size:16px;color:#ff9800"></ha-icon>
-                            <span class="setting-value">${this._fmt(m,0)}A</span>
+                            <span class="setting-value">${this._fmt(S,0)}A</span>
                         </div>
                         ${this._showHelp?W`<div class="setting-help">${this._t("tile_help_min_amps")}</div>`:q}
                     </div>
@@ -3294,7 +3305,7 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                             @click=${()=>{const t=new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:`number.sem_charger_${e}_ev_battery_capacity_kwh`}});this.dispatchEvent(t)}}
                         >
                             <ha-icon icon="mdi:car-battery" style="--mdc-icon-size:16px;color:#8DC892"></ha-icon>
-                            <span class="setting-value">${this._fmt(y,0)} kWh</span>
+                            <span class="setting-value">${this._fmt(C,0)} kWh</span>
                         </div>
                         ${this._showHelp?W`<div class="setting-help">${this._t("tile_help_capacity")}</div>`:q}
                     </div>
@@ -3304,7 +3315,7 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
                             @click=${()=>{const t=new CustomEvent("hass-more-info",{bubbles:!0,composed:!0,detail:{entityId:`number.sem_charger_${e}_ev_kwh_per_100km`}});this.dispatchEvent(t)}}
                         >
                             <ha-icon icon="mdi:map-marker-distance" style="--mdc-icon-size:16px;color:#5BC8D8"></ha-icon>
-                            <span class="setting-value">${this._fmt(v,0)} kWh/100km</span>
+                            <span class="setting-value">${this._fmt(z,0)} kWh/100km</span>
                         </div>
                         ${this._showHelp?W`<div class="setting-help">${this._t("tile_help_consumption")}</div>`:q}
                     </div>
@@ -3639,6 +3650,22 @@ const e=globalThis,t=e.ShadowRoot&&(void 0===e.ShadyCSS||e.ShadyCSS.nativeShadow
             .charger-metrics {
                 flex: 1;
                 display: flex; flex-direction: column; gap: 2px;
+            }
+            /* #708 — stale-sensor estimate info line */
+            .soc-info-708 {
+                display: flex; align-items: flex-start; gap: 6px;
+                margin: 4px 0 2px; padding: 4px 8px;
+                font-size: 11px; line-height: 1.35;
+                color: var(--secondary-text-color, #999);
+                background: rgba(91, 200, 216, 0.08);
+                border-radius: 6px;
+            }
+            .soc-info-708-stop {
+                background: rgba(141, 200, 146, 0.10);
+                color: var(--primary-text-color, #c9d4c9);
+            }
+            .soc-info-708 small {
+                font-size: 10px; opacity: 0.75;
             }
             .cm-row {
                 display: flex; justify-content: space-between; align-items: baseline;

--- a/dashboard/card/sem-localize.js
+++ b/dashboard/card/sem-localize.js
@@ -1,5 +1,5 @@
 // Auto-generated from translations.json — do not edit manually
-// Generated: 2026-08-01T11:21:18.824603+00:00
+// Generated: 2026-08-03T21:05:29.432272+00:00
 // IIFE-scoped translations; publishes ``window.semLocalize`` and
 // dispatches ``sem-localize-ready`` on document for late-loading cards.
 (function() {
@@ -290,6 +290,10 @@
       "notif_charger_night_no_ev": "Night: No EV",
       "notif_charger_target_done": "Target done",
       "notif_charger_complete": "Complete",
+      "notif_phase_guard_blocked": "Phase guard blocked: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Phase limit exceeded in Observer Mode at {location} ({reason}) — no action was taken.",
+      "notif_phase_guard_recovered": "Phase guard restored and armed after fresh safe readings.",
+      "notif_phase_guard_recovered_observer": "Phase readings returned to safe levels.",
       "notif_ev_nearly_full": "EV nearly full — ~{minutes:.0f} min remaining",
       "notif_daily_summary": "Today: {solar:.1f} kWh solar · {autarky:.0f}% autarky · Saved {savings:.2f} {currency} · Net cost {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -1243,7 +1247,12 @@
       "config_help_grid_power_sensor": "Overrides the auto-detected grid power sensor. The import/export sign convention is detected automatically on the chosen sensor. Leave empty for auto (Energy Dashboard).",
       "config_sources_all_auto": "all auto (Energy Dashboard)",
       "config_sources_overridden": "overridden",
-      "config_source_unavailable": "override sensor unavailable — SEM keeps reading it (no silent fallback). Fix the sensor or clear the override."
+      "config_source_unavailable": "override sensor unavailable — SEM keeps reading it (no silent fallback). Fix the sensor or clear the override.",
+      "notif_ev_estimate_stop": "{name}: stopped at ~{target:.0f}% (estimated) — car sensor is {age:.0f} min old (last: {sensor:.0f}%). SEM measured the delivered energy and stopped to protect your target.",
+      "notif_ev_estimate_resume": "{name}: car reported {sensor:.0f}% — topping up to your {target:.0f}% target.",
+      "soc_info_line": "Car: {soc}% ({age} min ago) · est. now ~{est}%",
+      "soc_target_reached_est": "Target reached — ~{est}% estimated",
+      "soc_confirms_next_update": "car sensor {age} min old; confirms on next update"
     },
     "de": {
       "charging": "Laden",
@@ -1522,6 +1531,10 @@
       "notif_charger_night_no_ev": "Nacht: Kein EV",
       "notif_charger_target_done": "Ziel fertig",
       "notif_charger_complete": "Abgeschlossen",
+      "notif_phase_guard_blocked": "Phasenwächter blockiert: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Phasengrenzwert im Beobachtungsmodus bei {location} überschritten ({reason}) — es wurde keine Maßnahme ausgeführt.",
+      "notif_phase_guard_recovered": "Phasenwächter nach frischen sicheren Messwerten wiederhergestellt und aktiviert.",
+      "notif_phase_guard_recovered_observer": "Die Phasenmesswerte sind wieder im sicheren Bereich.",
       "notif_ev_nearly_full": "EV fast voll — noch ~{minutes:.0f} Min",
       "notif_daily_summary": "Heute: {solar:.1f} kWh Solar · {autarky:.0f}% Autarkie · Gespart {savings:.2f} {currency} · Nettokosten {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -2483,7 +2496,12 @@
       "config_help_grid_power_sensor": "Überschreibt den automatisch erkannten Netzleistungssensor. Die Import/Export-Vorzeichenkonvention wird am gewählten Sensor automatisch erkannt. Leer lassen für Auto (Energie-Dashboard).",
       "config_sources_all_auto": "alles auto (Energie-Dashboard)",
       "config_sources_overridden": "überschrieben",
-      "config_source_unavailable": "Override-Sensor nicht verfügbar — SEM liest ihn weiter (kein stiller Fallback). Sensor reparieren oder Override entfernen."
+      "config_source_unavailable": "Override-Sensor nicht verfügbar — SEM liest ihn weiter (kein stiller Fallback). Sensor reparieren oder Override entfernen.",
+      "notif_ev_estimate_stop": "{name}: gestoppt bei ~{target:.0f}% (geschätzt) — der Fahrzeugsensor ist {age:.0f} Min. alt (zuletzt: {sensor:.0f}%). SEM hat die gelieferte Energie gemessen und gestoppt, um dein Ziel zu schützen.",
+      "notif_ev_estimate_resume": "{name}: Fahrzeug meldet {sensor:.0f}% — lädt nach bis zum Ziel von {target:.0f}%.",
+      "soc_info_line": "Auto: {soc}% (vor {age} Min.) · jetzt geschätzt ~{est}%",
+      "soc_target_reached_est": "Ziel erreicht — ~{est}% geschätzt",
+      "soc_confirms_next_update": "Fahrzeugsensor {age} Min. alt; Bestätigung beim nächsten Update"
     },
     "fr": {
       "charging": "En charge",
@@ -2759,6 +2777,10 @@
       "notif_charger_night_no_ev": "Nuit: Pas de VE",
       "notif_charger_target_done": "Objectif terminé",
       "notif_charger_complete": "Terminé",
+      "notif_phase_guard_blocked": "Protection de phase bloquée : {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Limite de phase dépassée en mode observation à {location} ({reason}) — aucune action n’a été effectuée.",
+      "notif_phase_guard_recovered": "Protection de phase rétablie et armée après des mesures sûres et récentes.",
+      "notif_phase_guard_recovered_observer": "Les mesures de phase sont revenues à des niveaux sûrs.",
       "notif_ev_nearly_full": "VE presque plein — ~{minutes:.0f} min restantes",
       "notif_daily_summary": "Aujourd'hui: {solar:.1f} kWh solaire · {autarky:.0f}% autarcie · Économisé {savings:.2f} {currency} · Coût net {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · VE {ev:.1f} kWh",
@@ -3723,7 +3745,12 @@
       "config_help_grid_power_sensor": "Remplace le capteur de puissance réseau détecté automatiquement. La convention de signe import/export est détectée automatiquement sur le capteur choisi. Laisser vide pour Auto (tableau de bord Énergie).",
       "config_sources_all_auto": "tout auto (tableau Énergie)",
       "config_sources_overridden": "remplacé(s)",
-      "config_source_unavailable": "capteur de remplacement indisponible — SEM continue de le lire (pas de repli silencieux). Réparez le capteur ou effacez le remplacement."
+      "config_source_unavailable": "capteur de remplacement indisponible — SEM continue de le lire (pas de repli silencieux). Réparez le capteur ou effacez le remplacement.",
+      "notif_ev_estimate_stop": "{name} : arrêt à ~{target:.0f}% (estimé) — le capteur du véhicule date de {age:.0f} min (dernier : {sensor:.0f}%). SEM a mesuré l'énergie livrée et s'est arrêté pour protéger votre cible.",
+      "notif_ev_estimate_resume": "{name} : le véhicule indique {sensor:.0f}% — recharge jusqu'à votre cible de {target:.0f}%.",
+      "soc_info_line": "Voiture : {soc}% (il y a {age} min) · est. actuelle ~{est}%",
+      "soc_target_reached_est": "Cible atteinte — ~{est}% estimé",
+      "soc_confirms_next_update": "capteur véhicule vieux de {age} min ; confirmation à la prochaine mise à jour"
     },
     "es": {
       "charging": "Cargando",
@@ -3999,6 +4026,10 @@
       "notif_charger_night_no_ev": "Noche: Sin VE",
       "notif_charger_target_done": "Objetivo listo",
       "notif_charger_complete": "Completo",
+      "notif_phase_guard_blocked": "Protector de fases bloqueado: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Límite de fase superado en modo observador en {location} ({reason}) — no se realizó ninguna acción.",
+      "notif_phase_guard_recovered": "Protector de fases restablecido y armado tras lecturas seguras y recientes.",
+      "notif_phase_guard_recovered_observer": "Las lecturas de fase volvieron a niveles seguros.",
       "notif_ev_nearly_full": "VE casi lleno — ~{minutes:.0f} min restantes",
       "notif_daily_summary": "Hoy: {solar:.1f} kWh solar · {autarky:.0f}% autarquía · Ahorrado {savings:.2f} {currency} · Coste neto {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · VE {ev:.1f} kWh",
@@ -4963,7 +4994,12 @@
       "config_help_grid_power_sensor": "Anula el sensor de potencia de red autodetectado. La convención de signo import/export se detecta automáticamente en el sensor elegido. Dejar vacío para Auto (panel de Energía).",
       "config_sources_all_auto": "todo auto (panel de Energía)",
       "config_sources_overridden": "anulado(s)",
-      "config_source_unavailable": "sensor de anulación no disponible — SEM sigue leyéndolo (sin respaldo silencioso). Repare el sensor o borre la anulación."
+      "config_source_unavailable": "sensor de anulación no disponible — SEM sigue leyéndolo (sin respaldo silencioso). Repare el sensor o borre la anulación.",
+      "notif_ev_estimate_stop": "{name}: detenido en ~{target:.0f}% (estimado) — el sensor del coche tiene {age:.0f} min (último: {sensor:.0f}%). SEM midió la energía entregada y se detuvo para proteger tu objetivo.",
+      "notif_ev_estimate_resume": "{name}: el coche informa {sensor:.0f}% — recargando hasta tu objetivo de {target:.0f}%.",
+      "soc_info_line": "Coche: {soc}% (hace {age} min) · est. ahora ~{est}%",
+      "soc_target_reached_est": "Objetivo alcanzado — ~{est}% estimado",
+      "soc_confirms_next_update": "sensor del coche de hace {age} min; se confirma en la próxima actualización"
     },
     "it": {
       "charging": "In carica",
@@ -5239,6 +5275,10 @@
       "notif_charger_night_no_ev": "Notte: Nessun VE",
       "notif_charger_target_done": "Obiettivo fatto",
       "notif_charger_complete": "Completato",
+      "notif_phase_guard_blocked": "Controllo fasi bloccato: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Limite di fase superato in modalità osservatore in {location} ({reason}) — non è stata eseguita alcuna azione.",
+      "notif_phase_guard_recovered": "Controllo fasi ripristinato e attivato dopo letture sicure e aggiornate.",
+      "notif_phase_guard_recovered_observer": "Le letture di fase sono tornate a livelli sicuri.",
       "notif_ev_nearly_full": "VE quasi pieno — ~{minutes:.0f} min rimanenti",
       "notif_daily_summary": "Oggi: {solar:.1f} kWh solare · {autarky:.0f}% autoconsumo · Risparmiato {savings:.2f} {currency} · Costo netto {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · VE {ev:.1f} kWh",
@@ -6203,7 +6243,12 @@
       "config_help_grid_power_sensor": "Sovrascrive il sensore di potenza di rete rilevato automaticamente. La convenzione di segno import/export viene rilevata automaticamente sul sensore scelto. Lasciare vuoto per Auto (dashboard Energia).",
       "config_sources_all_auto": "tutto auto (dashboard Energia)",
       "config_sources_overridden": "sovrascritti",
-      "config_source_unavailable": "sensore di override non disponibile — SEM continua a leggerlo (nessun fallback silenzioso). Riparare il sensore o rimuovere l'override."
+      "config_source_unavailable": "sensore di override non disponibile — SEM continua a leggerlo (nessun fallback silenzioso). Riparare il sensore o rimuovere l'override.",
+      "notif_ev_estimate_stop": "{name}: fermato a ~{target:.0f}% (stimato) — il sensore dell'auto è vecchio di {age:.0f} min (ultimo: {sensor:.0f}%). SEM ha misurato l'energia erogata e si è fermato per proteggere il tuo obiettivo.",
+      "notif_ev_estimate_resume": "{name}: l'auto segnala {sensor:.0f}% — ricarica fino al tuo obiettivo di {target:.0f}%.",
+      "soc_info_line": "Auto: {soc}% ({age} min fa) · stima attuale ~{est}%",
+      "soc_target_reached_est": "Obiettivo raggiunto — ~{est}% stimato",
+      "soc_confirms_next_update": "sensore auto di {age} min fa; conferma al prossimo aggiornamento"
     },
     "nl": {
       "charging": "Laden",
@@ -6482,6 +6527,10 @@
       "notif_charger_night_no_ev": "Nacht: Geen EV",
       "notif_charger_target_done": "Doel behaald",
       "notif_charger_complete": "Voltooid",
+      "notif_phase_guard_blocked": "Fasebewaking geblokkeerd: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Faselimiet overschreden in observatiemodus bij {location} ({reason}) — er is geen actie uitgevoerd.",
+      "notif_phase_guard_recovered": "Fasebewaking hersteld en geactiveerd na actuele veilige metingen.",
+      "notif_phase_guard_recovered_observer": "De fasemetingen zijn terug op veilige niveaus.",
       "notif_ev_nearly_full": "EV bijna vol — nog ~{minutes:.0f} min",
       "notif_daily_summary": "Vandaag: {solar:.1f} kWh zon · {autarky:.0f}% zelfvoorzienend · Bespaard {savings:.2f} {currency} · Netto kosten {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -7443,7 +7492,12 @@
       "config_help_grid_power_sensor": "Overschrijft de automatisch gedetecteerde netvermogenssensor. De import/export-tekenconventie wordt automatisch gedetecteerd op de gekozen sensor. Leeg laten voor Auto (Energiedashboard).",
       "config_sources_all_auto": "alles auto (Energiedashboard)",
       "config_sources_overridden": "overschreven",
-      "config_source_unavailable": "override-sensor niet beschikbaar — SEM blijft hem lezen (geen stille terugval). Repareer de sensor of wis de override."
+      "config_source_unavailable": "override-sensor niet beschikbaar — SEM blijft hem lezen (geen stille terugval). Repareer de sensor of wis de override.",
+      "notif_ev_estimate_stop": "{name}: gestopt op ~{target:.0f}% (geschat) — de autosensor is {age:.0f} min oud (laatst: {sensor:.0f}%). SEM heeft de geleverde energie gemeten en is gestopt om je doel te beschermen.",
+      "notif_ev_estimate_resume": "{name}: auto meldt {sensor:.0f}% — bijladen tot je doel van {target:.0f}%.",
+      "soc_info_line": "Auto: {soc}% ({age} min geleden) · nu geschat ~{est}%",
+      "soc_target_reached_est": "Doel bereikt — ~{est}% geschat",
+      "soc_confirms_next_update": "autosensor {age} min oud; bevestiging bij volgende update"
     },
     "cs": {
       "charging": "Nabíjení",
@@ -7719,6 +7773,10 @@
       "notif_charger_night_no_ev": "Noc: Žádné EV",
       "notif_charger_target_done": "Cíl hotovo",
       "notif_charger_complete": "Dokončeno",
+      "notif_phase_guard_blocked": "Fázová ochrana zablokovala provoz: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Ve sledovacím režimu byl překročen limit fáze v {location} ({reason}) — nebyla provedena žádná akce.",
+      "notif_phase_guard_recovered": "Fázová ochrana byla po čerstvých bezpečných měřeních obnovena a aktivována.",
+      "notif_phase_guard_recovered_observer": "Hodnoty fází se vrátily do bezpečného rozsahu.",
       "notif_ev_nearly_full": "EV téměř plné — zbývá ~{minutes:.0f} min",
       "notif_daily_summary": "Dnes: {solar:.1f} kWh solar · {autarky:.0f}% autarkie · Ušetřeno {savings:.2f} {currency} · Čisté náklady {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -8683,7 +8741,12 @@
       "config_help_grid_power_sensor": "Přepíše automaticky detekovaný senzor výkonu sítě. Znaménková konvence import/export se na zvoleném senzoru detekuje automaticky. Ponechte prázdné pro Auto (energetický panel).",
       "config_sources_all_auto": "vše auto (energetický panel)",
       "config_sources_overridden": "přepsáno",
-      "config_source_unavailable": "přepisový senzor nedostupný — SEM jej dále čte (žádný tichý fallback). Opravte senzor nebo přepis odstraňte."
+      "config_source_unavailable": "přepisový senzor nedostupný — SEM jej dále čte (žádný tichý fallback). Opravte senzor nebo přepis odstraňte.",
+      "notif_ev_estimate_stop": "{name}: zastaveno na ~{target:.0f}% (odhad) — senzor vozu je {age:.0f} min starý (naposledy: {sensor:.0f}%). SEM změřil dodanou energii a zastavil, aby ochránil váš cíl.",
+      "notif_ev_estimate_resume": "{name}: vůz hlásí {sensor:.0f}% — dobíjí se na váš cíl {target:.0f}%.",
+      "soc_info_line": "Vůz: {soc}% (před {age} min) · odhad nyní ~{est}%",
+      "soc_target_reached_est": "Cíl dosažen — ~{est}% odhad",
+      "soc_confirms_next_update": "senzor vozu {age} min starý; potvrzení při další aktualizaci"
     },
     "da": {
       "charging": "Oplader",
@@ -8959,6 +9022,10 @@
       "notif_charger_night_no_ev": "Nat: Ingen EV",
       "notif_charger_target_done": "Mål færdig",
       "notif_charger_complete": "Fuldført",
+      "notif_phase_guard_blocked": "Fasevagt blokerede: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Fasegrænsen blev overskredet i observatørtilstand ved {location} ({reason}) — der blev ikke foretaget nogen handling.",
+      "notif_phase_guard_recovered": "Fasevagt gendannet og aktiveret efter friske, sikre målinger.",
+      "notif_phase_guard_recovered_observer": "Fasemålingerne er tilbage på sikre niveauer.",
       "notif_ev_nearly_full": "EV næsten fuld — ~{minutes:.0f} min tilbage",
       "notif_daily_summary": "I dag: {solar:.1f} kWh sol · {autarky:.0f}% selvforsyning · Sparet {savings:.2f} {currency} · Nettoomkostning {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -9923,7 +9990,12 @@
       "config_help_grid_power_sensor": "Tilsidesætter den autodetekterede neteffektsensor. Import/eksport-fortegnskonventionen registreres automatisk på den valgte sensor. Lad stå tom for Auto (energidashboard).",
       "config_sources_all_auto": "alt auto (energidashboard)",
       "config_sources_overridden": "tilsidesat",
-      "config_source_unavailable": "tilsidesættelsessensor utilgængelig — SEM læser den fortsat (ingen stille fallback). Reparer sensoren eller ryd tilsidesættelsen."
+      "config_source_unavailable": "tilsidesættelsessensor utilgængelig — SEM læser den fortsat (ingen stille fallback). Reparer sensoren eller ryd tilsidesættelsen.",
+      "notif_ev_estimate_stop": "{name}: stoppet ved ~{target:.0f}% (estimeret) — bilens sensor er {age:.0f} min gammel (senest: {sensor:.0f}%). SEM målte den leverede energi og stoppede for at beskytte dit mål.",
+      "notif_ev_estimate_resume": "{name}: bilen melder {sensor:.0f}% — lader op til dit mål på {target:.0f}%.",
+      "soc_info_line": "Bil: {soc}% ({age} min siden) · est. nu ~{est}%",
+      "soc_target_reached_est": "Mål nået — ~{est}% estimeret",
+      "soc_confirms_next_update": "bilsensor {age} min gammel; bekræftes ved næste opdatering"
     },
     "fi": {
       "charging": "Lataus",
@@ -10199,6 +10271,10 @@
       "notif_charger_night_no_ev": "Yö: Ei EV",
       "notif_charger_target_done": "Tavoite valmis",
       "notif_charger_complete": "Valmis",
+      "notif_phase_guard_blocked": "Vaihevahti esti toiminnan: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Vaiheraja ylittyi tarkkailutilassa kohdassa {location} ({reason}) — mitään toimenpidettä ei tehty.",
+      "notif_phase_guard_recovered": "Vaihevahti palautettu ja aktivoitu tuoreiden turvallisten mittausten jälkeen.",
+      "notif_phase_guard_recovered_observer": "Vaihemittaukset ovat palanneet turvalliselle tasolle.",
       "notif_ev_nearly_full": "EV lähes täynnä — ~{minutes:.0f} min jäljellä",
       "notif_daily_summary": "Tänään: {solar:.1f} kWh aurinko · {autarky:.0f}% omavaraisuus · Säästetty {savings:.2f} {currency} · Nettokustannus {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -11163,7 +11239,12 @@
       "config_help_grid_power_sensor": "Ohittaa automaattisesti tunnistetun verkkotehon anturin. Tuonti/vienti-etumerkkikäytäntö tunnistetaan valitusta anturista automaattisesti. Jätä tyhjäksi (Auto, energiapaneeli).",
       "config_sources_all_auto": "kaikki auto (energiapaneeli)",
       "config_sources_overridden": "ohitettu",
-      "config_source_unavailable": "ohitusanturi ei saatavilla — SEM lukee sitä edelleen (ei hiljaista varasiirtymää). Korjaa anturi tai poista ohitus."
+      "config_source_unavailable": "ohitusanturi ei saatavilla — SEM lukee sitä edelleen (ei hiljaista varasiirtymää). Korjaa anturi tai poista ohitus.",
+      "notif_ev_estimate_stop": "{name}: pysäytetty ~{target:.0f}%:iin (arvio) — auton anturi on {age:.0f} min vanha (viimeisin: {sensor:.0f}%). SEM mittasi toimitetun energian ja pysähtyi suojatakseen tavoitteesi.",
+      "notif_ev_estimate_resume": "{name}: auto ilmoittaa {sensor:.0f}% — ladataan tavoitteeseesi {target:.0f}%.",
+      "soc_info_line": "Auto: {soc}% ({age} min sitten) · arvio nyt ~{est}%",
+      "soc_target_reached_est": "Tavoite saavutettu — ~{est}% arvioitu",
+      "soc_confirms_next_update": "auton anturi {age} min vanha; vahvistuu seuraavassa päivityksessä"
     },
     "hu": {
       "charging": "Töltés",
@@ -11439,6 +11520,10 @@
       "notif_charger_night_no_ev": "Éjszaka: Nincs EV",
       "notif_charger_target_done": "Cél kész",
       "notif_charger_complete": "Befejezve",
+      "notif_phase_guard_blocked": "Fázisőr blokkolt: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "A fázishatár túllépésre került megfigyelési módban itt: {location} ({reason}) — nem történt beavatkozás.",
+      "notif_phase_guard_recovered": "A fázisőr friss, biztonságos mérések után helyreállt és aktiválódott.",
+      "notif_phase_guard_recovered_observer": "A fázismérések visszatértek a biztonságos szintre.",
       "notif_ev_nearly_full": "EV majdnem tele — ~{minutes:.0f} perc hátra",
       "notif_daily_summary": "Ma: {solar:.1f} kWh nap · {autarky:.0f}% önellátás · Megtakarítva {savings:.2f} {currency} · Nettó költség {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -12403,7 +12488,12 @@
       "config_help_grid_power_sensor": "Felülírja az automatikusan észlelt hálózati teljesítményszenzort. Az import/export előjel-konvenció a kiválasztott szenzoron automatikusan felismerésre kerül. Hagyja üresen az Auto módhoz (Energia irányítópult).",
       "config_sources_all_auto": "minden auto (Energia irányítópult)",
       "config_sources_overridden": "felülírva",
-      "config_source_unavailable": "a felülíró szenzor nem elérhető — a SEM továbbra is azt olvassa (nincs csendes tartalék). Javítsa a szenzort vagy törölje a felülírást."
+      "config_source_unavailable": "a felülíró szenzor nem elérhető — a SEM továbbra is azt olvassa (nincs csendes tartalék). Javítsa a szenzort vagy törölje a felülírást.",
+      "notif_ev_estimate_stop": "{name}: leállítva ~{target:.0f}%-nál (becsült) — az autó szenzora {age:.0f} perc régi (utolsó: {sensor:.0f}%). A SEM megmérte a leadott energiát, és leállt, hogy védje a célodat.",
+      "notif_ev_estimate_resume": "{name}: az autó {sensor:.0f}%-ot jelez — töltés a {target:.0f}%-os célodig.",
+      "soc_info_line": "Autó: {soc}% ({age} perce) · becslés most ~{est}%",
+      "soc_target_reached_est": "Cél elérve — ~{est}% becsült",
+      "soc_confirms_next_update": "az autó szenzora {age} perc régi; a következő frissítés megerősíti"
     },
     "no": {
       "charging": "Lader",
@@ -12679,6 +12769,10 @@
       "notif_charger_night_no_ev": "Natt: Ingen EV",
       "notif_charger_target_done": "Mål fullført",
       "notif_charger_complete": "Fullført",
+      "notif_phase_guard_blocked": "Fasevakt blokkerte: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Fasegrensen ble overskredet i observatørmodus ved {location} ({reason}) — ingen handling ble utført.",
+      "notif_phase_guard_recovered": "Fasevakt gjenopprettet og aktivert etter ferske, trygge målinger.",
+      "notif_phase_guard_recovered_observer": "Fasemålingene er tilbake på trygge nivåer.",
       "notif_ev_nearly_full": "EV nesten full — ~{minutes:.0f} min gjenstår",
       "notif_daily_summary": "I dag: {solar:.1f} kWh sol · {autarky:.0f}% selvforsyning · Spart {savings:.2f} {currency} · Nettokostnad {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -13643,7 +13737,12 @@
       "config_help_grid_power_sensor": "Overstyrer den autodetekterte netteffektsensoren. Import/eksport-fortegnskonvensjonen oppdages automatisk på valgt sensor. La stå tom for Auto (energidashbord).",
       "config_sources_all_auto": "alt auto (energidashbord)",
       "config_sources_overridden": "overstyrt",
-      "config_source_unavailable": "overstyringssensor utilgjengelig — SEM fortsetter å lese den (ingen stille fallback). Reparer sensoren eller fjern overstyringen."
+      "config_source_unavailable": "overstyringssensor utilgjengelig — SEM fortsetter å lese den (ingen stille fallback). Reparer sensoren eller fjern overstyringen.",
+      "notif_ev_estimate_stop": "{name}: stoppet på ~{target:.0f}% (estimert) — bilens sensor er {age:.0f} min gammel (sist: {sensor:.0f}%). SEM målte levert energi og stoppet for å beskytte målet ditt.",
+      "notif_ev_estimate_resume": "{name}: bilen melder {sensor:.0f}% — lader opp til målet ditt på {target:.0f}%.",
+      "soc_info_line": "Bil: {soc}% ({age} min siden) · est. nå ~{est}%",
+      "soc_target_reached_est": "Mål nådd — ~{est}% estimert",
+      "soc_confirms_next_update": "bilsensor {age} min gammel; bekreftes ved neste oppdatering"
     },
     "pl": {
       "charging": "Ładowanie",
@@ -13919,6 +14018,10 @@
       "notif_charger_night_no_ev": "Noc: Brak EV",
       "notif_charger_target_done": "Cel gotowy",
       "notif_charger_complete": "Zakończone",
+      "notif_phase_guard_blocked": "Strażnik faz zablokował: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Limit fazy został przekroczony w trybie obserwatora w {location} ({reason}) — nie podjęto żadnego działania.",
+      "notif_phase_guard_recovered": "Strażnik faz został przywrócony i uzbrojony po świeżych, bezpiecznych odczytach.",
+      "notif_phase_guard_recovered_observer": "Odczyty faz wróciły do bezpiecznych poziomów.",
       "notif_ev_nearly_full": "EV prawie pełne — ~{minutes:.0f} min pozostało",
       "notif_daily_summary": "Dziś: {solar:.1f} kWh solar · {autarky:.0f}% autarkia · Zaoszczędzono {savings:.2f} {currency} · Koszt netto {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -14883,7 +14986,12 @@
       "config_help_grid_power_sensor": "Nadpisuje automatycznie wykryty czujnik mocy sieci. Konwencja znaku import/eksport jest wykrywana automatycznie na wybranym czujniku. Pozostaw puste dla Auto (Panel Energii).",
       "config_sources_all_auto": "wszystko auto (Panel Energii)",
       "config_sources_overridden": "nadpisane",
-      "config_source_unavailable": "czujnik nadpisania niedostępny — SEM nadal go odczytuje (brak cichego fallbacku). Napraw czujnik lub usuń nadpisanie."
+      "config_source_unavailable": "czujnik nadpisania niedostępny — SEM nadal go odczytuje (brak cichego fallbacku). Napraw czujnik lub usuń nadpisanie.",
+      "notif_ev_estimate_stop": "{name}: zatrzymano na ~{target:.0f}% (szacowane) — czujnik auta ma {age:.0f} min (ostatnio: {sensor:.0f}%). SEM zmierzył dostarczoną energię i zatrzymał ładowanie, aby chronić Twój cel.",
+      "notif_ev_estimate_resume": "{name}: auto zgłasza {sensor:.0f}% — doładowywanie do celu {target:.0f}%.",
+      "soc_info_line": "Auto: {soc}% ({age} min temu) · szac. teraz ~{est}%",
+      "soc_target_reached_est": "Cel osiągnięty — ~{est}% szacowane",
+      "soc_confirms_next_update": "czujnik auta sprzed {age} min; potwierdzenie przy następnej aktualizacji"
     },
     "pt": {
       "charging": "A carregar",
@@ -15159,6 +15267,10 @@
       "notif_charger_night_no_ev": "Noite: Sem VE",
       "notif_charger_target_done": "Meta concluída",
       "notif_charger_complete": "Concluído",
+      "notif_phase_guard_blocked": "Monitor de fases bloqueado: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Limite de fase excedido no modo observador em {location} ({reason}) — nenhuma ação foi executada.",
+      "notif_phase_guard_recovered": "Monitor de fases restaurado e ativado após leituras recentes e seguras.",
+      "notif_phase_guard_recovered_observer": "As leituras de fase voltaram a níveis seguros.",
       "notif_ev_nearly_full": "VE quase cheio — ~{minutes:.0f} min restantes",
       "notif_daily_summary": "Hoje: {solar:.1f} kWh solar · {autarky:.0f}% autarquia · Poupado {savings:.2f} {currency} · Custo líquido {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · VE {ev:.1f} kWh",
@@ -16123,7 +16235,12 @@
       "config_help_grid_power_sensor": "Substitui o sensor de potência da rede autodetetado. A convenção de sinal import/export é detetada automaticamente no sensor escolhido. Deixar vazio para Auto (painel de Energia).",
       "config_sources_all_auto": "tudo auto (painel de Energia)",
       "config_sources_overridden": "substituído(s)",
-      "config_source_unavailable": "sensor de substituição indisponível — o SEM continua a lê-lo (sem recurso silencioso). Repare o sensor ou limpe a substituição."
+      "config_source_unavailable": "sensor de substituição indisponível — o SEM continua a lê-lo (sem recurso silencioso). Repare o sensor ou limpe a substituição.",
+      "notif_ev_estimate_stop": "{name}: parado em ~{target:.0f}% (estimado) — o sensor do carro tem {age:.0f} min (último: {sensor:.0f}%). O SEM mediu a energia entregue e parou para proteger o teu objetivo.",
+      "notif_ev_estimate_resume": "{name}: o carro reporta {sensor:.0f}% — a carregar até ao teu objetivo de {target:.0f}%.",
+      "soc_info_line": "Carro: {soc}% (há {age} min) · est. agora ~{est}%",
+      "soc_target_reached_est": "Objetivo atingido — ~{est}% estimado",
+      "soc_confirms_next_update": "sensor do carro com {age} min; confirma na próxima atualização"
     },
     "ro": {
       "charging": "Încărcare",
@@ -16399,6 +16516,10 @@
       "notif_charger_night_no_ev": "Noapte: Fără VE",
       "notif_charger_target_done": "Obiectiv gata",
       "notif_charger_complete": "Complet",
+      "notif_phase_guard_blocked": "Monitorul de fază a blocat: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Limita fazei a fost depășită în modul observator la {location} ({reason}) — nu a fost efectuată nicio acțiune.",
+      "notif_phase_guard_recovered": "Monitorul de fază a fost restabilit și armat după citiri sigure și recente.",
+      "notif_phase_guard_recovered_observer": "Citirile de fază au revenit la niveluri sigure.",
       "notif_ev_nearly_full": "VE aproape plin — ~{minutes:.0f} min rămase",
       "notif_daily_summary": "Astăzi: {solar:.1f} kWh solar · {autarky:.0f}% autarhie · Economisit {savings:.2f} {currency} · Cost net {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · VE {ev:.1f} kWh",
@@ -17363,7 +17484,12 @@
       "config_help_grid_power_sensor": "Suprascrie senzorul de putere de rețea autodetectat. Convenția de semn import/export este detectată automat pe senzorul ales. Lăsați gol pentru Auto (panoul Energie).",
       "config_sources_all_auto": "totul auto (panoul Energie)",
       "config_sources_overridden": "suprascrise",
-      "config_source_unavailable": "senzorul de suprascriere indisponibil — SEM continuă să îl citească (fără revenire silențioasă). Reparați senzorul sau ștergeți suprascrierea."
+      "config_source_unavailable": "senzorul de suprascriere indisponibil — SEM continuă să îl citească (fără revenire silențioasă). Reparați senzorul sau ștergeți suprascrierea.",
+      "notif_ev_estimate_stop": "{name}: oprit la ~{target:.0f}% (estimat) — senzorul mașinii are {age:.0f} min (ultimul: {sensor:.0f}%). SEM a măsurat energia livrată și s-a oprit pentru a-ți proteja ținta.",
+      "notif_ev_estimate_resume": "{name}: mașina raportează {sensor:.0f}% — se încarcă până la ținta ta de {target:.0f}%.",
+      "soc_info_line": "Mașină: {soc}% (acum {age} min) · est. acum ~{est}%",
+      "soc_target_reached_est": "Țintă atinsă — ~{est}% estimat",
+      "soc_confirms_next_update": "senzorul mașinii vechi de {age} min; se confirmă la următoarea actualizare"
     },
     "sv": {
       "charging": "Laddar",
@@ -17639,6 +17765,10 @@
       "notif_charger_night_no_ev": "Natt: Ingen EV",
       "notif_charger_target_done": "Mål klart",
       "notif_charger_complete": "Klart",
+      "notif_phase_guard_blocked": "Fasvakten blockerade: {location} ({reason}).",
+      "notif_phase_guard_observer_warning": "Fasgränsen överskreds i observatörsläge vid {location} ({reason}) — ingen åtgärd utfördes.",
+      "notif_phase_guard_recovered": "Fasvakten är återställd och aktiverad efter nya säkra mätvärden.",
+      "notif_phase_guard_recovered_observer": "Fasvärdena är tillbaka på säkra nivåer.",
       "notif_ev_nearly_full": "EV nästan full — ~{minutes:.0f} min kvar",
       "notif_daily_summary": "Idag: {solar:.1f} kWh sol · {autarky:.0f}% självförsörjning · Sparat {savings:.2f} {currency} · Nettokostnad {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · EV {ev:.1f} kWh",
@@ -18603,7 +18733,12 @@
       "config_help_grid_power_sensor": "Åsidosätter den autodetekterade näteffektsensorn. Import/export-teckenkonventionen identifieras automatiskt på vald sensor. Lämna tomt för Auto (energipanel).",
       "config_sources_all_auto": "allt auto (energipanel)",
       "config_sources_overridden": "åsidosatta",
-      "config_source_unavailable": "åsidosättningssensor otillgänglig — SEM fortsätter läsa den (ingen tyst reserv). Reparera sensorn eller rensa åsidosättningen."
+      "config_source_unavailable": "åsidosättningssensor otillgänglig — SEM fortsätter läsa den (ingen tyst reserv). Reparera sensorn eller rensa åsidosättningen.",
+      "notif_ev_estimate_stop": "{name}: stoppad vid ~{target:.0f}% (uppskattat) — bilens sensor är {age:.0f} min gammal (senast: {sensor:.0f}%). SEM mätte den levererade energin och stoppade för att skydda ditt mål.",
+      "notif_ev_estimate_resume": "{name}: bilen rapporterar {sensor:.0f}% — laddar upp till ditt mål på {target:.0f}%.",
+      "soc_info_line": "Bil: {soc}% ({age} min sedan) · uppskattat nu ~{est}%",
+      "soc_target_reached_est": "Mål uppnått — ~{est}% uppskattat",
+      "soc_confirms_next_update": "bilsensor {age} min gammal; bekräftas vid nästa uppdatering"
     },
     "zh": {
       "charging": "充电中",
@@ -18890,6 +19025,10 @@
       "notif_charger_night_no_ev": "夜间：无车",
       "notif_charger_target_done": "目标完成",
       "notif_charger_complete": "完成",
+      "notif_phase_guard_blocked": "相位保护已阻止运行：{location}（{reason}）。",
+      "notif_phase_guard_observer_warning": "观察模式下 {location} 的相位限值已超出（{reason}）— 未执行任何操作。",
+      "notif_phase_guard_recovered": "相位保护在获得新的安全读数后已恢复并启用。",
+      "notif_phase_guard_recovered_observer": "相位读数已恢复到安全水平。",
       "notif_ev_nearly_full": "电动汽车即将充满 — 约剩 {minutes:.0f} 分钟",
       "notif_daily_summary": "今日：太阳能 {solar:.1f} kWh · 自给率 {autarky:.0f}% · 节省 {savings:.2f} {currency} · 净费用 {net_cost:.2f} {currency}",
       "notif_daily_summary_ev": " · 电动汽车 {ev:.1f} kWh",
@@ -19843,7 +19982,12 @@
       "config_help_grid_power_sensor": "覆盖自动检测的电网功率传感器。所选传感器的输入/输出符号约定会自动检测。留空则使用自动（能源仪表板）。",
       "config_sources_all_auto": "全部自动（能源仪表板）",
       "config_sources_overridden": "已覆盖",
-      "config_source_unavailable": "覆盖传感器不可用 — SEM 仍在读取它（不会静默回退）。请修复传感器或清除覆盖。"
+      "config_source_unavailable": "覆盖传感器不可用 — SEM 仍在读取它（不会静默回退）。请修复传感器或清除覆盖。",
+      "notif_ev_estimate_stop": "{name}：已在约 {target:.0f}%（估算）停止 — 车辆传感器数据已有 {age:.0f} 分钟（最近:{sensor:.0f}%）。SEM 根据实测充入电量停止充电，以保护你的目标。",
+      "notif_ev_estimate_resume": "{name}：车辆报告 {sensor:.0f}% — 正在补充至你的 {target:.0f}% 目标。",
+      "soc_info_line": "车辆:{soc}%（{age} 分钟前）· 当前估算 ~{est}%",
+      "soc_target_reached_est": "已达目标 — 估算约 {est}%",
+      "soc_confirms_next_update": "车辆传感器数据 {age} 分钟前;下次更新时确认"
     }
   };
 

--- a/dashboard/card/src/cards/sem-ev-status-card.js
+++ b/dashboard/card/src/cards/sem-ev-status-card.js
@@ -532,6 +532,30 @@ class SEMEVStatusCard extends SEMLitBase {
             this._val(`charger_${id}_estimated_soc`, null),
             this._chargers.length,
         );
+        // #708 — stale-sensor info line (approved Option A): the gauge keeps
+        // showing exactly what the car reports; the session energy-accounted
+        // estimate appears as a separate line with the sensor's age, and a
+        // "target reached (estimated)" line explains an estimate-based stop.
+        // Sensor age comes client-side from the vehicle_soc mirror's own
+        // last_changed — no extra server data, no recorder churn.
+        const estAttrs708 = this._stateAttrs(`sensor.sem_charger_${id}_estimated_soc`);
+        const eaSoc708 = estAttrs708.energy_accounted_soc;
+        const estStop708 = estAttrs708.estimate_stop_active === true;
+        const vSoc708 = this._val(`charger_${id}_vehicle_soc`, null);
+        let socAge708 = null;
+        const vSocState708 = this._hass?.states[`sensor.sem_charger_${id}_vehicle_soc`];
+        if (vSocState708?.last_changed) {
+            socAge708 = Math.round(
+                (Date.now() - new Date(vSocState708.last_changed).getTime()) / 60000);
+        }
+        const fmt708 = (key) => (this._t(key) || '')
+            .replace(/\{soc\}/g, vSoc708 != null ? Math.round(vSoc708) : '—')
+            .replace(/\{age\}/g, socAge708 != null ? socAge708 : '—')
+            .replace(/\{est\}/g, eaSoc708 != null ? Math.round(eaSoc708) : '—');
+        // Only show while the estimate meaningfully leads the sensor and the
+        // sensor is actually stale (>= 5 min) — display users see no change.
+        const showSocInfo708 = vSoc708 != null && eaSoc708 != null
+            && socAge708 != null && socAge708 >= 5 && (eaSoc708 - vSoc708) >= 1;
         // (#440) nights / chargeNeeded / needsCharge / chargeIcon / chargeColor /
         // chargeText removed — the underlying skip decision is gone.
         const name = this._chargerName(id);
@@ -679,6 +703,17 @@ class SEMEVStatusCard extends SEMLitBase {
                              authority on whether to charge at night. -->
                     </div>
                 </div>
+
+                ${estStop708 ? html`
+                <div class="soc-info-708 soc-info-708-stop">
+                    <ha-icon icon="mdi:check-circle-outline" style="--mdc-icon-size:14px;color:#8DC892"></ha-icon>
+                    <span>${fmt708('soc_target_reached_est')}<br>
+                        <small>${fmt708('soc_confirms_next_update')}</small></span>
+                </div>` : showSocInfo708 ? html`
+                <div class="soc-info-708">
+                    <ha-icon icon="mdi:information-outline" style="--mdc-icon-size:14px;color:#5BC8D8"></ha-icon>
+                    <span>${fmt708('soc_info_line')}</span>
+                </div>` : nothing}
 
                 <div class="charge-target-group">
                     <div class="ct-title">
@@ -1184,6 +1219,22 @@ class SEMEVStatusCard extends SEMLitBase {
             .charger-metrics {
                 flex: 1;
                 display: flex; flex-direction: column; gap: 2px;
+            }
+            /* #708 — stale-sensor estimate info line */
+            .soc-info-708 {
+                display: flex; align-items: flex-start; gap: 6px;
+                margin: 4px 0 2px; padding: 4px 8px;
+                font-size: 11px; line-height: 1.35;
+                color: var(--secondary-text-color, #999);
+                background: rgba(91, 200, 216, 0.08);
+                border-radius: 6px;
+            }
+            .soc-info-708-stop {
+                background: rgba(141, 200, 146, 0.10);
+                color: var(--primary-text-color, #c9d4c9);
+            }
+            .soc-info-708 small {
+                font-size: 10px; opacity: 0.75;
             }
             .cm-row {
                 display: flex; justify-content: space-between; align-items: baseline;

--- a/dashboard/translations.json
+++ b/dashboard/translations.json
@@ -1241,7 +1241,12 @@
     "config_help_grid_power_sensor": "Overrides the auto-detected grid power sensor. The import/export sign convention is detected automatically on the chosen sensor. Leave empty for auto (Energy Dashboard).",
     "config_sources_all_auto": "all auto (Energy Dashboard)",
     "config_sources_overridden": "overridden",
-    "config_source_unavailable": "override sensor unavailable — SEM keeps reading it (no silent fallback). Fix the sensor or clear the override."
+    "config_source_unavailable": "override sensor unavailable — SEM keeps reading it (no silent fallback). Fix the sensor or clear the override.",
+    "notif_ev_estimate_stop": "{name}: stopped at ~{target:.0f}% (estimated) — car sensor is {age:.0f} min old (last: {sensor:.0f}%). SEM measured the delivered energy and stopped to protect your target.",
+    "notif_ev_estimate_resume": "{name}: car reported {sensor:.0f}% — topping up to your {target:.0f}% target.",
+    "soc_info_line": "Car: {soc}% ({age} min ago) · est. now ~{est}%",
+    "soc_target_reached_est": "Target reached — ~{est}% estimated",
+    "soc_confirms_next_update": "car sensor {age} min old; confirms on next update"
   },
   "de": {
     "charging": "Laden",
@@ -2485,7 +2490,12 @@
     "config_help_grid_power_sensor": "Überschreibt den automatisch erkannten Netzleistungssensor. Die Import/Export-Vorzeichenkonvention wird am gewählten Sensor automatisch erkannt. Leer lassen für Auto (Energie-Dashboard).",
     "config_sources_all_auto": "alles auto (Energie-Dashboard)",
     "config_sources_overridden": "überschrieben",
-    "config_source_unavailable": "Override-Sensor nicht verfügbar — SEM liest ihn weiter (kein stiller Fallback). Sensor reparieren oder Override entfernen."
+    "config_source_unavailable": "Override-Sensor nicht verfügbar — SEM liest ihn weiter (kein stiller Fallback). Sensor reparieren oder Override entfernen.",
+    "notif_ev_estimate_stop": "{name}: gestoppt bei ~{target:.0f}% (geschätzt) — der Fahrzeugsensor ist {age:.0f} Min. alt (zuletzt: {sensor:.0f}%). SEM hat die gelieferte Energie gemessen und gestoppt, um dein Ziel zu schützen.",
+    "notif_ev_estimate_resume": "{name}: Fahrzeug meldet {sensor:.0f}% — lädt nach bis zum Ziel von {target:.0f}%.",
+    "soc_info_line": "Auto: {soc}% (vor {age} Min.) · jetzt geschätzt ~{est}%",
+    "soc_target_reached_est": "Ziel erreicht — ~{est}% geschätzt",
+    "soc_confirms_next_update": "Fahrzeugsensor {age} Min. alt; Bestätigung beim nächsten Update"
   },
   "fr": {
     "charging": "En charge",
@@ -3729,7 +3739,12 @@
     "config_help_grid_power_sensor": "Remplace le capteur de puissance réseau détecté automatiquement. La convention de signe import/export est détectée automatiquement sur le capteur choisi. Laisser vide pour Auto (tableau de bord Énergie).",
     "config_sources_all_auto": "tout auto (tableau Énergie)",
     "config_sources_overridden": "remplacé(s)",
-    "config_source_unavailable": "capteur de remplacement indisponible — SEM continue de le lire (pas de repli silencieux). Réparez le capteur ou effacez le remplacement."
+    "config_source_unavailable": "capteur de remplacement indisponible — SEM continue de le lire (pas de repli silencieux). Réparez le capteur ou effacez le remplacement.",
+    "notif_ev_estimate_stop": "{name} : arrêt à ~{target:.0f}% (estimé) — le capteur du véhicule date de {age:.0f} min (dernier : {sensor:.0f}%). SEM a mesuré l'énergie livrée et s'est arrêté pour protéger votre cible.",
+    "notif_ev_estimate_resume": "{name} : le véhicule indique {sensor:.0f}% — recharge jusqu'à votre cible de {target:.0f}%.",
+    "soc_info_line": "Voiture : {soc}% (il y a {age} min) · est. actuelle ~{est}%",
+    "soc_target_reached_est": "Cible atteinte — ~{est}% estimé",
+    "soc_confirms_next_update": "capteur véhicule vieux de {age} min ; confirmation à la prochaine mise à jour"
   },
   "es": {
     "charging": "Cargando",
@@ -4973,7 +4988,12 @@
     "config_help_grid_power_sensor": "Anula el sensor de potencia de red autodetectado. La convención de signo import/export se detecta automáticamente en el sensor elegido. Dejar vacío para Auto (panel de Energía).",
     "config_sources_all_auto": "todo auto (panel de Energía)",
     "config_sources_overridden": "anulado(s)",
-    "config_source_unavailable": "sensor de anulación no disponible — SEM sigue leyéndolo (sin respaldo silencioso). Repare el sensor o borre la anulación."
+    "config_source_unavailable": "sensor de anulación no disponible — SEM sigue leyéndolo (sin respaldo silencioso). Repare el sensor o borre la anulación.",
+    "notif_ev_estimate_stop": "{name}: detenido en ~{target:.0f}% (estimado) — el sensor del coche tiene {age:.0f} min (último: {sensor:.0f}%). SEM midió la energía entregada y se detuvo para proteger tu objetivo.",
+    "notif_ev_estimate_resume": "{name}: el coche informa {sensor:.0f}% — recargando hasta tu objetivo de {target:.0f}%.",
+    "soc_info_line": "Coche: {soc}% (hace {age} min) · est. ahora ~{est}%",
+    "soc_target_reached_est": "Objetivo alcanzado — ~{est}% estimado",
+    "soc_confirms_next_update": "sensor del coche de hace {age} min; se confirma en la próxima actualización"
   },
   "it": {
     "charging": "In carica",
@@ -6217,7 +6237,12 @@
     "config_help_grid_power_sensor": "Sovrascrive il sensore di potenza di rete rilevato automaticamente. La convenzione di segno import/export viene rilevata automaticamente sul sensore scelto. Lasciare vuoto per Auto (dashboard Energia).",
     "config_sources_all_auto": "tutto auto (dashboard Energia)",
     "config_sources_overridden": "sovrascritti",
-    "config_source_unavailable": "sensore di override non disponibile — SEM continua a leggerlo (nessun fallback silenzioso). Riparare il sensore o rimuovere l'override."
+    "config_source_unavailable": "sensore di override non disponibile — SEM continua a leggerlo (nessun fallback silenzioso). Riparare il sensore o rimuovere l'override.",
+    "notif_ev_estimate_stop": "{name}: fermato a ~{target:.0f}% (stimato) — il sensore dell'auto è vecchio di {age:.0f} min (ultimo: {sensor:.0f}%). SEM ha misurato l'energia erogata e si è fermato per proteggere il tuo obiettivo.",
+    "notif_ev_estimate_resume": "{name}: l'auto segnala {sensor:.0f}% — ricarica fino al tuo obiettivo di {target:.0f}%.",
+    "soc_info_line": "Auto: {soc}% ({age} min fa) · stima attuale ~{est}%",
+    "soc_target_reached_est": "Obiettivo raggiunto — ~{est}% stimato",
+    "soc_confirms_next_update": "sensore auto di {age} min fa; conferma al prossimo aggiornamento"
   },
   "nl": {
     "charging": "Laden",
@@ -7461,7 +7486,12 @@
     "config_help_grid_power_sensor": "Overschrijft de automatisch gedetecteerde netvermogenssensor. De import/export-tekenconventie wordt automatisch gedetecteerd op de gekozen sensor. Leeg laten voor Auto (Energiedashboard).",
     "config_sources_all_auto": "alles auto (Energiedashboard)",
     "config_sources_overridden": "overschreven",
-    "config_source_unavailable": "override-sensor niet beschikbaar — SEM blijft hem lezen (geen stille terugval). Repareer de sensor of wis de override."
+    "config_source_unavailable": "override-sensor niet beschikbaar — SEM blijft hem lezen (geen stille terugval). Repareer de sensor of wis de override.",
+    "notif_ev_estimate_stop": "{name}: gestopt op ~{target:.0f}% (geschat) — de autosensor is {age:.0f} min oud (laatst: {sensor:.0f}%). SEM heeft de geleverde energie gemeten en is gestopt om je doel te beschermen.",
+    "notif_ev_estimate_resume": "{name}: auto meldt {sensor:.0f}% — bijladen tot je doel van {target:.0f}%.",
+    "soc_info_line": "Auto: {soc}% ({age} min geleden) · nu geschat ~{est}%",
+    "soc_target_reached_est": "Doel bereikt — ~{est}% geschat",
+    "soc_confirms_next_update": "autosensor {age} min oud; bevestiging bij volgende update"
   },
   "cs": {
     "charging": "Nabíjení",
@@ -8705,7 +8735,12 @@
     "config_help_grid_power_sensor": "Přepíše automaticky detekovaný senzor výkonu sítě. Znaménková konvence import/export se na zvoleném senzoru detekuje automaticky. Ponechte prázdné pro Auto (energetický panel).",
     "config_sources_all_auto": "vše auto (energetický panel)",
     "config_sources_overridden": "přepsáno",
-    "config_source_unavailable": "přepisový senzor nedostupný — SEM jej dále čte (žádný tichý fallback). Opravte senzor nebo přepis odstraňte."
+    "config_source_unavailable": "přepisový senzor nedostupný — SEM jej dále čte (žádný tichý fallback). Opravte senzor nebo přepis odstraňte.",
+    "notif_ev_estimate_stop": "{name}: zastaveno na ~{target:.0f}% (odhad) — senzor vozu je {age:.0f} min starý (naposledy: {sensor:.0f}%). SEM změřil dodanou energii a zastavil, aby ochránil váš cíl.",
+    "notif_ev_estimate_resume": "{name}: vůz hlásí {sensor:.0f}% — dobíjí se na váš cíl {target:.0f}%.",
+    "soc_info_line": "Vůz: {soc}% (před {age} min) · odhad nyní ~{est}%",
+    "soc_target_reached_est": "Cíl dosažen — ~{est}% odhad",
+    "soc_confirms_next_update": "senzor vozu {age} min starý; potvrzení při další aktualizaci"
   },
   "da": {
     "charging": "Oplader",
@@ -9949,7 +9984,12 @@
     "config_help_grid_power_sensor": "Tilsidesætter den autodetekterede neteffektsensor. Import/eksport-fortegnskonventionen registreres automatisk på den valgte sensor. Lad stå tom for Auto (energidashboard).",
     "config_sources_all_auto": "alt auto (energidashboard)",
     "config_sources_overridden": "tilsidesat",
-    "config_source_unavailable": "tilsidesættelsessensor utilgængelig — SEM læser den fortsat (ingen stille fallback). Reparer sensoren eller ryd tilsidesættelsen."
+    "config_source_unavailable": "tilsidesættelsessensor utilgængelig — SEM læser den fortsat (ingen stille fallback). Reparer sensoren eller ryd tilsidesættelsen.",
+    "notif_ev_estimate_stop": "{name}: stoppet ved ~{target:.0f}% (estimeret) — bilens sensor er {age:.0f} min gammel (senest: {sensor:.0f}%). SEM målte den leverede energi og stoppede for at beskytte dit mål.",
+    "notif_ev_estimate_resume": "{name}: bilen melder {sensor:.0f}% — lader op til dit mål på {target:.0f}%.",
+    "soc_info_line": "Bil: {soc}% ({age} min siden) · est. nu ~{est}%",
+    "soc_target_reached_est": "Mål nået — ~{est}% estimeret",
+    "soc_confirms_next_update": "bilsensor {age} min gammel; bekræftes ved næste opdatering"
   },
   "fi": {
     "charging": "Lataus",
@@ -11193,7 +11233,12 @@
     "config_help_grid_power_sensor": "Ohittaa automaattisesti tunnistetun verkkotehon anturin. Tuonti/vienti-etumerkkikäytäntö tunnistetaan valitusta anturista automaattisesti. Jätä tyhjäksi (Auto, energiapaneeli).",
     "config_sources_all_auto": "kaikki auto (energiapaneeli)",
     "config_sources_overridden": "ohitettu",
-    "config_source_unavailable": "ohitusanturi ei saatavilla — SEM lukee sitä edelleen (ei hiljaista varasiirtymää). Korjaa anturi tai poista ohitus."
+    "config_source_unavailable": "ohitusanturi ei saatavilla — SEM lukee sitä edelleen (ei hiljaista varasiirtymää). Korjaa anturi tai poista ohitus.",
+    "notif_ev_estimate_stop": "{name}: pysäytetty ~{target:.0f}%:iin (arvio) — auton anturi on {age:.0f} min vanha (viimeisin: {sensor:.0f}%). SEM mittasi toimitetun energian ja pysähtyi suojatakseen tavoitteesi.",
+    "notif_ev_estimate_resume": "{name}: auto ilmoittaa {sensor:.0f}% — ladataan tavoitteeseesi {target:.0f}%.",
+    "soc_info_line": "Auto: {soc}% ({age} min sitten) · arvio nyt ~{est}%",
+    "soc_target_reached_est": "Tavoite saavutettu — ~{est}% arvioitu",
+    "soc_confirms_next_update": "auton anturi {age} min vanha; vahvistuu seuraavassa päivityksessä"
   },
   "hu": {
     "charging": "Töltés",
@@ -12437,7 +12482,12 @@
     "config_help_grid_power_sensor": "Felülírja az automatikusan észlelt hálózati teljesítményszenzort. Az import/export előjel-konvenció a kiválasztott szenzoron automatikusan felismerésre kerül. Hagyja üresen az Auto módhoz (Energia irányítópult).",
     "config_sources_all_auto": "minden auto (Energia irányítópult)",
     "config_sources_overridden": "felülírva",
-    "config_source_unavailable": "a felülíró szenzor nem elérhető — a SEM továbbra is azt olvassa (nincs csendes tartalék). Javítsa a szenzort vagy törölje a felülírást."
+    "config_source_unavailable": "a felülíró szenzor nem elérhető — a SEM továbbra is azt olvassa (nincs csendes tartalék). Javítsa a szenzort vagy törölje a felülírást.",
+    "notif_ev_estimate_stop": "{name}: leállítva ~{target:.0f}%-nál (becsült) — az autó szenzora {age:.0f} perc régi (utolsó: {sensor:.0f}%). A SEM megmérte a leadott energiát, és leállt, hogy védje a célodat.",
+    "notif_ev_estimate_resume": "{name}: az autó {sensor:.0f}%-ot jelez — töltés a {target:.0f}%-os célodig.",
+    "soc_info_line": "Autó: {soc}% ({age} perce) · becslés most ~{est}%",
+    "soc_target_reached_est": "Cél elérve — ~{est}% becsült",
+    "soc_confirms_next_update": "az autó szenzora {age} perc régi; a következő frissítés megerősíti"
   },
   "no": {
     "charging": "Lader",
@@ -13681,7 +13731,12 @@
     "config_help_grid_power_sensor": "Overstyrer den autodetekterte netteffektsensoren. Import/eksport-fortegnskonvensjonen oppdages automatisk på valgt sensor. La stå tom for Auto (energidashbord).",
     "config_sources_all_auto": "alt auto (energidashbord)",
     "config_sources_overridden": "overstyrt",
-    "config_source_unavailable": "overstyringssensor utilgjengelig — SEM fortsetter å lese den (ingen stille fallback). Reparer sensoren eller fjern overstyringen."
+    "config_source_unavailable": "overstyringssensor utilgjengelig — SEM fortsetter å lese den (ingen stille fallback). Reparer sensoren eller fjern overstyringen.",
+    "notif_ev_estimate_stop": "{name}: stoppet på ~{target:.0f}% (estimert) — bilens sensor er {age:.0f} min gammel (sist: {sensor:.0f}%). SEM målte levert energi og stoppet for å beskytte målet ditt.",
+    "notif_ev_estimate_resume": "{name}: bilen melder {sensor:.0f}% — lader opp til målet ditt på {target:.0f}%.",
+    "soc_info_line": "Bil: {soc}% ({age} min siden) · est. nå ~{est}%",
+    "soc_target_reached_est": "Mål nådd — ~{est}% estimert",
+    "soc_confirms_next_update": "bilsensor {age} min gammel; bekreftes ved neste oppdatering"
   },
   "pl": {
     "charging": "Ładowanie",
@@ -14925,7 +14980,12 @@
     "config_help_grid_power_sensor": "Nadpisuje automatycznie wykryty czujnik mocy sieci. Konwencja znaku import/eksport jest wykrywana automatycznie na wybranym czujniku. Pozostaw puste dla Auto (Panel Energii).",
     "config_sources_all_auto": "wszystko auto (Panel Energii)",
     "config_sources_overridden": "nadpisane",
-    "config_source_unavailable": "czujnik nadpisania niedostępny — SEM nadal go odczytuje (brak cichego fallbacku). Napraw czujnik lub usuń nadpisanie."
+    "config_source_unavailable": "czujnik nadpisania niedostępny — SEM nadal go odczytuje (brak cichego fallbacku). Napraw czujnik lub usuń nadpisanie.",
+    "notif_ev_estimate_stop": "{name}: zatrzymano na ~{target:.0f}% (szacowane) — czujnik auta ma {age:.0f} min (ostatnio: {sensor:.0f}%). SEM zmierzył dostarczoną energię i zatrzymał ładowanie, aby chronić Twój cel.",
+    "notif_ev_estimate_resume": "{name}: auto zgłasza {sensor:.0f}% — doładowywanie do celu {target:.0f}%.",
+    "soc_info_line": "Auto: {soc}% ({age} min temu) · szac. teraz ~{est}%",
+    "soc_target_reached_est": "Cel osiągnięty — ~{est}% szacowane",
+    "soc_confirms_next_update": "czujnik auta sprzed {age} min; potwierdzenie przy następnej aktualizacji"
   },
   "pt": {
     "charging": "A carregar",
@@ -16169,7 +16229,12 @@
     "config_help_grid_power_sensor": "Substitui o sensor de potência da rede autodetetado. A convenção de sinal import/export é detetada automaticamente no sensor escolhido. Deixar vazio para Auto (painel de Energia).",
     "config_sources_all_auto": "tudo auto (painel de Energia)",
     "config_sources_overridden": "substituído(s)",
-    "config_source_unavailable": "sensor de substituição indisponível — o SEM continua a lê-lo (sem recurso silencioso). Repare o sensor ou limpe a substituição."
+    "config_source_unavailable": "sensor de substituição indisponível — o SEM continua a lê-lo (sem recurso silencioso). Repare o sensor ou limpe a substituição.",
+    "notif_ev_estimate_stop": "{name}: parado em ~{target:.0f}% (estimado) — o sensor do carro tem {age:.0f} min (último: {sensor:.0f}%). O SEM mediu a energia entregue e parou para proteger o teu objetivo.",
+    "notif_ev_estimate_resume": "{name}: o carro reporta {sensor:.0f}% — a carregar até ao teu objetivo de {target:.0f}%.",
+    "soc_info_line": "Carro: {soc}% (há {age} min) · est. agora ~{est}%",
+    "soc_target_reached_est": "Objetivo atingido — ~{est}% estimado",
+    "soc_confirms_next_update": "sensor do carro com {age} min; confirma na próxima atualização"
   },
   "ro": {
     "charging": "Încărcare",
@@ -17413,7 +17478,12 @@
     "config_help_grid_power_sensor": "Suprascrie senzorul de putere de rețea autodetectat. Convenția de semn import/export este detectată automat pe senzorul ales. Lăsați gol pentru Auto (panoul Energie).",
     "config_sources_all_auto": "totul auto (panoul Energie)",
     "config_sources_overridden": "suprascrise",
-    "config_source_unavailable": "senzorul de suprascriere indisponibil — SEM continuă să îl citească (fără revenire silențioasă). Reparați senzorul sau ștergeți suprascrierea."
+    "config_source_unavailable": "senzorul de suprascriere indisponibil — SEM continuă să îl citească (fără revenire silențioasă). Reparați senzorul sau ștergeți suprascrierea.",
+    "notif_ev_estimate_stop": "{name}: oprit la ~{target:.0f}% (estimat) — senzorul mașinii are {age:.0f} min (ultimul: {sensor:.0f}%). SEM a măsurat energia livrată și s-a oprit pentru a-ți proteja ținta.",
+    "notif_ev_estimate_resume": "{name}: mașina raportează {sensor:.0f}% — se încarcă până la ținta ta de {target:.0f}%.",
+    "soc_info_line": "Mașină: {soc}% (acum {age} min) · est. acum ~{est}%",
+    "soc_target_reached_est": "Țintă atinsă — ~{est}% estimat",
+    "soc_confirms_next_update": "senzorul mașinii vechi de {age} min; se confirmă la următoarea actualizare"
   },
   "sv": {
     "charging": "Laddar",
@@ -18657,7 +18727,12 @@
     "config_help_grid_power_sensor": "Åsidosätter den autodetekterade näteffektsensorn. Import/export-teckenkonventionen identifieras automatiskt på vald sensor. Lämna tomt för Auto (energipanel).",
     "config_sources_all_auto": "allt auto (energipanel)",
     "config_sources_overridden": "åsidosatta",
-    "config_source_unavailable": "åsidosättningssensor otillgänglig — SEM fortsätter läsa den (ingen tyst reserv). Reparera sensorn eller rensa åsidosättningen."
+    "config_source_unavailable": "åsidosättningssensor otillgänglig — SEM fortsätter läsa den (ingen tyst reserv). Reparera sensorn eller rensa åsidosättningen.",
+    "notif_ev_estimate_stop": "{name}: stoppad vid ~{target:.0f}% (uppskattat) — bilens sensor är {age:.0f} min gammal (senast: {sensor:.0f}%). SEM mätte den levererade energin och stoppade för att skydda ditt mål.",
+    "notif_ev_estimate_resume": "{name}: bilen rapporterar {sensor:.0f}% — laddar upp till ditt mål på {target:.0f}%.",
+    "soc_info_line": "Bil: {soc}% ({age} min sedan) · uppskattat nu ~{est}%",
+    "soc_target_reached_est": "Mål uppnått — ~{est}% uppskattat",
+    "soc_confirms_next_update": "bilsensor {age} min gammal; bekräftas vid nästa uppdatering"
   },
   "zh": {
     "charging": "充电中",
@@ -19901,6 +19976,11 @@
     "config_help_grid_power_sensor": "覆盖自动检测的电网功率传感器。所选传感器的输入/输出符号约定会自动检测。留空则使用自动（能源仪表板）。",
     "config_sources_all_auto": "全部自动（能源仪表板）",
     "config_sources_overridden": "已覆盖",
-    "config_source_unavailable": "覆盖传感器不可用 — SEM 仍在读取它（不会静默回退）。请修复传感器或清除覆盖。"
+    "config_source_unavailable": "覆盖传感器不可用 — SEM 仍在读取它（不会静默回退）。请修复传感器或清除覆盖。",
+    "notif_ev_estimate_stop": "{name}：已在约 {target:.0f}%（估算）停止 — 车辆传感器数据已有 {age:.0f} 分钟（最近:{sensor:.0f}%）。SEM 根据实测充入电量停止充电，以保护你的目标。",
+    "notif_ev_estimate_resume": "{name}：车辆报告 {sensor:.0f}% — 正在补充至你的 {target:.0f}% 目标。",
+    "soc_info_line": "车辆:{soc}%（{age} 分钟前）· 当前估算 ~{est}%",
+    "soc_target_reached_est": "已达目标 — 估算约 {est}%",
+    "soc_confirms_next_update": "车辆传感器数据 {age} 分钟前;下次更新时确认"
   }
 }

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -517,6 +517,23 @@ exact residual of the six rows published beside it.
 - The *instantaneous* `sensor.sem_home_consumption_power` is unchanged (see ADR 0004) — only the
   daily energy row moved to the balance.
 
+## Charging stopped before my car app showed the target (slow SOC sensors)
+
+**This is intentional (v1.7.6, #708).** Some car integrations (OnStar and similar) poll the
+vehicle SOC as rarely as every 30 minutes. Steering on such a stale value used to overshoot the
+target by *sensor lag × charge power* — a 60 % target could land at 67 %. SEM now also tracks the
+energy it actually delivered during the session: when *last reading + delivered energy* says the
+target is reached, charging stops even though the car sensor still shows the old value.
+
+- The charger card shows the reasoning live: `Car: 55 % (28 min ago) · est. now ~59 %`, and
+  "Target reached — ~60 % estimated" after the stop. A mobile notification explains it too.
+- When the sensor finally updates: if it confirms the target, nothing happens. If it lands
+  **below** the target, SEM automatically resumes for the difference — you may see one or two
+  short top-ups spaced by the sensor's polling interval. That is the feature keeping your
+  "at least X %" promise, not flapping.
+- The battery gauge always shows exactly what your car reports — the estimate only ever appears
+  in the info line, and only while the sensor is stale during a session.
+
 ## Energy values spiked after integration update or restart
 
 **Cause:** When a hardware integration (e.g. Huawei Solar) restarts or updates, its sensors go `unavailable` briefly. When they come back, SEM's energy integrator could multiply the returned power value by the entire gap duration, producing unrealistic energy spikes (e.g. 40+ kWh battery discharge on a 15 kWh battery).

--- a/sensor.py
+++ b/sensor.py
@@ -2320,6 +2320,25 @@ class SEMSolarSensor(CoordinatorEntity, RestoreSensor):
                 # Per-charger plan rows (#464) — {cid: [rows…]}.
                 "per_charger_plans": _per_charger_plans,
             })
+        elif (self.entity_description.key.startswith("charger_")
+              and self.entity_description.key.endswith("_estimated_soc")):
+            # #708 — the stale-sensor overshoot guard rides as attributes
+            # of the per-charger Estimated SOC sensor (no new entities):
+            # the session energy-accounted SOC and whether it is what
+            # currently holds the charge stopped. The card's info line
+            # reads these; sensor age is computed client-side from the
+            # vehicle_soc mirror's own last_changed (no churn here).
+            cid_708 = self.entity_description.key[
+                len("charger_"):-len("_estimated_soc")
+            ]
+            attrs.update({
+                "energy_accounted_soc": self.coordinator.data.get(
+                    f"charger_{cid_708}_energy_accounted_soc"
+                ),
+                "estimate_stop_active": self.coordinator.data.get(
+                    f"charger_{cid_708}_estimate_stop_active"
+                ),
+            })
         elif self.entity_description.key == "vpp_event":
             # #580 — per-event accounting for payment reconciliation.
             d = self.coordinator.data

--- a/tests/test_708_soc_lag_ceiling.py
+++ b/tests/test_708_soc_lag_ceiling.py
@@ -1,0 +1,291 @@
+"""#708 — the energy-accounted SOC ceiling beside a slow/polled sensor.
+
+The reported mechanism: OnStar polls the vehicle SOC every 30 minutes, so
+SEM steered an 11.5 kW charge on a 30-minute-old reading — 60 % target,
+stopped at 67 %. Overshoot = sensor lag × charge power.
+
+The fix: the pack cannot be emptier than the last sensor reading plus what
+this session measurably delivered since, so the stop decision uses
+``effective_soc = max(sensor, anchor + delivered × 0.92 / capacity)``.
+The sensor stays primary (every fresh value re-anchors and wins) — this is
+a CAP, not the #446-banned virtual-SOC substitution. When a later reading
+lands below target, remaining need goes positive again and charging
+auto-resumes; resumes are spaced by the sensor's own update interval and
+each round shrinks.
+
+Reporter's numbers throughout: 85 kWh pack, target 60 %, sensor stuck at
+55 %, 11.5 kW.
+"""
+from datetime import datetime, timedelta
+
+import pytest
+from unittest.mock import MagicMock
+
+from custom_components.solar_energy_management.coordinator.coordinator import (
+    SEMCoordinator,
+)
+from custom_components.solar_energy_management.coordinator.ev_taper_detector import (
+    CHARGE_EFFICIENCY,
+    EVTaperDetector,
+)
+
+
+CAPACITY = 85.0
+
+
+def _detector(capacity=CAPACITY):
+    return EVTaperDetector({"ev_battery_capacity_kwh": capacity})
+
+
+def _feed_energy(det, kwh, power_w=11500.0, start=None):
+    """Push ``kwh`` through the detector's session integrator at power_w."""
+    t = start or datetime(2026, 8, 3, 22, 0, 0)
+    hours = kwh / (power_w / 1000.0)
+    steps = max(2, int(hours * 360))  # 10 s cycles
+    dt_step = timedelta(hours=hours / steps)
+    for _ in range(steps + 1):
+        det.update(power_w, 16.0, True, t)
+        t += dt_step
+    return t
+
+
+def _make_coordinator(config=None, detectors=None):
+    coord = SEMCoordinator.__new__(SEMCoordinator)
+    coord.config = config or {
+        "ev_target_type": "soc",
+        "ev_target_soc": 60,
+        "ev_battery_capacity_kwh": CAPACITY,
+        "daily_ev_target": 10,
+    }
+    if detectors is not None:
+        coord._ev_taper_detectors = detectors
+    return coord
+
+
+def _floor(coord, vehicle_soc, charger_cfg=None):
+    energy = MagicMock()
+    energy.daily_ev = 0.0
+    return coord._calculate_remaining_need(
+        energy, vehicle_soc=vehicle_soc, charger_cfg=charger_cfg, bound="min"
+    )
+
+
+# ──────────────────────────────────────────────
+# Detector: anchor lifecycle + estimate math
+# ──────────────────────────────────────────────
+
+class TestAnchorLifecycle:
+    def test_bootstrap_anchor_on_first_reading(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        assert det._soc_anchor_value == 55.0
+        assert det._soc_anchor_session_kwh == 0.0
+
+    def test_unchanged_reading_does_not_move_anchor(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 2.0)
+        det.get_virtual_soc(55.0)  # poll re-publishes the same stale value
+        assert det._soc_anchor_value == 55.0
+        assert det._soc_anchor_session_kwh == 0.0
+
+    def test_fresh_value_reanchors(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 4.0)
+        det.get_virtual_soc(58.0)  # sensor catches up
+        assert det._soc_anchor_value == 58.0
+        assert det._soc_anchor_session_kwh == pytest.approx(4.0, abs=0.05)
+
+    def test_disconnect_clears_anchor_and_latch(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        det._estimate_stop_active = True
+        det.reset_session()
+        assert det._soc_anchor_value is None
+        assert det._soc_anchor_session_kwh is None
+        assert det._estimate_stop_active is False
+
+    def test_rebootstrap_after_disconnect_even_without_value_change(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        det.reset_session()
+        # Same value again (< 0.5 delta) — the bootstrap path must re-arm,
+        # or a session whose target sits inside the sensor's first polling
+        # window would run entirely unguarded.
+        det.get_virtual_soc(55.0)
+        assert det._soc_anchor_value == 55.0
+
+
+class TestEstimateMath:
+    def test_no_anchor_returns_none(self):
+        det = _detector()
+        assert det.energy_accounted_soc() is None
+
+    def test_zero_capacity_returns_none(self):
+        det = _detector(capacity=0)
+        det.get_virtual_soc(55.0)
+        assert det.energy_accounted_soc() is None
+
+    def test_estimate_advances_with_delivered_energy(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 4.0)
+        expected = 55.0 + 4.0 * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert det.energy_accounted_soc() == pytest.approx(expected, abs=0.15)
+
+    def test_estimate_caps_at_100(self):
+        det = _detector(capacity=10.0)
+        det.get_virtual_soc(95.0)
+        _feed_energy(det, 3.0, power_w=7000.0)
+        assert det.energy_accounted_soc() == 100.0
+
+    def test_estimate_counts_from_anchor_not_session_start(self):
+        det = _detector()
+        det.get_virtual_soc(50.0)
+        _feed_energy(det, 3.0)
+        det.get_virtual_soc(53.0)  # re-anchor mid-session
+        end = _feed_energy(det, 2.0, start=datetime(2026, 8, 3, 23, 0, 0))
+        expected = 53.0 + 2.0 * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert det.energy_accounted_soc() == pytest.approx(expected, abs=0.15)
+
+
+# ──────────────────────────────────────────────
+# The stop decision — reporter's exact scenario
+# ──────────────────────────────────────────────
+
+class TestRemainingNeedCeiling:
+    def test_azlinon_scenario_stops_at_target_not_67(self):
+        """Sensor frozen at 55 while 5 kWh flow in: the pre-fix path still
+        wanted (60−55)% × 85 = 4.25 kWh more; the ceiling says done."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        # Enough energy that anchor + delivered×0.92 reaches the 60 % target:
+        # (60−55)/100 × 85 / 0.92 = 4.62 kWh
+        _feed_energy(det, 4.7)
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg) == 0
+
+    def test_before_ceiling_reached_sensor_math_unchanged(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 1.0)  # est ≈ 56.1 — sensor still the binding term? No:
+        # effective = max(55, 56.1) = 56.1 → remaining shrinks as energy flows.
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        remaining = _floor(coord, vehicle_soc=55.0, charger_cfg=cfg)
+        est = det.energy_accounted_soc()
+        assert remaining == pytest.approx((60 - est) / 100 * CAPACITY, abs=0.1)
+        assert 0 < remaining < 4.25
+
+    def test_no_detector_falls_back_to_sensor_only(self):
+        coord = _make_coordinator(detectors={})
+        cfg = {"ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg) == pytest.approx(4.25)
+
+    def test_bare_coordinator_without_detector_attr_is_safe(self):
+        """The __new__-built harness coordinator has no _ev_taper_detectors."""
+        coord = _make_coordinator()
+        cfg = {"ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg) == pytest.approx(4.25)
+
+    def test_sensor_ahead_of_estimate_wins(self):
+        """A fresh reading ABOVE the estimate steers directly (re-anchored)."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 1.0)
+        det.get_virtual_soc(59.0)  # car reports more than we estimated
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=59.0, charger_cfg=cfg) == pytest.approx(0.85)
+
+    def test_auto_resume_when_late_reading_lands_below_target(self):
+        """Estimate stopped the charge; the sensor then reports 58 → need
+        goes positive again (the auto-resume Guido chose, no dead band)."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 4.7)  # estimate reached 60, charge stopped
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg) == 0
+        det.get_virtual_soc(58.0)  # fresh reading, below target → re-anchor
+        remaining = _floor(coord, vehicle_soc=58.0, charger_cfg=cfg)
+        assert remaining == pytest.approx((60 - 58) / 100 * CAPACITY, abs=0.05)
+
+    def test_sensor_unavailable_with_anchor_uses_ceiling_not_full_capacity(self):
+        """Mid-session sensor dropout: pre-#708 returned the full capacity
+        (charge until taper); with an anchor the estimate keeps counting."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 2.0)
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        remaining = _floor(coord, vehicle_soc=None, charger_cfg=cfg)
+        est = det.energy_accounted_soc()
+        assert remaining == pytest.approx((60 - est) / 100 * CAPACITY, abs=0.1)
+        assert remaining < CAPACITY
+
+    def test_sensor_unavailable_without_anchor_keeps_full_capacity(self):
+        det = _detector()  # never saw a reading
+        coord = _make_coordinator(detectors={"c1": det})
+        cfg = {"id": "c1", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=None, charger_cfg=cfg) == CAPACITY
+
+    def test_kwh_mode_never_consults_the_ceiling(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 4.7)
+        coord = _make_coordinator(
+            config={"ev_target_type": "kwh", "daily_ev_target": 10,
+                    "ev_battery_capacity_kwh": CAPACITY},
+            detectors={"c1": det},
+        )
+        cfg = {"id": "c1", "ev_target_type": "kwh", "daily_ev_target": 10}
+        energy = MagicMock()
+        energy.daily_ev = 3.0
+        coord._charger_daily_kwh = lambda cid, e: 3.0
+        remaining = coord._calculate_remaining_need(
+            energy, vehicle_soc=None, charger_cfg=cfg, bound="min"
+        )
+        assert remaining == pytest.approx(7.0)
+
+    def test_two_chargers_use_their_own_anchors(self):
+        det_a = _detector()
+        det_a.get_virtual_soc(55.0)
+        _feed_energy(det_a, 4.7)          # A's estimate at target
+        det_b = _detector()
+        det_b.get_virtual_soc(55.0)       # B delivered nothing
+        coord = _make_coordinator(detectors={"a": det_a, "b": det_b})
+        cfg_a = {"id": "a", "ev_target_type": "soc", "ev_target_soc": 60,
+                 "ev_battery_capacity_kwh": CAPACITY}
+        cfg_b = {"id": "b", "ev_target_type": "soc", "ev_target_soc": 60,
+                 "ev_battery_capacity_kwh": CAPACITY}
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg_a) == 0
+        assert _floor(coord, vehicle_soc=55.0, charger_cfg=cfg_b) == pytest.approx(4.25)
+
+
+# ──────────────────────────────────────────────
+# Restart safety
+# ──────────────────────────────────────────────
+
+class TestRestartSafety:
+    def test_anchor_not_persisted(self):
+        """get_state must not carry the session anchor — a restored anchor
+        against a reset session-energy counter would over-credit the pack."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 4.0)
+        state = det.get_state()
+        fresh = _detector()
+        fresh.restore_state(state)
+        assert fresh._soc_anchor_value is None
+        assert fresh.energy_accounted_soc() is None

--- a/tests/test_708_soc_lag_ceiling.py
+++ b/tests/test_708_soc_lag_ceiling.py
@@ -289,3 +289,127 @@ class TestRestartSafety:
         fresh.restore_state(state)
         assert fresh._soc_anchor_value is None
         assert fresh.energy_accounted_soc() is None
+
+
+# ──────────────────────────────────────────────
+# Multi-charger disconnect reset (review BLOCKER)
+# ──────────────────────────────────────────────
+#
+# ``_update_ev_intelligence`` resets a taper detector's session on
+# disconnect, but that reset only ever reaches the PRIMARY charger — it
+# reads ``self._ev_taper_detector``, a computed property that resolves to
+# ``_ev_taper_detectors[primary_id]``, gated on the fleet-wide OR of every
+# charger's connection state. #708 put steering-critical session state (the
+# SOC anchor) on the same detector class, so a SECONDARY charger's stale
+# anchor from a finished session could survive into its own next session
+# and falsely report the SOC target already met on the very first cycle.
+# ``_reset_per_charger_estimate_state`` closes the gap: called from inside
+# the per-charger loop with THIS charger's own before/after connected
+# state, so it resets the correct detector regardless of which charger is
+# primary.
+
+class TestMultiChargerSessionReset:
+    def _coord_with_notifier(self, detectors):
+        coord = SEMCoordinator.__new__(SEMCoordinator)
+        coord._ev_taper_detectors = detectors
+        coord._notification_manager = MagicMock()
+        return coord
+
+    def test_secondary_charger_disconnect_resets_only_its_own_detector(self):
+        """The BLOCKER scenario: 'b' is NOT primary. Its stale anchor must
+        not survive its own disconnect just because the fleet-scoped path
+        only ever touches 'a' (the primary)."""
+        det_a = _detector()
+        det_a.get_virtual_soc(55.0)
+        det_b = _detector()
+        det_b.get_virtual_soc(55.0)
+        _feed_energy(det_b, 4.7)  # b's stale session reached target
+        coord = self._coord_with_notifier({"a": det_a, "b": det_b})
+        coord._last_ev_connected = False  # b just disconnected
+
+        coord._reset_per_charger_estimate_state("b", was_connected=True)
+
+        assert det_b._soc_anchor_value is None
+        assert det_b.energy_accounted_soc() is None
+        # 'a' (primary) untouched by a reset scoped to 'b'.
+        assert det_a._soc_anchor_value == 55.0
+
+    def test_reconnect_after_reset_does_not_falsely_cap_new_session(self):
+        """After the fix, 'b' reconnects with a real lower SOC — remaining
+        need must reflect the NEW reading, not the stale estimate."""
+        det_b = _detector()
+        det_b.get_virtual_soc(55.0)
+        _feed_energy(det_b, 4.7)  # old session's estimate reached 60 target
+        coord = self._coord_with_notifier({"b": det_b})
+        coord._last_ev_connected = False
+        coord._reset_per_charger_estimate_state("b", was_connected=True)
+
+        # New session: car reconnects, sensor reports a real (lower) SOC.
+        det_b.get_virtual_soc(40.0)
+        coord.config = {"ev_target_type": "soc", "ev_target_soc": 60,
+                         "ev_battery_capacity_kwh": CAPACITY, "daily_ev_target": 10}
+        cfg = {"id": "b", "ev_target_type": "soc", "ev_target_soc": 60,
+               "ev_battery_capacity_kwh": CAPACITY}
+        remaining = _floor(coord, vehicle_soc=40.0, charger_cfg=cfg)
+        assert remaining == pytest.approx((60 - 40) / 100 * CAPACITY)
+
+    def test_still_connected_does_not_reset(self):
+        """No transition (still connected) → anchor must survive untouched."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        _feed_energy(det, 2.0)
+        anchor_before = det._soc_anchor_value
+        coord = self._coord_with_notifier({"c1": det})
+        coord._last_ev_connected = True  # still connected this cycle
+
+        coord._reset_per_charger_estimate_state("c1", was_connected=True)
+
+        assert det._soc_anchor_value == anchor_before
+
+    def test_fresh_connect_does_not_reset(self):
+        """False→True (a fresh connect, not a disconnect) must not reset."""
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        coord = self._coord_with_notifier({"c1": det})
+        coord._last_ev_connected = True
+
+        coord._reset_per_charger_estimate_state("c1", was_connected=False)
+
+        assert det._soc_anchor_value == 55.0
+
+    def test_clears_this_chargers_notification_flags(self):
+        det = _detector()
+        coord = self._coord_with_notifier({"c1": det})
+        coord._last_ev_connected = False
+
+        coord._reset_per_charger_estimate_state("c1", was_connected=True)
+
+        coord._notification_manager.clear_estimate_flags.assert_called_once_with(
+            flag_key="c1"
+        )
+
+    def test_unknown_charger_id_is_a_safe_noop(self):
+        coord = self._coord_with_notifier({"a": _detector()})
+        coord._last_ev_connected = False
+        coord._reset_per_charger_estimate_state("nonexistent", was_connected=True)
+        # no exception; the notification manager is still consulted
+        coord._notification_manager.clear_estimate_flags.assert_called_once_with(
+            flag_key="nonexistent"
+        )
+
+    def test_missing_detectors_attr_is_safe(self):
+        """The bare __new__ harness coordinator without _ev_taper_detectors
+        set at all must not raise (mirrors test_bare_coordinator_* above)."""
+        coord = SEMCoordinator.__new__(SEMCoordinator)
+        coord._notification_manager = MagicMock()
+        coord._last_ev_connected = False
+        coord._reset_per_charger_estimate_state("c1", was_connected=True)  # no raise
+
+    def test_missing_notification_manager_is_safe(self):
+        det = _detector()
+        det.get_virtual_soc(55.0)
+        coord = SEMCoordinator.__new__(SEMCoordinator)
+        coord._ev_taper_detectors = {"c1": det}
+        coord._last_ev_connected = False
+        coord._reset_per_charger_estimate_state("c1", was_connected=True)  # no raise
+        assert det._soc_anchor_value is None

--- a/tests/test_calculate_remaining_need_no_estimated_soc.py
+++ b/tests/test_calculate_remaining_need_no_estimated_soc.py
@@ -81,10 +81,16 @@ def test_detector_access_is_energy_accounted_only():
     """#708 — detector access exists solely to call ``energy_accounted_soc``.
 
     Collects every name bound from ``self._ev_taper_detector[s]`` and
-    asserts that any method invoked on such a name (or directly on the
-    detector attribute) is in the allowlist. A future edit that pulls
-    anything else off the detector — the virtual SOC, taper state,
-    session internals — fails here with the #446 history attached.
+    asserts that every ATTRIBUTE reached on such a name (or directly on the
+    detector attribute) is in the allowlist — whether it's called as a
+    method or just read bare. A future edit that pulls anything else off
+    the detector — the virtual SOC, taper state, session internals — fails
+    here with the #446 history attached.
+
+    (Reviewed 2026-08-03: an earlier version of this test only walked
+    ``ast.Call`` nodes, so a bare attribute read like ``det._soc_anchor_value``
+    — no call, just a lookup — slipped through unnoticed. Walking every
+    ``ast.Attribute`` node closes that gap.)
     """
     fn = _load_fn()
 
@@ -99,21 +105,18 @@ def test_detector_access_is_energy_accounted_only():
                         detector_names.add(target.id)
 
     for node in ast.walk(fn):
-        if not isinstance(node, ast.Call):
+        if not isinstance(node, ast.Attribute):
             continue
-        func = node.func
-        if not isinstance(func, ast.Attribute):
-            continue
-        base = func.value
-        is_detector_method = (
+        base = node.value
+        is_detector_attr = (
             (isinstance(base, ast.Name) and base.id in detector_names)
             or (isinstance(base, ast.Attribute) and base.attr in _DETECTOR_ATTRS)
         )
-        if is_detector_method and func.attr not in _ALLOWED_DETECTOR_METHODS:
+        if is_detector_attr and node.attr not in _ALLOWED_DETECTOR_METHODS:
             raise AssertionError(
-                f"_calculate_remaining_need calls detector method "
-                f"{func.attr!r} at line {node.lineno}. Only "
+                f"_calculate_remaining_need reaches detector attribute "
+                f"{node.attr!r} at line {node.lineno}. Only "
                 f"{sorted(_ALLOWED_DETECTOR_METHODS)} are sanctioned (#708); "
                 "everything else on the detector is the speculative surface "
-                "#446 banned from budgets."
+                "#446 banned from budgets — whether called or just read."
             )

--- a/tests/test_calculate_remaining_need_no_estimated_soc.py
+++ b/tests/test_calculate_remaining_need_no_estimated_soc.py
@@ -6,6 +6,17 @@ saved ``ev_target_type`` was ``"soc"`` but no real vehicle SOC sensor was
 configured. That leak idled the EV on PROD 2026-06-06 against a
 fictitious SOC. The fix removed the rescue path; this test pins the
 invariant so a future refactor doesn't accidentally reintroduce it.
+
+#708 amendment: the function MAY reach the per-charger taper detector for
+exactly ONE method — ``energy_accounted_soc()`` — the measurement-only
+session estimate (last real sensor value + measured delivered energy)
+that CAPS the stale sensor in the stop decision. That is not the #446
+substitution: the virtual SOC's speculative terms (daily driving decay,
+temperature correction, self-heal) remain banned, ``get_virtual_soc``
+remains banned, and the sensor stays primary (a fresh reading re-anchors
+and wins). This lint therefore still bans ``estimated_soc`` /
+``get_virtual_soc`` outright, and additionally asserts the ONLY method
+ever invoked on a detector-derived name is ``energy_accounted_soc``.
 """
 import ast
 import pathlib
@@ -14,7 +25,8 @@ import pathlib
 _BANNED_ATTRS = {"_estimated_soc", "estimated_soc"}
 _BANNED_NAMES = {"_estimated_soc", "estimated_soc"}
 _BANNED_CALLS = {"get_virtual_soc"}
-_BANNED_DETECTOR_ATTRS = {"_ev_taper_detector", "_ev_taper_detectors"}
+_DETECTOR_ATTRS = {"_ev_taper_detector", "_ev_taper_detectors"}
+_ALLOWED_DETECTOR_METHODS = {"energy_accounted_soc", "get"}
 
 
 def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef:
@@ -24,8 +36,7 @@ def _find_function(tree: ast.AST, name: str) -> ast.FunctionDef:
     raise AssertionError(f"Could not find function {name!r} in source")
 
 
-def test_calculate_remaining_need_never_reads_estimated_soc():
-    """AST-walk ``_calculate_remaining_need`` and assert no banned name appears."""
+def _load_fn() -> ast.FunctionDef:
     source = (
         pathlib.Path(__file__).parent.parent
         / "coordinator"
@@ -33,7 +44,12 @@ def test_calculate_remaining_need_never_reads_estimated_soc():
     )
     assert source.exists(), f"coordinator.py not at expected path: {source}"
     tree = ast.parse(source.read_text())
-    fn = _find_function(tree, "_calculate_remaining_need")
+    return _find_function(tree, "_calculate_remaining_need")
+
+
+def test_calculate_remaining_need_never_reads_estimated_soc():
+    """AST-walk ``_calculate_remaining_need`` and assert no banned name appears."""
+    fn = _load_fn()
 
     for node in ast.walk(fn):
         # ``x.estimated_soc`` or ``x._estimated_soc``
@@ -59,14 +75,45 @@ def test_calculate_remaining_need_never_reads_estimated_soc():
                     f"line {node.lineno}. The taper detector's virtual SOC "
                     "must not enter the budget calculation (#446)."
                 )
-        # ``self._ev_taper_detector`` / ``self._ev_taper_detectors``
-        if (
-            isinstance(node, ast.Attribute)
-            and node.attr in _BANNED_DETECTOR_ATTRS
-        ):
+
+
+def test_detector_access_is_energy_accounted_only():
+    """#708 — detector access exists solely to call ``energy_accounted_soc``.
+
+    Collects every name bound from ``self._ev_taper_detector[s]`` and
+    asserts that any method invoked on such a name (or directly on the
+    detector attribute) is in the allowlist. A future edit that pulls
+    anything else off the detector — the virtual SOC, taper state,
+    session internals — fails here with the #446 history attached.
+    """
+    fn = _load_fn()
+
+    detector_names: set[str] = set()
+    for node in ast.walk(fn):
+        if isinstance(node, ast.Assign) and len(node.targets) == 1:
+            target = node.targets[0]
+            if isinstance(target, ast.Name):
+                for sub in ast.walk(node.value):
+                    if (isinstance(sub, ast.Attribute)
+                            and sub.attr in _DETECTOR_ATTRS):
+                        detector_names.add(target.id)
+
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if not isinstance(func, ast.Attribute):
+            continue
+        base = func.value
+        is_detector_method = (
+            (isinstance(base, ast.Name) and base.id in detector_names)
+            or (isinstance(base, ast.Attribute) and base.attr in _DETECTOR_ATTRS)
+        )
+        if is_detector_method and func.attr not in _ALLOWED_DETECTOR_METHODS:
             raise AssertionError(
-                f"_calculate_remaining_need reads {node.attr!r} at "
-                f"line {node.lineno}. The taper detector is not load-bearing "
-                "for the kWh budget — only the saved config drives the mode "
-                "(#446)."
+                f"_calculate_remaining_need calls detector method "
+                f"{func.attr!r} at line {node.lineno}. Only "
+                f"{sorted(_ALLOWED_DETECTOR_METHODS)} are sanctioned (#708); "
+                "everything else on the detector is the speculative surface "
+                "#446 banned from budgets."
             )


### PR DESCRIPTION
## Summary

OnStar-class EV integrations poll vehicle SOC as rarely as every 30 minutes. SEM steered on the last reading as if it were live, so a slow sensor let charging overshoot the target by roughly *lag × charge power* (60% target → 67% on an 85 kWh pack at 11.5 kW — matches @Azlinon's report in #708 to the minute).

## Fix

The stop decision now uses `effective_soc = max(sensor, anchor + delivered_since_anchor × 0.92 / capacity)`:

- The anchor lives on the existing per-charger `EVTaperDetector` (not a third parallel SOC tracker — this was flagged as a real collision risk with the #440/#446 virtual/estimated SOC and addressed by reusing the detector's existing bookkeeping instead of adding a new one).
- Every fresh sensor reading re-anchors and wins — the sensor is never replaced, only capped.
- Session-scoped only: never persisted across restarts, cleared on disconnect.
- Efficiency is hardcoded at 0.92 (biases toward stopping at-or-above target). No new config keys.
- Auto-resume if a later real reading lands below target — spaced by the sensor's own polling interval, self-limiting (not flappy).

## User-visible

- Mobile notification on both the estimate-based stop and the resume, explaining why (sensor age included).
- Card info line below the SOC gauge (Option A, approved mockup) — gauge keeps showing the raw sensor value; the estimate is separate, informational text only.
- 16-language translations.

## #446 guard

The AST lint (`test_calculate_remaining_need_no_estimated_soc.py`) is extended, not weakened: `estimated_soc` / `get_virtual_soc` stay banned outright, and an assertion pins that the *only* method ever invoked on a taper-detector-derived name inside `_calculate_remaining_need` is `energy_accounted_soc`.

## Review found a BLOCKER — fixed

An independent `ruflo-core:reviewer` pass before deploy caught a real multi-charger gap: the only production `reset_session()` call lived in `_update_ev_intelligence`, reached via the computed `self._ev_taper_detector` property, which **always resolves to the primary charger's detector**, gated on the fleet-wide OR of every charger's connection state. Since #708 put steering-critical session state (the SOC anchor) on that same detector class, a **secondary** charger's stale anchor could survive its own disconnect and falsely cap a brand-new session's target as already met — potentially blocking a car from charging at all on its first cycle.

Fixed with `_reset_per_charger_estimate_state(cid, was_connected)`, called from inside the per-charger loop with THIS charger's own before/after connection state (already swapped into context there), so the reset is scoped correctly regardless of which charger is primary. The pre-existing fleet-scoped reset is untouched (idempotent, still does its own job for the primary's virtual-SOC bootstrap).

Two smaller findings from the same review, also fixed:
- **HIGH** — the #446 AST guard only walked `ast.Call` nodes, so a bare attribute read off the detector (no call) would slip through. Extended to walk every `ast.Attribute` node.
- **MEDIUM** — the estimate stop/resume notification flags never cleared on disconnect, so a new session's first estimate event could be silently swallowed as a dedup no-op. Added `clear_estimate_flags()`, wired to the same per-charger disconnect transition, flags now mutually clear.

8 new regression tests (`TestMultiChargerSessionReset`) reproduce the traced BLOCKER scenario directly.

## Live-verified on HA-TEST (two-charger rig)

Built out a genuine second SEM-registered charger (`mock_charger_2`, 85 kWh, target 60% SOC) alongside the real primary KEBA charger, via the options-flow API, to directly exercise the multi-charger BLOCKER fix on real entities rather than only in unit tests:

- Simulated a charging session on charger 2 (real grid-import energy flow, not just raw charger power) and confirmed `energy_accounted_soc` climbed above the raw `vehicle_soc` (49% vs 40%) — the ceiling math is live.
- Disconnected charger 2 and confirmed its `energy_accounted_soc` snapped back to exactly the raw sensor value (40) — the per-charger reset fires on this charger's own disconnect.
- Set a fresh, different SOC (35%) and reconnected: `energy_accounted_soc` read exactly 35 with zero leakage from the prior session's inflated 49% — direct proof the BLOCKER (a stale anchor surviving into a new session) does not occur with the fix.
- The primary KEBA charger's entities were byte-for-byte unchanged (identical `last_changed`/`last_updated`) throughout charger 2's entire connect/charge/disconnect/reconnect cycle — per-charger isolation confirmed, no cross-contamination.
- Zero SEM-related errors or exceptions in the HA-TEST log across the whole test.

## Status

**Not ready to merge yet.** Per Guido: do not tag/release regardless of lane; this stays on its own branch pending his explicit go-ahead.

## Test plan

- [x] 31 new/updated unit tests green (`test_708_soc_lag_ceiling.py`, `test_calculate_remaining_need_no_estimated_soc.py`)
- [x] Full suite green (5775 passed, 2 skipped)
- [x] Card bundle rebuilt, no drift
- [x] Reviewer pass (`ruflo-core:reviewer`) — BLOCKER + HIGH + MEDIUM all fixed
- [x] Live-verify on HA-TEST, including the two-charger rig for the multi-charger fix — done, see above

Refs #708