### PR TITLE
fix: complete phase guard topology localization

### DIFF
--- a/coordinator/active_phase_guard.py
+++ b/coordinator/active_phase_guard.py
@@ -254,6 +254,11 @@ class ActivePhaseGuard:
             or power_w < 0
         ):
             return None
+        # The power-derived current can lag a just-issued charger write by one
+        # or more coordinator cycles. Use it as the baseline for incremental
+        # headroom accounting, never as an authoritative command floor;
+        # treating it as one could re-issue an unsafe current while a reduction
+        # is still settling.
         current_a = power_w / (phases * voltage)
         if not math.isfinite(current_a):
             return None

--- a/tests/test_config_flow_slim_install.py
+++ b/tests/test_config_flow_slim_install.py
@@ -73,22 +73,16 @@ def test_install_defaults_seed_empty_ev_chargers_list():
     assert defaults["ev_chargers"] == []
 
 
-def test_install_defaults_never_enable_phase_guard_without_topology():
-    """Silent install defaults must not create an ambiguous enforcing config.
+def test_install_defaults_leave_phase_guard_disabled():
+    """Silent install defaults must leave phase guard disabled.
 
     Runtime helpers intentionally use the least-assumptive ``grid_only``
-    fallback for legacy/disabled entries. If the slim installer ever starts
-    enabling the phase guard by default, it must also persist the selected
-    topology so a hybrid installation cannot silently lose its inverter lane.
+    fallback for legacy/disabled entries. The slim installer must not silently
+    enable enforcement before the user has selected an installation topology.
     """
     defaults = SolarEnergyManagementConfigFlow._install_defaults()
 
-    # Pin today's safe default while retaining the forward-looking invariant
-    # that any future opt-in must persist an unambiguous topology.
     assert not defaults.get("phase_guard_enabled", False)
-    assert not defaults.get("phase_guard_enabled", False) or (
-        defaults.get("phase_guard_topology") in {"grid_only", "hybrid_load_port"}
-    )
 
 
 def test_options_flow_ev_charger_step_still_registered():

--- a/tests/test_config_flow_slim_install.py
+++ b/tests/test_config_flow_slim_install.py
@@ -73,6 +73,21 @@ def test_install_defaults_seed_empty_ev_chargers_list():
     assert defaults["ev_chargers"] == []
 
 
+def test_install_defaults_never_enable_phase_guard_without_topology():
+    """Silent install defaults must not create an ambiguous enforcing config.
+
+    Runtime helpers intentionally use the least-assumptive ``grid_only``
+    fallback for legacy/disabled entries. If the slim installer ever starts
+    enabling the phase guard by default, it must also persist the selected
+    topology so a hybrid installation cannot silently lose its inverter lane.
+    """
+    defaults = SolarEnergyManagementConfigFlow._install_defaults()
+
+    assert not defaults.get("phase_guard_enabled", False) or (
+        defaults.get("phase_guard_topology") in {"grid_only", "hybrid_load_port"}
+    )
+
+
 def test_options_flow_ev_charger_step_still_registered():
     """The OptionsFlow EV step must remain since (1) power users use it
     directly and (2) the new ``sem-config-card`` deep-links to it for

