### PR TITLE
fix(#717): repair stale ladder telemetry + guard services.yaml peak range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   number left it sizing as if nothing constrained it, ignoring the limit just set. The EV
   controller now reads the flag from the live load manager first, the same way it already
   read the target kW value, falling back to config only when no load manager is wired up yet.
+- 🔧 **The shed ladder's own telemetry could publish an inverted warning/emergency pair**
+  (#717, found in review) — `get_load_management_data()` returned the raw stored
+  `warning_level`/`emergency_level`, not the ladder `_effective_levels()` repairs at read
+  time before `_monitor_and_shed()` acts on it. Nothing consumed those two keys from the dict
+  yet, so this was inert, but any future card or sensor reading them would have shown a ladder
+  that didn't match what shedding actually used. Now returns the repaired pair.
+- 🧪 **`services.yaml`'s peak-limit selector had no test tying it to the shared range**
+  (#717, found in review) — the `update_target_peak` service's Developer Tools selector
+  hardcodes `1.0`/`80.0` because YAML can't import `MIN_PEAK_LIMIT_KW`/`MAX_PEAK_LIMIT_KW`,
+  the same drift shape that caused #717 in the first place (five different hard-coded
+  ceilings, nobody comparing them). Added a guard that fails CI if the YAML ever falls out of
+  sync with the constants.
 - 🌐 **Six options-flow error messages rendered as raw keys** (found while fixing #717) —
   HA resolves options-flow errors under `options.error`, not `config.error`
   (`show-dialog-options-flow.ts` falls back to the bare key), and all of SEM's options-flow

--- a/features/load_management.py
+++ b/features/load_management.py
@@ -1322,11 +1322,19 @@ class LoadManagementCoordinator:
                 self._is_device_currently_on(device_info))
         )
 
+        warning_level, emergency_level = self._effective_levels()
+
         return {
             "state": self._state,
             "target_peak_limit": self._target_peak_limit,
-            "warning_level": self._warning_level,
-            "emergency_level": self._emergency_level,
+            # (#717, found in review) repaired at read time, not the raw
+            # stored values — a consumer of this dict must see the same
+            # ladder _monitor_and_shed() actually shed against, not a stored
+            # ladder that could still be inverted (set_option writes with no
+            # validation; pre-#717 entries could predate the options-flow
+            # ordering check).
+            "warning_level": warning_level,
+            "emergency_level": emergency_level,
             # (#716) The label, not the number. The stored kW values stay as
             # they are and keep flowing to the sensors — no consumer of this
             # dict ever sees an infinity, so nothing downstream can render

--- a/tests/test_717_peak_limit_range.py
+++ b/tests/test_717_peak_limit_range.py
@@ -37,6 +37,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import voluptuous as vol
+import yaml
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.solar_energy_management.config_flow import (
@@ -136,6 +137,25 @@ def test_the_service_accepts_a_north_american_service():
     assert schema({"target_peak_limit": 38.4})["target_peak_limit"] == 38.4
     with pytest.raises(vol.Invalid):
         schema({"target_peak_limit": MAX_PEAK_LIMIT_KW + 1})
+
+
+def test_the_service_yaml_selector_matches_the_shared_range():
+    """``services.yaml`` cannot import ``MIN_PEAK_LIMIT_KW``/``MAX_PEAK_LIMIT_KW``
+    — YAML has no notion of a Python constant — so its ``update_target_peak``
+    selector is a hand-typed mirror of the same range every other surface in
+    this file derives from a shared import. That is exactly the shape that
+    already drifted once (#717): five different hard-coded ceilings across ten
+    controls, nobody noticing because nothing compared them. This pins the one
+    surface that structurally cannot use the import, so a future bump of the
+    constants can't leave the Developer Tools → Actions picker still offering
+    the old ceiling (found in review).
+    """
+    spec = yaml.safe_load((_ROOT / "services.yaml").read_text(encoding="utf-8"))
+    selector = (
+        spec["update_target_peak"]["fields"]["target_peak_limit"]["selector"]["number"]
+    )
+    assert selector["min"] == MIN_PEAK_LIMIT_KW
+    assert selector["max"] == MAX_PEAK_LIMIT_KW
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Two lower-severity ruflo findings from the #716/#717 peak-limit-range review, left open after PR #720 fixed the CRITICAL one.

- **WARNING**: `get_load_management_data()` published the raw stored `warning_level`/`emergency_level` instead of the `_effective_levels()` repaired pair that `_monitor_and_shed()` actually sheds against. Currently inert (no consumer reads these two keys from the dict yet), but a live trap for the next card/sensor that does.
- **INFO**: `services.yaml`'s `update_target_peak` selector hardcodes `1.0`/`80.0` because YAML can't import `MIN_PEAK_LIMIT_KW`/`MAX_PEAK_LIMIT_KW` — the same drift shape #717 itself was filed over (five different hard-coded ceilings, nobody comparing them). Added a CI guard tying the YAML literals to the shared constants.

## Test plan
- [x] Targeted run: 148 passed across test_717/test_716/test_load_management/test_657/test_433/test_night_peak_rolling/test_673
- [x] Full suite: 5837 passed, 2 skipped, 0 failed (up 1 from pre-fix baseline — the new services.yaml sync test)
- [x] Syntax check on edited files