### PR TITLE
fix(#729): today-plan windows name their closing boundary, not their last slot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the two comparisons are equivalent, and #359's boundaries are pinned by test to prove
   it. The mirror case is fixed too — a small *off*-peak block was pulling the middle tier
   down into "very cheap".
+- 🕐 **Today's-plan windows read an hour short** (#729, spotted by @Azlinon in #686) — a
+  cheap window covering the slots 00:00 through 05:00 announced itself as "open until
+  **05:00**", quietly disclaiming the last hour of itself. The two endpoints were not the
+  same kind of thing: `start` was the moment the window opens, but `end` was the *start
+  stamp of the final slot*. It now names the closing boundary — the same window reads
+  "until **06:00**" — and the slot length is measured off the price curve rather than
+  assumed hourly, so 15-minute markets close on the quarter. The EV strip's cheap/expensive
+  tint, which drew from the same value, stops stopping one slot early too.
 
 # [1.7.6-beta.2] — 05.08.2026
 

--- a/coordinator/today_plan.py
+++ b/coordinator/today_plan.py
@@ -76,13 +76,44 @@ class PlanRow:
         }
 
 
+_DEFAULT_SLOT = timedelta(hours=1)
+
+
+def _slot_duration(points: List[Dict[str, Any]]) -> timedelta:
+    """How long one price point covers, read off the curve's own cadence.
+
+    Most markets post hourly, but 15-minute curves exist, so measure rather
+    than assume. The cadence is the SMALLEST positive gap: a missing slot
+    leaves a double-width gap that must not be read as a wider slot, and a
+    duplicated timestamp leaves a zero gap that would collapse every window
+    onto its own start. One lone point has nothing to measure — fall back to
+    the common case (#729).
+
+    A curve that changes cadence half-way (an hourly day followed by a
+    quarter-hourly one, as markets moving to 15-minute settlement briefly
+    post) is measured by its finer half. No single number describes such a
+    curve; providers post one cadence, and reading the window slightly
+    short beats reading it long.
+    """
+    gaps = [b["t"] - a["t"] for a, b in zip(points, points[1:])
+            if b["t"] > a["t"]]
+    return min(gaps) if gaps else _DEFAULT_SLOT
+
+
 def _consecutive_blocks(
     points: List[Dict[str, Any]],
     levels: tuple,
     min_block_len: int = 1,
 ) -> List[Dict[str, Any]]:
-    """Group consecutive `upcoming` points whose level ∈ levels into blocks."""
+    """Group consecutive `upcoming` points whose level ∈ levels into blocks.
+
+    ``end`` is the block's **closing boundary** — one slot past the last
+    matching point, not that point's own timestamp. Cheap slots 00:00
+    through 05:00 mean cheap power until 06:00, and that is what the user
+    needs to read (#729).
+    """
     blocks: List[Dict[str, Any]] = []
+    slot = _slot_duration(points)
     cur_start = None
     cur_prices: List[float] = []
     last_t = None
