### PR TITLE
fix(#728): a Time-of-Use tier is judged by where its hours sit, not by its price

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [1.7.6-beta.3] — 06.08.2026
+
+### 🐛 Fixes
+- 💵 **Time-of-Use tariffs got their middle rate back — "normal" was unreachable**
+  (#728, reported by @Azlinon) — on a plan with a handful of fixed rates rather than a
+  continuous hourly curve, SEM classified the day as *only* cheap and expensive. The
+  reporter's Consumers Energy "Nighttime Savers" plan has three prices; his twelve
+  mid-peak hours — half the day — all read **expensive**, so anything waiting for a
+  normal-or-better price sat out the afternoon. Root cause: the percentile classifier
+  picks its breakpoints by nearest rank, which on a discrete plan lands the p75 break
+  *exactly on* one of the tier prices; the comparison `price >= p75` then swallowed that
+  whole tier. Whenever the top tier covers less than about a quarter of the day the
+  middle tier disappears into it — and the flat-day guard never fires, so it failed
+  silently. Classification now compares **positions in the sorted price window** instead
+  of the prices themselves, so a tier is judged by where its hours sit in the day rather
+  than by which single number a quantile happened to land on. Continuous curves
+  (Nordpool, Tibber, Amber, aWATTar) are untouched: wherever a price occurs at most once
+  the two comparisons are equivalent, and #359's boundaries are pinned by test to prove
+  it. The mirror case is fixed too — a small *off*-peak block was pulling the middle tier
+  down into "very cheap".
+
 # [1.7.6-beta.2] — 05.08.2026
 
 ### 🐛 Fixes

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -408,6 +408,17 @@ When tariff mode is **Dynamic**, SEM bucketises every price reading into one of
   Calibrated for CHF — change to your currency only if you've explicitly opted
   in to this mode in Settings → Configure → Tariff settings.
 
+**Tiered / Time-of-Use plans (#728)**: a plan with a handful of fixed rates —
+US ToU, Spain's 2.0TD, UK Economy 7 — is bucketised by **where each tier's
+hours sit in the day**, not by the tier's price alone. A three-rate plan
+therefore gets three labels: the off-peak tier reads cheap, the mid tier
+`normal`, the on-peak tier expensive — whatever the split between them.
+(Before v1.7.6-beta.3 a tier covering less than about a quarter of the day
+pulled its neighbour in with it, so a reporter's twelve mid-peak hours all
+read `expensive` and `normal` never appeared.) Note that `very_cheap` vs
+`cheap` — and `expensive` vs `very_expensive` — is a display distinction
+only; every SEM control path treats each pair identically.
+
 **Cold start / sparse data (#359)**: in percentile mode, if SEM has fewer than
 4 price points for today (cold start before your dynamic-tariff integration
 populates, or a perfectly flat day), the classifier returns `normal` as a safe

--- a/tariff/tariff_provider.py
+++ b/tariff/tariff_provider.py
@@ -11,6 +11,7 @@ SurplusController for price-responsive device control.
 import logging
 import math
 from abc import ABC, abstractmethod
+from bisect import bisect_left, bisect_right
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
@@ -20,6 +21,19 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _quantile_index(n: int, q: float) -> int:
+    """Nearest-rank index of quantile ``q`` in a sorted list of ``n``.
+
+    Plain nearest-rank — good enough for 24/48-point arrays; avoids a
+    numpy dependency. Shared by the breakpoint picker and the
+    classifier so the two can never disagree about where p75 sits
+    (#728).
+    """
+    if n <= 0:
+        return 0
+    return max(0, min(n - 1, int(round(q * (n - 1)))))
 
 
 def _as_local(timestamp: datetime) -> datetime:
@@ -358,8 +372,11 @@ class DynamicTariffProvider(TariffProvider):
         self._no_price_array_warned = False
         # Cached percentile breakpoints, recomputed when the price
         # cache or the rolling window's slot changes.
-        # Keys: ``p10``, ``p25``, ``p75``, ``p90``.
-        self._percentile_breaks: Optional[Dict[str, float]] = None
+        # Keys: ``p10``, ``p25``, ``p75``, ``p90`` (floats, for the
+        # diagnostic path string) plus ``values`` — the sorted window
+        # itself, which is what the classifier actually buckets against
+        # (#728).
+        self._percentile_breaks: Optional[Dict[str, Any]] = None
         self._percentile_breaks_for: Optional[str] = None  # window key
         # #359 follow-up — surface which classifier path produced the most
         # recent ``price_level`` via the ``tariff_classifier_path`` sensor
@@ -1028,13 +1045,28 @@ class DynamicTariffProvider(TariffProvider):
             if breaks is not None:
                 # _get_percentile_breaks sets the active-path string in
                 # the happy case; just return the bucketed level.
-                if price <= breaks["p10"]:
+                #
+                # #728: compare POSITIONS in the sorted window, not
+                # prices. A nearest-rank quantile lands on an actual
+                # sample, so on a discrete Time-of-Use plan p75 IS one
+                # of the three tier prices — and ``price >= p75`` then
+                # swallowed that entire tier. Half of @Azlinon's day
+                # read as EXPENSIVE and NORMAL was unreachable.
+                #
+                # In index space each hour keeps its own slot and a
+                # tier sits at its middle. Where a price occurs at most
+                # once the two comparisons are equivalent, so #359's
+                # continuous curves are untouched.
+                window = breaks["values"]
+                n = len(window)
+                pos = self._window_position(window, price)
+                if pos <= _quantile_index(n, 0.10):
                     return PriceLevel.VERY_CHEAP
-                if price <= breaks["p25"]:
+                if pos <= _quantile_index(n, 0.25):
                     return PriceLevel.CHEAP
-                if price >= breaks["p90"]:
+                if pos >= _quantile_index(n, 0.90):
                     return PriceLevel.VERY_EXPENSIVE
-                if price >= breaks["p75"]:
+                if pos >= _quantile_index(n, 0.75):
                     return PriceLevel.EXPENSIVE
                 return PriceLevel.NORMAL
             # #359: percentile requested but no breaks available.
@@ -1066,7 +1098,27 @@ class DynamicTariffProvider(TariffProvider):
             return PriceLevel.EXPENSIVE
         return PriceLevel.NORMAL
 
-    def _get_percentile_breaks(self) -> Optional[Dict[str, float]]:
+    @staticmethod
+    def _window_position(sorted_values: List[float], price: float) -> float:
+        """Where ``price`` sits in the sorted window, in index space.
+
+        A price the window carries once returns its index. A price it
+        carries N times — every hour of a Time-of-Use tier posts the
+        same number — returns the MIDDLE of the ranks it occupies,
+        because the middle is where that tier sits in the day. A price
+        absent from the window lands half-way between its neighbours.
+
+        Bucketing on this instead of on the price itself is what fixes
+        #728, and it is a narrow change: whenever a price occurs at
+        most once, comparing indices and comparing values give the same
+        answer, so every continuous curve (Nordpool, Tibber, Amber)
+        keeps the boundaries #359 gave it. Only tied tiers move.
+        """
+        below = bisect_left(sorted_values, price)
+        equal = bisect_right(sorted_values, price) - below
+        return below + (equal - 1) / 2.0
+
+    def _get_percentile_breaks(self) -> Optional[Dict[str, Any]]:
         """Compute percentile breakpoints over a rolling ~24h window.
         Returns ``None`` when there's not enough data (< 4 points) for
         percentiles to be meaningful.
@@ -1150,24 +1202,24 @@ class DynamicTariffProvider(TariffProvider):
             return None
 
         def _quantile(sorted_values: List[float], q: float) -> float:
-            # Plain nearest-rank quantile — good enough for 24/48-point
-            # arrays; avoids a numpy dependency.
+            # #728: index picked by the module-level helper the
+            # classifier also uses, so the breakpoint reported in the
+            # diagnostic string and the one bucketing runs against are
+            # always the same index.
             if not sorted_values:
                 return 0.0
-            idx = max(
-                0,
-                min(
-                    len(sorted_values) - 1,
-                    int(round(q * (len(sorted_values) - 1))),
-                ),
-            )
-            return sorted_values[idx]
+            return sorted_values[_quantile_index(len(sorted_values), q)]
 
         breaks = {
             "p10": _quantile(window_prices, 0.10),
             "p25": _quantile(window_prices, 0.25),
             "p75": _quantile(window_prices, 0.75),
             "p90": _quantile(window_prices, 0.90),
+            # #728: the classifier buckets by rank against this list.
+            # The four breakpoints above stay for the flat-day guard
+            # and the diagnostic path string users read off the
+            # ``tariff_classifier_path`` attribute.
+            "values": window_prices,
         }
         # Degenerate distribution guard (M1 reviewer note): a flat or
         # near-flat day collapses every break to the same value, which

--- a/tests/test_728_discrete_tou_normal.py
+++ b/tests/test_728_discrete_tou_normal.py
@@ -1,0 +1,198 @@
+"""Percentile classification on discrete Time-of-Use tariffs (#728).
+
+Reported by @Azlinon against Consumers Energy "Nighttime Savers": a rate
+plan with exactly three prices per day was classified as *only* cheap and
+expensive — ``NORMAL`` never appeared, so the middle tier (half the day)
+was treated as expensive power.
+
+The percentile path was written for continuous curves (Nordpool / Tibber /
+Amber), where every quantile lands on a distinct value. A Time-of-Use plan
+has a handful of repeated values, so a quantile lands *on* a tier — and
+with an inclusive ``price >= p75`` the whole tier falls through to
+EXPENSIVE. Concretely: whenever the top tier covers less than ~25% of the
+day, p75 ties onto the middle tier and swallows it.
+
+These tests pin the ToU shape. The continuous-curve behaviour that #359
+established is asserted here too, so a fix for one can't silently regress
+the other.
+"""
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from custom_components.solar_energy_management.tariff.tariff_provider import (
+    DynamicTariffProvider,
+    PriceLevel,
+    PricePoint,
+)
+from homeassistant.util import dt as dt_util
+
+
+def _make_provider() -> DynamicTariffProvider:
+    hass = MagicMock()
+    return DynamicTariffProvider(
+        hass,
+        price_entity="sensor.fake_tariff",
+        classification_mode="percentile",
+    )
+
+
+def _seed(provider: DynamicTariffProvider, values: list[float]) -> None:
+    """Load one day of hourly prices into the provider's cache."""
+    today = dt_util.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    provider._prices_cache = [
+        PricePoint(
+            timestamp=today + timedelta(hours=i),
+            price=v,
+            currency="USD",
+            level=PriceLevel.NORMAL,
+        )
+        for i, v in enumerate(values)
+    ]
+
+
+# Consumers Energy "Nighttime Savers", summer weekday — the reporter's own
+# plan. Off-peak 0.187 (7h), mid-peak 0.209 (12h), on-peak 0.245 (5h).
+OFF_PEAK, MID_PEAK, ON_PEAK = 0.187, 0.209, 0.245
+NIGHTTIME_SAVERS = [
+    OFF_PEAK if (h < 6 or h >= 23)
+    else MID_PEAK if (6 <= h < 14 or 19 <= h < 23)
+    else ON_PEAK
+    for h in range(24)
+]
+
+
+class TestThreeTierTimeOfUse:
+    def test_the_middle_tier_is_normal(self):
+        """The reporter's mid-peak rate is the ordinary price of his day."""
+        p = _make_provider()
+        _seed(p, NIGHTTIME_SAVERS)
+
+        assert p._classify_price(MID_PEAK) is PriceLevel.NORMAL
+
+    def test_the_cheapest_tier_is_still_cheap(self):
+        p = _make_provider()
+        _seed(p, NIGHTTIME_SAVERS)
+
+        assert p._classify_price(OFF_PEAK) in (
+            PriceLevel.VERY_CHEAP, PriceLevel.CHEAP,
+        )
+
+    def test_the_priciest_tier_is_still_expensive(self):
+        p = _make_provider()
+        _seed(p, NIGHTTIME_SAVERS)
+
+        assert p._classify_price(ON_PEAK) in (
+            PriceLevel.VERY_EXPENSIVE, PriceLevel.EXPENSIVE,
+        )
+
+    def test_all_three_levels_appear_across_the_day(self):
+        """A three-price day should use three buckets, not two."""
+        p = _make_provider()
+        _seed(p, NIGHTTIME_SAVERS)
+
+        levels = {p._classify_price(v) for v in NIGHTTIME_SAVERS}
+        cheap = levels & {PriceLevel.VERY_CHEAP, PriceLevel.CHEAP}
+        pricey = levels & {PriceLevel.VERY_EXPENSIVE, PriceLevel.EXPENSIVE}
+
+        assert cheap, f"no cheap bucket used: {levels}"
+        assert PriceLevel.NORMAL in levels, f"NORMAL unreachable: {levels}"
+        assert pricey, f"no expensive bucket used: {levels}"
+
+
+class TestSkewedTimeOfUse:
+    """The tie can land on either side — pin both."""
+
+    def test_a_tiny_on_peak_block_does_not_swallow_the_middle_tier(self):
+        """Top tier well under 25% of the day: p75 ties onto mid-peak."""
+        p = _make_provider()
+        # 2h on-peak only — the case that provoked the report.
+        _seed(p, [
+            OFF_PEAK if h < 8 else ON_PEAK if 17 <= h < 19 else MID_PEAK
+            for h in range(24)
+        ])
+
+        assert p._classify_price(MID_PEAK) is PriceLevel.NORMAL
+
+    def test_a_tiny_off_peak_block_does_not_swallow_the_middle_tier(self):
+        """Mirror image: bottom tier under 25%, p25 ties onto mid-peak."""
+        p = _make_provider()
+        _seed(p, [
+            OFF_PEAK if h < 2 else ON_PEAK if 17 <= h < 23 else MID_PEAK
+            for h in range(24)
+        ])
+
+        assert p._classify_price(MID_PEAK) is PriceLevel.NORMAL
+
+
+class TestContinuousCurveUnchanged:
+    """#359's Nordpool/Tibber behaviour must survive the ToU fix."""
+
+    def test_bottom_of_a_continuous_day_is_very_cheap(self):
+        p = _make_provider()
+        _seed(p, [v / 100 for v in range(10, 81, 3)])  # 24 distinct values
+
+        assert p._classify_price(0.10) is PriceLevel.VERY_CHEAP
+
+    def test_middle_of_a_continuous_day_is_normal(self):
+        p = _make_provider()
+        _seed(p, [v / 100 for v in range(10, 81, 3)])
+
+        assert p._classify_price(0.45) is PriceLevel.NORMAL
+
+    def test_top_of_a_continuous_day_is_very_expensive(self):
+        p = _make_provider()
+        _seed(p, [v / 100 for v in range(10, 81, 3)])
+
+        assert p._classify_price(0.79) is PriceLevel.VERY_EXPENSIVE
+
+
+class TestLonePricesKeepTheirBucket:
+    """The guarantee that makes the #728 fix safe to ship.
+
+    A price only ONE hour of the window carries must land in exactly
+    the bucket it always did. Only tied tiers — several hours sharing
+    one number — may move, and that is the entire scope of the bug.
+
+    The curve below is RienduPre's synthetic Tibber-NL day from #359,
+    whose p75 lands squarely on EUR 0.30 — a price his day carries for
+    a single hour, and the exact value he reported as mis-classified.
+    A #728 fix that demotes it to NORMAL has re-opened #359.
+    """
+
+    TIBBER_NL = [
+        0.18, 0.16, 0.15, 0.14, 0.13, 0.14, 0.18, 0.24,
+        0.30, 0.32, 0.28, 0.25, 0.22, 0.20, 0.22, 0.26,
+        0.32, 0.42, 0.45, 0.40, 0.34, 0.28, 0.22, 0.18,
+    ]
+
+    def test_a_lone_price_sitting_on_p75_is_still_expensive(self):
+        p = _make_provider()
+        _seed(p, self.TIBBER_NL)
+
+        assert p._classify_price(0.30) is PriceLevel.EXPENSIVE
+
+    def test_the_rest_of_that_day_keeps_its_buckets_too(self):
+        p = _make_provider()
+        _seed(p, self.TIBBER_NL)
+
+        assert p._classify_price(0.13) is PriceLevel.VERY_CHEAP
+        assert p._classify_price(0.15) is PriceLevel.CHEAP
+        assert p._classify_price(0.32) is PriceLevel.EXPENSIVE
+        assert p._classify_price(0.45) is PriceLevel.VERY_EXPENSIVE
+
+
+class TestTwoTierTimeOfUse:
+    """A genuine two-price plan has no middle — it must NOT invent one."""
+
+    def test_a_two_tier_day_uses_only_cheap_and_expensive(self):
+        p = _make_provider()
+        _seed(p, [OFF_PEAK if h < 12 else ON_PEAK for h in range(24)])
+
+        assert p._classify_price(OFF_PEAK) in (
+            PriceLevel.VERY_CHEAP, PriceLevel.CHEAP,
+        )
+        assert p._classify_price(ON_PEAK) in (
+            PriceLevel.VERY_EXPENSIVE, PriceLevel.EXPENSIVE,
+        )


### PR DESCRIPTION
Fixes the percentile price classifier never emitting `normal` on discrete Time-of-Use tariffs.

Reported by @Azlinon on Consumers Energy "Nighttime Savers" (#728).

## The bug

His plan has three rates — off-peak 0.187 (7 h), mid-peak 0.209 (12 h), on-peak 0.245 (5 h). SEM labelled the day **only cheap and expensive**: all twelve mid-peak hours read `expensive`, and `normal` was unreachable. Anything waiting for a normal-or-better price sat out half his day.

The percentile classifier picks breakpoints by **nearest rank**, so `p75` is an actual sample from the window. On a continuous curve (Nordpool, Tibber, Amber) that is harmless — every price is its own value. On a discrete plan the break lands *exactly on* a tier's price, and the inclusive `price >= breaks["p75"]` then swallowed that whole tier:

```
sorted window:  [0.187]*7  [0.209]*12  [0.245]*5
                 idx 0-6    idx 7-18    idx 19-23
p25 = idx 6  = 0.187
p75 = idx 17 = 0.209   <-- lands ON the middle tier
=> 0.209 >= p75 => EXPENSIVE, for 12 of 24 hours
```

General rule: **whenever the top tier covers less than about a quarter of the window, p75 ties onto the middle tier and absorbs it.** The mirror case exists too — a small off-peak block pulls the middle tier down into `very_cheap`. The flat-day guard never fires (spread 0.058 >= 0.01), so it fails silently, and silently is how most of North America runs.

## The fix

Classification compares **positions in the sorted window** against the breakpoints' own indices, instead of comparing prices. Each hour keeps its own slot, so a tier is judged by its *middle* rather than by which single number a quantile happened to land on. `_quantile_index()` is now shared by the breakpoint picker and the classifier, so the two can never disagree about where p75 is.

Azlinon's day now reads: off-peak `cheap`, mid-peak **`normal`**, on-peak `very_expensive`.

## Why this is safe

The change is narrow by construction: **where a price occurs at most once, comparing indices and comparing values are the same operation.** Verified by brute force over 3.8M probes across 200k random windows (n = 4…96, distinct / tiered / mixed shapes) — zero singleton-or-absent prices changed bucket. Only tied tiers move, which is exactly the bug.

#359's continuous-curve boundaries are pinned by test, including RienduPre's Tibber-NL day whose p75 sits on a lone EUR 0.30 that must stay `expensive` — an earlier draft of this fix demoted it to `normal`, which would have re-opened #359 through a different door. That is now a regression test.

Degenerate inputs re-checked: price below/above the whole window, NaN, +inf, n=1, n=2, all-identical windows (the flat-day guard still owns that case). No changes.

## Side effect — display only

A tier covering a third of the day no longer reads "very cheap": Spain's 2.0TD `valle` moves `very_cheap` -> `cheap` and `punta` moves `very_expensive` -> `expensive`. **No control path distinguishes those pairs** — every consumer tests `in ("cheap", "very_cheap", "negative")` or `in ("expensive", "very_expensive")`; verified across `coordinator/`, `analytics/`, the dashboard cards and the template. `sem-schedule-card` even paints each pair the same colour. Only `sem-price-card` shows separate labels, which is the honest outcome.

## Tests

`tests/test_728_discrete_tou_normal.py` — 12 tests: the reporter's exact curve, both skew directions, a two-tier plan (must not invent a middle), the #359 continuous-curve guards, and the lone-price-keeps-its-bucket guarantee.

Full suite: **5914 passed, 2 skipped**.

Refs #728