### PR TITLE
fix(#716): EV controller could miss a live peak_limit_unlimited flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   limit](docs/USER_GUIDE.md#no-grid-limit), [SETUP_GUIDE.md → Step
   3](docs/SETUP_GUIDE.md#step-3-hardware-and-dashboard-settings),
   [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md#peak-load-management-not-working).
+- 🔧 **The "no grid limit" opt-out could lag a full restart behind the slider, in both
+  directions** (#716, found in review) — dragging the Control-tab slider to "Uncapped" writes
+  straight into the live load manager and deliberately skips a config-entry reload (a full
+  rebuild on every drag would be too heavy), so the EV controller's own copy of the flag —
+  read from the un-reloaded config — could still see the old value. Dragging to "Uncapped"
+  left the EV sizing against the old ceiling until a restart; dragging back down to a real
+  number left it sizing as if nothing constrained it, ignoring the limit just set. The EV
+  controller now reads the flag from the live load manager first, the same way it already
+  read the target kW value, falling back to config only when no load manager is wired up yet.
 - 🌐 **Six options-flow error messages rendered as raw keys** (found while fixing #717) —
   HA resolves options-flow errors under `options.error`, not `config.error`
   (`show-dialog-options-flow.ts` falls back to the bare key), and all of SEM's options-flow

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -411,7 +411,26 @@ class EVControlMixin:
         return self.config.get("target_peak_limit", 5.0) * 1000
 
     def _peak_limit_unlimited(self) -> bool:
-        """True when this install declared it has no grid ceiling (#716)."""
+        """True when this install declared it has no grid ceiling (#716).
+
+        Prefers the live ``LoadManagementCoordinator`` value over
+        ``self.config`` — same reason ``_get_peak_limit_w()`` prefers it for
+        ``target_peak_limit`` three lines above: the Control-tab slider
+        writes through ``update_target_peak_limit()`` and deliberately skips
+        the config-entry reload (to avoid a full coordinator rebuild on
+        every drag), so ``self.config`` can sit stale — in either direction —
+        until the next restart. Reading ``self.config`` only here let the EV
+        controller miss a live "Uncapped" flip, and worse, keep charging
+        past a limit the user had just restored.
+        """
+        if self._load_manager:
+            try:
+                lm_info = self._load_manager.get_load_management_data()
+                return bool(
+                    lm_info.get("peak_limit_unlimited", DEFAULT_PEAK_LIMIT_UNLIMITED)
+                )
+            except Exception:
+                pass
         return bool(
             self.config.get("peak_limit_unlimited", DEFAULT_PEAK_LIMIT_UNLIMITED)
         )

--- a/tests/test_716_peak_limit_unlimited.py
+++ b/tests/test_716_peak_limit_unlimited.py
@@ -139,12 +139,52 @@ class TestPeakLimitRead:
         host._load_manager = lm
         assert host._get_peak_limit_w() == 9000.0
 
-    def test_flag_beats_the_load_manager(self):
-        """The opt-out short-circuits before the LoadManager is consulted, so
-        a stale stored limit can't leak back in."""
+    def test_live_load_manager_unlimited_wins_over_stale_config(self):
+        """Regression for the bug this method was named after: the Control-
+        tab slider writes ``peak_limit_unlimited`` straight into the live
+        ``LoadManagementCoordinator`` and deliberately skips the config-entry
+        reload (see ``update_target_peak_limit``), so ``self.config`` can sit
+        stale in the "limited" state after the user drags to MAX. The EV
+        controller must observe the live flip immediately, not after the
+        next restart."""
+        host = _ev_host({"target_peak_limit": 5.0, "peak_limit_unlimited": False})
+        lm = MagicMock()
+        lm.get_load_management_data.return_value = {
+            "target_peak_limit": 5.0,
+            "peak_limit_unlimited": True,
+        }
+        host._load_manager = lm
+        assert host._get_peak_limit_w() == math.inf
+
+    def test_live_load_manager_limited_overrides_stale_config_unlimited(self):
+        """The dangerous direction: config stuck at "Uncapped" from before a
+        restart, but the user has since dragged the slider back down to a
+        real ceiling. The EV must respect the number the user just set, not
+        keep sizing as if nothing constrains it."""
         host = _ev_host({"target_peak_limit": 5.0, "peak_limit_unlimited": True})
         lm = MagicMock()
-        lm.get_load_management_data.return_value = {"target_peak_limit": 9.0}
+        lm.get_load_management_data.return_value = {
+            "target_peak_limit": 9.0,
+            "peak_limit_unlimited": False,
+        }
+        host._load_manager = lm
+        assert host._get_peak_limit_w() == 9000.0
+
+    def test_config_flag_used_when_no_load_manager(self):
+        """Before the LoadManager is wired up (or when load management is
+        off and the coordinator never constructs one), the config value is
+        the only source of truth left."""
+        host = _ev_host({"target_peak_limit": 5.0, "peak_limit_unlimited": True})
+        assert host._load_manager is None
+        assert host._get_peak_limit_w() == math.inf
+
+    def test_config_flag_used_when_load_manager_read_raises(self):
+        """A defensive fallback, matching ``target_peak_limit``'s own
+        try/except three lines above — an unexpected LoadManager error must
+        not crash EV sizing."""
+        host = _ev_host({"target_peak_limit": 5.0, "peak_limit_unlimited": True})
+        lm = MagicMock()
+        lm.get_load_management_data.side_effect = RuntimeError("boom")
         host._load_manager = lm
         assert host._get_peak_limit_w() == math.inf
 


### PR DESCRIPTION
## Summary
- Post-merge `ruflo-core:reviewer` pass on #716/#717 (PR #719) found a CRITICAL bug: `EVControlMixin._peak_limit_unlimited()` read `self.config` directly instead of the live `LoadManagementCoordinator` value
- The Control-tab slider writes `peak_limit_unlimited` straight into the live load manager and deliberately skips a config-entry reload (to avoid a full coordinator rebuild on every drag) — so the EV controller's copy of the flag could lag a full restart behind the slider, in both directions:
  - Dragging to "Uncapped" → EV kept sizing against the old numeric ceiling
  - Dragging back down to a real number → EV kept sizing as if unlimited, ignoring the limit just restored (the unsafe direction)
- Fix mirrors the existing pattern already used for `target_peak_limit` three lines above: prefer the live `LoadManager` value, fall back to `self.config` only when no load manager is wired up yet (or its read raises)

## Test plan
- [x] 4 new regression tests in `test_716_peak_limit_unlimited.py`: live-unlimited-wins-over-stale-config, live-limited-overrides-stale-unlimited-config, config-fallback-when-no-load-manager, config-fallback-on-load-manager-exception
- [x] Full unit suite green: 5836 passed, 2 skipped, 0 failed