@@ -94,12 +125,12 @@ def _consecutive_blocks(
             last_t = p["t"]
         else:
             if cur_start and len(cur_prices) >= min_block_len:
-                blocks.append({"start": cur_start, "end": last_t,
+                blocks.append({"start": cur_start, "end": last_t + slot,
                                "prices": list(cur_prices)})
             cur_start = None
             cur_prices = []
     if cur_start and len(cur_prices) >= min_block_len:
-        blocks.append({"start": cur_start, "end": last_t,
+        blocks.append({"start": cur_start, "end": last_t + slot,
                        "prices": list(cur_prices)})
     return blocks
 

--- a/tests/test_729_window_end_boundary.py
+++ b/tests/test_729_window_end_boundary.py
@@ -1,0 +1,121 @@
+"""#729 — a plan window's ``end`` is its closing boundary, not its last slot.
+
+Reported by @Azlinon in #686: a cheap window covering the hourly slots 00:00
+through 05:00 — cheap power right up until 06:00 — rendered as "cheap hours
+open until 05:00", so the reader loses the final hour of it.
+
+The asymmetry was the bug: ``start`` is genuinely when the window opens, but
+``end`` was the *start timestamp of the last slot*. One endpoint was a
+boundary, the other a slot label. These tests pin ``end`` as a boundary, and
+pin that the boundary is derived from the curve's own cadence rather than
+assumed hourly, because 15-minute price curves exist.
+"""
+from datetime import datetime, timedelta
+
+from custom_components.solar_energy_management.coordinator.today_plan import (
+    compose_today_plan,
+    _consecutive_blocks,
+    KIND_CHEAP_START,
+    KIND_EXPENSIVE_START,
+)
+
+
+NOW = datetime(2026, 5, 28, 22, 0, 0)
+
+
+def _prices(now: datetime, levels: list[tuple[float, str, float]]) -> list[dict]:
+    """Build upcoming_prices from (hour_offset, level, price) tuples."""
+    return [
+        {"t": (now + timedelta(hours=h)).isoformat(), "level": lvl, "price": p}
+        for h, lvl, p in levels
+    ]
+
+
+def _end_of(plan: list[dict], kind: str) -> str:
+    rows = [r for r in plan if r["kind"] == kind]
+    assert len(rows) == 1, f"expected exactly one {kind} row, got {len(rows)}"
+    return rows[0]["values"]["end"]
+
+
+class TestReportedWindowReadsOneHourShort:
+    """The exact shape from #686 — six cheap hours, 00:00 through 05:00."""
+
+    # NOW is 22:00, so +2h .. +7h are the slots 00:00 .. 05:00.
+    CURVE = [
+        (1, "normal", 0.20),
+        (2, "cheap", 0.10), (3, "cheap", 0.10), (4, "cheap", 0.10),
+        (5, "cheap", 0.10), (6, "cheap", 0.10), (7, "cheap", 0.10),
+        (8, "normal", 0.20),
+    ]
+
+    def test_the_window_closes_at_06_00_not_05_00(self):
+        plan = compose_today_plan(now=NOW, upcoming_prices=_prices(NOW, self.CURVE))
+        assert _end_of(plan, KIND_CHEAP_START) == "06:00"
+
+    def test_the_opening_endpoint_is_untouched(self):
+        # ``start`` was always right; the fix must not shift it.
+        plan = compose_today_plan(now=NOW, upcoming_prices=_prices(NOW, self.CURVE))
+        rows = [r for r in plan if r["kind"] == KIND_CHEAP_START]
+        assert datetime.fromisoformat(rows[0]["when"]) == NOW + timedelta(hours=2)
+
+
+class TestExpensiveWindowsToo:
+    def test_an_expensive_block_closes_on_its_boundary(self):
+        curve = [
+            (1, "normal", 0.20),
+            (2, "expensive", 0.40), (3, "very_expensive", 0.50),
+            (4, "normal", 0.20),
+        ]
+        plan = compose_today_plan(now=NOW, upcoming_prices=_prices(NOW, curve))
+        # Peak runs 00:00 and 01:00 → it is over at 02:00.
+        assert _end_of(plan, KIND_EXPENSIVE_START) == "02:00"
+
+
+class TestQuarterHourCurves:
+    """Slot length comes from the curve, not from an assumption."""
+
+    def test_a_15_minute_curve_closes_a_quarter_hour_past_the_last_slot(self):
+        curve = [
+            (0.00, "normal", 0.20),
+            (0.25, "cheap", 0.10), (0.50, "cheap", 0.10), (0.75, "cheap", 0.10),
+            (1.00, "normal", 0.20),
+        ]
+        plan = compose_today_plan(now=NOW, upcoming_prices=_prices(NOW, curve))
+        # Cheap slots 22:15, 22:30, 22:45 → cheap until 23:00.
+        assert _end_of(plan, KIND_CHEAP_START) == "23:00"
+
+
+class TestGapsDoNotStretchTheBoundary:
+    def test_a_missing_slot_does_not_widen_the_others(self):
+        # Hourly curve with the +4h slot absent. The cadence is still one
+        # hour; the gap must not be mistaken for a two-hour slot.
+        curve = [
+            (1, "cheap", 0.10), (2, "cheap", 0.10), (3, "cheap", 0.10),
+            (5, "normal", 0.20), (6, "normal", 0.20),
+        ]
+        plan = compose_today_plan(now=NOW, upcoming_prices=_prices(NOW, curve))
+        assert _end_of(plan, KIND_CHEAP_START) == "02:00"
+
+
+class TestDegenerateCurves:
+    def test_a_single_slot_falls_back_to_one_hour(self):
+        # Nothing to measure a cadence against — assume the common case
+        # rather than emitting a zero-length window.
+        points = [{"t": NOW, "level": "cheap", "price": 0.10}]
+        blocks = _consecutive_blocks(points, ("cheap",), min_block_len=1)
+        assert len(blocks) == 1
+        assert blocks[0]["end"] == NOW + timedelta(hours=1)
+
+    def test_repeated_timestamps_do_not_collapse_the_window(self):
+        # A duplicated timestamp yields a zero delta; it must not be taken
+        # as the slot length or every window would close where it opened.
+        points = [
+            {"t": NOW, "level": "cheap", "price": 0.10},
+            {"t": NOW, "level": "cheap", "price": 0.10},
+            {"t": NOW + timedelta(hours=1), "level": "cheap", "price": 0.10},
+        ]
+        blocks = _consecutive_blocks(points, ("cheap",), min_block_len=1)
+        assert blocks[0]["end"] == NOW + timedelta(hours=2)
+
+    def test_an_empty_curve_still_returns_no_blocks(self):
+        assert _consecutive_blocks([], ("cheap",), min_block_len=1) == []


### PR DESCRIPTION
Fixes the one-slot-short window reported by @Azlinon in #686, split out as #729.

A cheap window covering the hourly slots 00:00 through 05:00 — cheap power right up until 06:00 — rendered as **"cheap hours open until 05:00"**. The reader loses the last hour of it, and on a tariff where the boundary drives a charge decision that is an hour of cheap energy the plan appears to disclaim.

### Root cause

`_consecutive_blocks()` set a block's `end` to `last_t`, the *start timestamp of the last slot in the block*. `start` was already correct — it genuinely is when the window opens. The asymmetry was the bug: one endpoint was a boundary, the other a slot label.

### Fix

`end = last_t + one slot`, with the slot length measured off the curve's own cadence (`_slot_duration`) rather than assumed hourly, since 15-minute markets exist. The cadence is the **smallest positive gap** between consecutive points:

- a **missing slot** leaves a double-width gap that must not be read as a wider slot;
- a **duplicated timestamp** leaves a zero gap that would collapse every window onto its own start;
- a **lone point** has nothing to measure — falls back to one hour.

### Blast radius

`_consecutive_blocks` is private to `today_plan.py` and called from exactly two places (cheap levels, expensive levels). Two consumers read the value, neither compensating for the old behaviour:

- the translation string `until {end}` — now correct;
- `sem-ev-status-card.js` (~L295-320), which paints the cheap/expensive tint from block start to `values.end` — it was **under-painting by one slot** and now covers the window it names. No JS change, so no bundle rebuild.

### Tests

New `tests/test_729_window_end_boundary.py` — 8 tests: the reporter's exact six-hour window, expensive blocks, a 15-minute curve, a curve with a hole, duplicate timestamps, a single slot, an empty curve, and a guard that `start` is untouched. 6 of the 8 verified RED before the fix; the other two are guards that must *not* change.

Full suite: **5922 passed, 2 skipped**.

Refs #729