--- a/tests/test_config_flow_slim_install.py
+++ b/tests/test_config_flow_slim_install.py
@@ -83,6 +83,9 @@ def test_install_defaults_never_enable_phase_guard_without_topology():
     """
     defaults = SolarEnergyManagementConfigFlow._install_defaults()
 
+    # Pin today's safe default while retaining the forward-looking invariant
+    # that any future opt-in must persist an unambiguous topology.
+    assert not defaults.get("phase_guard_enabled", False)
     assert not defaults.get("phase_guard_enabled", False) or (
         defaults.get("phase_guard_topology") in {"grid_only", "hybrid_load_port"}
     )

--- a/tests/test_phase_guard_options_flow.py
+++ b/tests/test_phase_guard_options_flow.py
@@ -209,7 +209,7 @@ def test_phase_guard_topology_copy_is_localized_in_every_language():
             assert step["data_description"][key] != english_step["data_description"][
                 key
             ], (path.name, key)
-        for key in ("grid_only", "hybrid_load_port"):
+        for key in ("disabled", "grid_only", "hybrid_load_port"):
             assert options[key] != english_options[key], (path.name, key)
 
 

--- a/tests/test_phase_guard_options_flow.py
+++ b/tests/test_phase_guard_options_flow.py
@@ -181,6 +181,38 @@ def test_phase_guard_safety_controls_are_localized_in_every_language():
                 )
 
 
+def test_phase_guard_topology_copy_is_localized_in_every_language():
+    root = Path(__file__).resolve().parents[1]
+    english = json.loads(
+        (root / "translations" / "en.json").read_text(encoding="utf-8")
+    )
+    english_step = english["options"]["step"]["settings_phase_guard_topology"]
+    english_options = english["selector"]["phase_guard_topology"]["options"]
+
+    for path in sorted((root / "translations").glob("*.json")):
+        if path.name == "en.json":
+            continue
+        translation = json.loads(path.read_text(encoding="utf-8"))
+        step = translation["options"]["step"]["settings_phase_guard_topology"]
+        options = translation["selector"]["phase_guard_topology"]["options"]
+
+        assert step["title"] != english_step["title"], (path.name, "title")
+        assert step["description"] != english_step["description"], (
+            path.name,
+            "description",
+        )
+        for key in ("phase_guard_topology", "phase_guard_phase_count"):
+            assert step["data"][key] != english_step["data"][key], (
+                path.name,
+                key,
+            )
+            assert step["data_description"][key] != english_step["data_description"][
+                key
+            ], (path.name, key)
+        for key in ("grid_only", "hybrid_load_port"):
+            assert options[key] != english_options[key], (path.name, key)
+
+
 def test_english_phase_guard_labels_explain_effect_without_internal_jargon():
     root = Path(__file__).resolve().parents[1]
     block = json.loads(

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Zakázáno",
         "grid_only": "Pouze distribuční síť",
         "hybrid_load_port": "Distribuční síť + výstup Load/EPS hybridního střídače"
       }

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektrická topologie",
+        "description": "Zvolte způsob napájení domu. V hybridní instalaci mohou dům současně napájet distribuční síť a výstup Load/EPS/Backup střídače. Zatížení uvnitř domu proto může být vyšší než proud procházející hlavním jističem. SEM sleduje obě cesty nezávisle. Aktivní ochrana je volitelná; před povolením řízení EV ověřte hodnoty v režimu sledování.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologie napájení",
           "phase_guard_phase_count": "Počet fází"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Vyberte 1 pro jednofázové napájení nebo 3 pro třífázové napájení. Vyžadovány a monitorovány jsou pouze vybrané fáze."
+          "phase_guard_topology": "Pro běžnou instalaci vyberte Pouze distribuční síť. Pokud jsou spotřebiče napájeny také přes výstup Load, EPS nebo Backup, vyberte Distribuční síť + hybridní střídač.",
+          "phase_guard_phase_count": "Pro jednofázové napájení vyberte 1, pro třífázové 3. Vyžadovány a sledovány budou pouze vybrané fáze."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Pouze distribuční síť",
+        "hybrid_load_port": "Distribuční síť + výstup Load/EPS hybridního střídače"
       }
     }
   }

--- a/translations/da.json
+++ b/translations/da.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Deaktiveret",
         "grid_only": "Kun elforsyning fra nettet",
         "hybrid_load_port": "Elnet + hybridinverterens Load/EPS-udgang"
       }

--- a/translations/da.json
+++ b/translations/da.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektrisk topologi",
+        "description": "Vælg, hvordan husets belastning forsynes. I en hybridinstallation kan elnettet og inverterens Load/EPS/Backup-udgang forsyne huset samtidig. Belastningen i huset kan derfor være højere end strømmen gennem hovedsikringen. SEM overvåger de to forsyningsveje uafhængigt. Aktiv indgriben er valgfri; kontrollér målingerne i observatørtilstand, før EV-styring aktiveres.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Forsyningstopologi",
           "phase_guard_phase_count": "Antal faser"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Vælg 1 for en enkeltfaset forsyning eller 3 for en trefaset forsyning. Kun de valgte faser kræves og overvåges."
+          "phase_guard_topology": "Vælg Kun elnet for en almindelig installation. Vælg Elnet + hybridinverter, når belastninger også forsynes via en Load-, EPS- eller Backup-udgang.",
+          "phase_guard_phase_count": "Vælg 1 for enfaset forsyning eller 3 for trefaset forsyning. Kun de valgte faser er påkrævede og overvåges."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Kun elforsyning fra nettet",
+        "hybrid_load_port": "Elnet + hybridinverterens Load/EPS-udgang"
       }
     }
   }

--- a/translations/de.json
+++ b/translations/de.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Deaktiviert",
         "grid_only": "Nur Netzversorgung",
         "hybrid_load_port": "Stromnetz + Load/EPS-Ausgang des Hybridwechselrichters"
       }

--- a/translations/de.json
+++ b/translations/de.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektrische Topologie",
+        "description": "Wählen Sie, wie die Hauslast versorgt wird. Bei einer Hybridinstallation können das Stromnetz und der Load/EPS/Backup-Ausgang des Wechselrichters das Haus gleichzeitig versorgen. Die Last im Haus kann daher höher sein als der Strom durch die Hauptsicherung. SEM überwacht beide Pfade unabhängig voneinander. Der aktive Eingriff ist optional; prüfen Sie die Messwerte im Beobachtermodus, bevor Sie die EV-Steuerung aktivieren.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Versorgungstopologie",
           "phase_guard_phase_count": "Anzahl der Phasen"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Wählen Sie 1 für eine einphasige oder 3 für eine dreiphasige Versorgung. Nur die ausgewählten Phasen werden benötigt und überwacht."
+          "phase_guard_topology": "Wählen Sie Nur Stromnetz für eine herkömmliche Installation. Wählen Sie Stromnetz + Hybridwechselrichter, wenn Verbraucher zusätzlich über einen Load-, EPS- oder Backup-Ausgang versorgt werden.",
+          "phase_guard_phase_count": "Wählen Sie 1 für eine einphasige oder 3 für eine dreiphasige Versorgung. Nur die ausgewählten Phasen sind erforderlich und werden überwacht."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Nur Netzversorgung",
+        "hybrid_load_port": "Stromnetz + Load/EPS-Ausgang des Hybridwechselrichters"
       }
     }
   }

--- a/translations/es.json
+++ b/translations/es.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topología eléctrica",
+        "description": "Elija cómo se suministra la carga de la vivienda. En una instalación híbrida, la red y la salida Load/EPS/Backup del inversor pueden alimentar la vivienda al mismo tiempo. Por lo tanto, la carga dentro de la vivienda puede ser mayor que la corriente que circula por el fusible principal. SEM supervisa las dos rutas de forma independiente. La intervención activa es opcional; verifique las lecturas en el modo Observador antes de habilitar el control de EV.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topología de suministro",
           "phase_guard_phase_count": "Número de fases"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Seleccione 1 para un suministro monofásico o 3 para un suministro trifásico. Solo las fases seleccionadas son requeridas y monitoreadas."
+          "phase_guard_topology": "Seleccione Solo red para una instalación convencional. Seleccione Red + inversor híbrido cuando las cargas también se alimenten a través de una salida Load, EPS o Backup.",
+          "phase_guard_phase_count": "Seleccione 1 para un suministro monofásico o 3 para un suministro trifásico. Solo se requieren y supervisan las fases seleccionadas."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Solo suministro de red",
+        "hybrid_load_port": "Red + salida Load/EPS del inversor híbrido"
       }
     }
   }

--- a/translations/es.json
+++ b/translations/es.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Desactivado",
         "grid_only": "Solo suministro de red",
         "hybrid_load_port": "Red + salida Load/EPS del inversor híbrido"
       }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Sähköinen topologia",
+        "description": "Valitse, miten talon kuorma syötetään. Hybridiasennuksessa sähköverkko ja invertterin Load/EPS/Backup-lähtö voivat syöttää taloa samanaikaisesti. Talon sisäinen kuorma voi siksi olla suurempi kuin pääsulakkeen läpi kulkeva virta. SEM valvoo kahta syöttöreittiä toisistaan riippumatta. Aktiivinen ohjaus on valinnainen; tarkista lukemat tarkkailutilassa ennen EV-ohjauksen käyttöönottoa.",
         "data": {
-          "phase_guard_topology": "Supply topology",
-          "phase_guard_phase_count": "Vaiheiden lukumäärä"
+          "phase_guard_topology": "Syöttötopologia",
+          "phase_guard_phase_count": "Vaiheiden määrä"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Valitse 1 yksivaiheiselle tai 3 kolmivaiheiselle syötölle. Vain valitut vaiheet ovat pakollisia ja niitä valvotaan."
+          "phase_guard_topology": "Valitse Vain sähköverkko tavalliselle asennukselle. Valitse Sähköverkko + hybridi-invertteri, kun kuormia syötetään myös Load-, EPS- tai Backup-lähdön kautta.",
+          "phase_guard_phase_count": "Valitse 1 yksivaiheiselle tai 3 kolmivaiheiselle syötölle. Vain valitut vaiheet vaaditaan ja niitä valvotaan."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Vain verkkosyöttö",
+        "hybrid_load_port": "Sähköverkko + hybridi-invertterin Load/EPS-lähtö"
       }
     }
   }

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Poistettu käytöstä",
         "grid_only": "Vain verkkosyöttö",
         "hybrid_load_port": "Sähköverkko + hybridi-invertterin Load/EPS-lähtö"
       }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -427,14 +427,14 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topologie électrique",
+        "description": "Choisissez comment la charge de la maison est alimentée. Dans une installation hybride, le réseau et la sortie Load/EPS/Backup de l'onduleur peuvent alimenter la maison en même temps. La charge à l'intérieur de la maison peut donc être supérieure au courant traversant le fusible principal. SEM surveille les deux chemins indépendamment. Le contrôle actif est facultatif ; vérifiez les relevés en mode Observateur avant d'activer le contrôle EV.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologie d'alimentation",
           "phase_guard_phase_count": "Nombre de phases"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
+          "phase_guard_topology": "Sélectionnez Réseau seul pour une installation classique. Sélectionnez Réseau + onduleur hybride lorsque les charges sont également alimentées via une sortie Load, EPS ou Backup.",
           "phase_guard_phase_count": "Sélectionnez 1 pour une alimentation monophasée ou 3 pour une alimentation triphasée. Seules les phases sélectionnées sont requises et surveillées."
         }
       },
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Alimentation réseau seule",
+        "hybrid_load_port": "Réseau + sortie Load/EPS de l'onduleur hybride"
       }
     }
   }

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Désactivé",
         "grid_only": "Alimentation réseau seule",
         "hybrid_load_port": "Réseau + sortie Load/EPS de l'onduleur hybride"
       }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektromos topológia",
+        "description": "Válassza ki, hogyan legyen ellátva a ház terhelése. Hibrid telepítés esetén a hálózat és az inverter Load/EPS/Backup kimenete egyidejűleg táplálhatja a házat. A házon belüli terhelés ezért magasabb is lehet, mint a főbiztosítékon átfolyó áram. A SEM a két útvonalat egymástól függetlenül felügyeli. Az aktív beavatkozás opcionális; a leolvasásokat Observer módban ellenőrizze, mielőtt engedélyezi az EV-vezérlést.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Ellátási topológia",
           "phase_guard_phase_count": "Fázisok száma"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Válasszon 1-et egyfázisú vagy 3-at háromfázisú tápláláshoz. Csak a kiválasztott fázisok szükségesek és figyeltek."
+          "phase_guard_topology": "Hagyományos telepítéshez válassza a Csak hálózat opciót. Válassza a Hálózat + hibrid invertert, ha a terheléseket Load, EPS vagy Backup kimeneten keresztül is táplálják.",
+          "phase_guard_phase_count": "Egyfázisú ellátáshoz válasszon 1-et, háromfázisúhoz 3-at. Csak a kiválasztott fázisok szükségesek és kerülnek felügyelet alá."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Csak hálózati ellátás",
+        "hybrid_load_port": "Hálózat + hibrid inverter Load/EPS kimenete"
       }
     }
   }

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Letiltva",
         "grid_only": "Csak hálózati ellátás",
         "hybrid_load_port": "Hálózat + hibrid inverter Load/EPS kimenete"
       }

--- a/translations/it.json
+++ b/translations/it.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Disattivato",
         "grid_only": "Solo alimentazione di rete",
         "hybrid_load_port": "Rete + uscita Load/EPS dell'inverter ibrido"
       }

--- a/translations/it.json
+++ b/translations/it.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topologia elettrica",
+        "description": "Scegli come viene alimentato il carico dell'abitazione. In un'installazione ibrida, la rete e l'uscita Load/EPS/Backup dell'inverter possono alimentare la casa contemporaneamente. Il carico all'interno della casa può quindi essere superiore alla corrente che attraversa il fusibile principale. SEM monitora i due percorsi in modo indipendente. L'intervento attivo è facoltativo; verifica le letture in modalità Osservatore prima di abilitare il controllo EV.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologia di alimentazione",
           "phase_guard_phase_count": "Numero di fasi"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Selezionare 1 per un'alimentazione monofase o 3 per un'alimentazione trifase. Solo le fasi selezionate sono richieste e monitorate."
+          "phase_guard_topology": "Seleziona Solo rete per un'installazione convenzionale. Seleziona Rete + inverter ibrido quando i carichi sono alimentati anche tramite un'uscita Load, EPS o Backup.",
+          "phase_guard_phase_count": "Seleziona 1 per un'alimentazione monofase o 3 per un'alimentazione trifase. Solo le fasi selezionate sono richieste e monitorate."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Solo alimentazione di rete",
+        "hybrid_load_port": "Rete + uscita Load/EPS dell'inverter ibrido"
       }
     }
   }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Uitgeschakeld",
         "grid_only": "Alleen netvoeding",
         "hybrid_load_port": "Net + Load/EPS-uitgang van de hybride omvormer"
       }

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektrische topologie",
+        "description": "Kies hoe de belasting van de woning wordt gevoed. Bij een hybride installatie kunnen het net en de Load/EPS/Backup-uitgang van de omvormer tegelijkertijd de woning voeden. De belasting in huis kan daardoor hoger zijn dan de stroom door de hoofdzekering. SEM bewaakt de twee paden onafhankelijk van elkaar. Actief ingrijpen is optioneel; controleer de metingen in de observatiemodus voordat u EV-regeling inschakelt.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Voedingstopologie",
           "phase_guard_phase_count": "Aantal fasen"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Selecteer 1 voor een enkelfasige of 3 voor een driefasige voeding. Alleen de geselecteerde fasen zijn vereist en worden bewaakt."
+          "phase_guard_topology": "Selecteer Alleen net voor een conventionele installatie. Selecteer Net + hybride omvormer wanneer belastingen ook via een Load-, EPS- of Backup-uitgang worden gevoed.",
+          "phase_guard_phase_count": "Selecteer 1 voor een eenfasige voeding of 3 voor een driefasige voeding. Alleen de geselecteerde fasen zijn vereist en worden bewaakt."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Alleen netvoeding",
+        "hybrid_load_port": "Net + Load/EPS-uitgang van de hybride omvormer"
       }
     }
   }

--- a/translations/no.json
+++ b/translations/no.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Deaktivert",
         "grid_only": "Kun nettforsyning",
         "hybrid_load_port": "Nett + hybridinverterens Load/EPS-utgang"
       }

--- a/translations/no.json
+++ b/translations/no.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Elektrisk topologi",
+        "description": "Velg hvordan husets last skal forsynes. I en hybridinstallasjon kan nettet og inverterens Load/EPS/Backup-utgang forsyne huset samtidig. Lasten inne i huset kan derfor være høyere enn strømmen gjennom hovedsikringen. SEM overvåker de to strømbanene uavhengig av hverandre. Aktiv inngripen er valgfri; kontroller avlesningene i observatørmodus før du aktiverer EV-styring.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Forsyningstopologi",
           "phase_guard_phase_count": "Antall faser"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Velg 1 for en enfaset eller 3 for en trefaset forsyning. Kun de valgte fasene kreves og overvåkes."
+          "phase_guard_topology": "Velg Kun nett for en konvensjonell installasjon. Velg Nett + hybridinverter når laster også forsynes gjennom en Load-, EPS- eller Backup-utgang.",
+          "phase_guard_phase_count": "Velg 1 for enfaset forsyning eller 3 for trefaset forsyning. Kun de valgte fasene er nødvendige og overvåkes."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Kun nettforsyning",
+        "hybrid_load_port": "Nett + hybridinverterens Load/EPS-utgang"
       }
     }
   }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topologia elektryczna",
+        "description": "Wybierz sposób zasilania obciążenia domu. W instalacji hybrydowej sieć oraz wyjście Load/EPS/Backup falownika mogą zasilać dom jednocześnie. Obciążenie wewnątrz domu może zatem być wyższe niż prąd płynący przez główny bezpiecznik. SEM monitoruje obie ścieżki niezależnie. Aktywne wymuszanie jest opcjonalne; przed włączeniem sterowania EV zweryfikuj odczyty w trybie obserwatora.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologia zasilania",
           "phase_guard_phase_count": "Liczba faz"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Wybierz 1 dla zasilania jednofazowego lub 3 dla zasilania trójfazowego. Tylko wybrane fazy są wymagane i monitorowane."
+          "phase_guard_topology": "Wybierz Tylko sieć w przypadku instalacji konwencjonalnej. Wybierz Sieć + falownik hybrydowy, gdy odbiorniki są również zasilane przez wyjście Load, EPS lub Backup.",
+          "phase_guard_phase_count": "Wybierz 1 dla zasilania jednofazowego lub 3 dla zasilania trójfazowego. Monitorowane i wymagane są tylko wybrane fazy."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Tylko zasilanie z sieci",
+        "hybrid_load_port": "Sieć + wyjście Load/EPS falownika hybrydowego"
       }
     }
   }

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -434,7 +434,7 @@
           "phase_guard_phase_count": "Liczba faz"
         },
         "data_description": {
-          "phase_guard_topology": "Wybierz Tylko sieć w przypadku instalacji konwencjonalnej. Wybierz Sieć + falownik hybrydowy, gdy odbiorniki są również zasilane przez wyjście Load, EPS lub Backup.",
+          "phase_guard_topology": "Wybierz Tylko zasilanie z sieci w przypadku instalacji konwencjonalnej. Wybierz Sieć + wyjście Load/EPS falownika hybrydowego, gdy odbiorniki są również zasilane przez wyjście Load, EPS lub Backup.",
           "phase_guard_phase_count": "Wybierz 1 dla zasilania jednofazowego lub 3 dla zasilania trójfazowego. Monitorowane i wymagane są tylko wybrane fazy."
         }
       },
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Wyłączone",
         "grid_only": "Tylko zasilanie z sieci",
         "hybrid_load_port": "Sieć + wyjście Load/EPS falownika hybrydowego"
       }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topologia elétrica",
+        "description": "Escolha como a carga da casa é fornecida. Numa instalação híbrida, a rede e a saída Load/EPS/Backup do inversor podem alimentar a casa ao mesmo tempo. Assim, a carga no interior da casa pode ser superior à corrente que passa pelo fusível principal. A SEM monitoriza os dois caminhos de forma independente. A atuação ativa é opcional; verifique as leituras no Modo Observador antes de ativar o controlo de EV.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologia de fornecimento",
           "phase_guard_phase_count": "Número de fases"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Selecione 1 para uma alimentação monofásica ou 3 para uma alimentação trifásica. Somente as fases selecionadas são exigidas e monitoradas."
+          "phase_guard_topology": "Selecione Apenas rede para uma instalação convencional. Selecione Rede + inversor híbrido quando as cargas também forem fornecidas através de uma saída Load, EPS ou Backup.",
+          "phase_guard_phase_count": "Selecione 1 para um fornecimento monofásico ou 3 para um fornecimento trifásico. Apenas as fases selecionadas são necessárias e monitorizadas."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Apenas fornecimento de rede",
+        "hybrid_load_port": "Rede + saída Load/EPS do inversor híbrido"
       }
     }
   }

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Desativado",
         "grid_only": "Apenas fornecimento de rede",
         "hybrid_load_port": "Rede + saída Load/EPS do inversor híbrido"
       }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "Topologie electrică",
+        "description": "Alegeți modul în care este alimentată locuința. Într-o instalație hibridă, rețeaua și ieșirea Load/EPS/Backup a invertorului pot alimenta locuința în același timp. Sarcina din interiorul locuinței poate fi, prin urmare, mai mare decât curentul prin siguranța principală. SEM monitorizează cele două căi în mod independent. Intervenția activă este opțională; verificați citirile în Modul Observator înainte de a activa controlul EV.",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "Topologia alimentării",
           "phase_guard_phase_count": "Număr de faze"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "Selectați 1 pentru o alimentare monofazată sau 3 pentru o alimentare trifazată. Doar fazele selectate sunt obligatorii și sunt monitorizate."
+          "phase_guard_topology": "Selectați Numai rețea pentru o instalație convențională. Selectați Rețea + invertor hibrid atunci când sarcinile sunt alimentate și printr-o ieșire Load, EPS sau Backup.",
+          "phase_guard_phase_count": "Selectați 1 pentru o alimentare monofazată sau 3 pentru o alimentare trifazată. Doar fazele selectate sunt necesare și monitorizate."
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "Doar alimentare din rețea",
+        "hybrid_load_port": "Rețea + ieșire Load/EPS a invertorului hibrid"
       }
     }
   }

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "Dezactivat",
         "grid_only": "Doar alimentare din rețea",
         "hybrid_load_port": "Rețea + ieșire Load/EPS a invertorului hibrid"
       }

--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -427,15 +427,15 @@
         }
       },
       "settings_phase_guard_topology": {
-        "title": "Electrical topology",
-        "description": "Choose how the house load is supplied. In a hybrid installation, the grid and the inverter Load/EPS/Backup output can feed the house at the same time. The load inside the house can therefore be higher than the current through the main fuse. SEM monitors the two paths independently. Enforcement is opt-in; verify the readings in Observer Mode before enabling EV control.",
+        "title": "电气拓扑",
+        "description": "选择住宅的供电方式。在混合安装中，电网和逆变器的 Load/EPS/Backup 输出可以同时为住宅供电。因此，住宅内部的负载可能高于主保险丝的电流。SEM 会独立监测这两条路径。主动干预为可选功能；请在启用 EV 控制之前，先在观察者模式下核对读数。",
         "data": {
-          "phase_guard_topology": "Supply topology",
+          "phase_guard_topology": "供电拓扑",
           "phase_guard_phase_count": "相数"
         },
         "data_description": {
-          "phase_guard_topology": "Select Grid only for a conventional installation. Select Grid + hybrid inverter when loads are also supplied through a Load, EPS or Backup output.",
-          "phase_guard_phase_count": "选择 1 表示单相供电，选择 3 表示三相供电。仅选定相位为必需并进行监控。"
+          "phase_guard_topology": "对于传统安装，请选择“仅电网”。当负载也通过 Load、EPS 或 Backup 输出供电时，请选择“电网 + 混合逆变器”。",
+          "phase_guard_phase_count": "单相供电请选择 1，三相供电请选择 3。仅所选相会被要求和监测。"
         }
       },
       "settings_phase_guard": {
@@ -1348,8 +1348,8 @@
     "phase_guard_topology": {
       "options": {
         "disabled": "Disabled",
-        "grid_only": "Grid supply only",
-        "hybrid_load_port": "Grid + hybrid inverter Load/EPS output"
+        "grid_only": "仅电网供电",
+        "hybrid_load_port": "电网 + 混合逆变器 Load/EPS 输出"
       }
     }
   }

--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -1347,7 +1347,7 @@
   "selector": {
     "phase_guard_topology": {
       "options": {
-        "disabled": "Disabled",
+        "disabled": "已禁用",
         "grid_only": "仅电网供电",
         "hybrid_load_port": "电网 + 混合逆变器 Load/EPS 输出"
       }


### PR DESCRIPTION
## Summary
- localize the phase-guard topology step and selector options across all 16 supported languages
- add regression coverage preventing English fallback copy in non-English translations
- keep silent-install defaults fail-closed by requiring an explicit valid topology if phase guard is ever enabled by default
- document that power-derived charger current may lag writes and must not become an authoritative command floor

## Why
This is the small follow-up identified after #712: complete the translation backfill and preserve the accepted fail-closed phase-guard behavior without introducing a new control algorithm.

## Verification
- Full component suite: **5,747 passed, 2 skipped**
- Targeted phase-guard/config/localization tests: **53 passed**
- Ruff: passed
- All translation JSON files parsed successfully
- : passed
- Independent fail-closed review: passed with no security or logic findings

## Safety
- No runtime control logic changed
- No new hysteresis or actuation behavior
- Existing fail-closed behavior remains intact
- Auto-merge is not enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved phase-guard setup so it only activates with a valid electrical topology.
  * Clarified current-limit behavior while charger reductions are settling.

* **Localization**
  * Added and updated phase-guard topology labels, descriptions, and options across multiple languages, including Czech, Danish, German, Spanish, French, Italian, Dutch, Polish, Portuguese, Romanian, Chinese, and others.

* **Tests**
  * Added regression coverage for valid topology configuration and translated phase-guard settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->