### PR TITLE
fix(#716): night plan hardware limits come from config, not literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [1.7.6-beta.4] — 06.08.2026
+
+### 🐛 Fixes
+- 🔌 **Overnight charging read the wrong charger's hardware limits**
+  (#716, reported by @Azlinon) — the night planner sizes the charge rate as
+  `(peak limit − house load) ÷ watts-per-amp`, and it was assembling those limits
+  from the wrong places. `watts_per_amp` hardcoded 230 V, while `ev_voltage` is
+  read by every other conversion in the codebase — all of `decide.py`, the energy
+  calculator, and `_night_deliverable_kwh` forty lines further down the same file.
+  `max_amps` read the *fleet* `ev_max_current`, while the line directly below it
+  read `ev_phases` per-charger — so in a mixed fleet the 16 A box was planned as
+  the 32 A one, over-claiming budget the next charger in the list then never saw.
+  Both now resolve per-charger-then-fleet like the rest of the planner, and a
+  non-positive voltage falls back to the default instead of reaching
+  `amps_from_headroom`'s 1 W/A floor, which would have saturated the charger to
+  max current on a junk config value. The charger's own reported rating still has
+  the last word over config. **Note for North American installs:** the reporter's
+  1.6 kW clamp came from `Phases` defaulting to 3 on single-phase 240 V hardware —
+  a believed 690 W/A against a measured 244. Setting the per-charger **Phases**
+  number entity to 1 is the fix for that today; a declared voltage / Max-Amps
+  surface and measured watts-per-amp learning are still queued on #716.
+
 # [1.7.6-beta.3] — 06.08.2026
 
 ### 🐛 Fixes

--- a/coordinator/ev_control.py
+++ b/coordinator/ev_control.py
@@ -150,12 +150,32 @@ class EVControlMixin:
             "vehicle_min_current": cfg.get("vehicle_min_current"),
         }
         min_amps = effective_min_amps(_effective_cfg, 6)
-        max_amps = int(self.config.get("ev_max_current", 32))
+        # Hardware limits resolve per-charger-then-fleet, same as everything
+        # else here (#716). Reading ``ev_max_current`` off the fleet plans a
+        # 16 A box as if it were the 32 A one; the device's own rating still
+        # gets the last word below, because config can out-claim the box.
+        max_amps = int(_pc("ev_max_current", 32))
         ev = getattr(self, "_ev_device", None)
         if ev is not None:
             max_amps = int(getattr(ev, "max_current", max_amps))
         phases = int(_pc("ev_phases", 3))
-        watts_per_amp = phases * DEFAULT_VOLTAGE_PER_PHASE
+        # ``ev_voltage`` is read by every other watts-per-amp conversion in
+        # the codebase — decide.py, the energy calculator, and
+        # ``_night_deliverable_kwh`` in this very file. This one alone
+        # hardcoded 230, so a 240 V install was planned 4% short (#716).
+        #
+        # A non-positive or unparseable value falls back to the default
+        # rather than through to ``amps_from_headroom``'s 1.0 W/A floor:
+        # that floor would not crash, it would saturate the charger to max
+        # current on a junk config value — the same fails-open shape the
+        # peak limit was hardened against in this issue.
+        try:
+            voltage = float(_pc("ev_voltage", DEFAULT_VOLTAGE_PER_PHASE))
+        except (TypeError, ValueError):
+            voltage = float(DEFAULT_VOLTAGE_PER_PHASE)
+        if voltage <= 0:
+            voltage = float(DEFAULT_VOLTAGE_PER_PHASE)
+        watts_per_amp = phases * voltage
 
         tariff_optimized = self._tariff_optimized_for(cfg)
         target_time = self._charger_target_time(cfg)

--- a/tests/test_716_night_plan_hardware_model.py
+++ b/tests/test_716_night_plan_hardware_model.py
@@ -1,0 +1,149 @@
+"""#716 — the night plan's hardware model must come from config, not literals.
+
+@Azlinon's install clamps overnight charging at the 6 A floor. The arithmetic
+behind it: the night rate is ``(peak_limit - home - committed) / watts_per_amp``,
+and ``watts_per_amp`` is built in ``_compute_night_plan``. Two of its three
+inputs are read from the wrong place:
+
+* ``max_amps`` reads the FLEET ``ev_max_current`` — while the very next line
+  reads ``ev_phases`` per-charger-then-fleet. In a mixed fleet the 16 A box is
+  planned as if it were the 32 A one.
+* ``watts_per_amp`` hardcodes 230 V. Seven other sites — including
+  ``_night_deliverable_kwh`` forty lines further down the SAME file, plus every
+  ``decide.py`` conversion — read ``ev_voltage``. North America runs 240 V.
+
+Neither literal is safe-by-default: an over-large ``watts_per_amp`` under-commands
+the charger (slow), an over-large ``max_amps`` over-commands it (claims fleet
+budget the box cannot draw). These tests pin both reads to the same
+per-charger-then-fleet resolution the rest of the planner already uses.
+"""
+from unittest.mock import MagicMock, patch
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.solar_energy_management.consts.states import ChargingState
+from custom_components.solar_energy_management.coordinator import SEMCoordinator
+
+
+def _coordinator(fleet=None, charger=None):
+    """A coordinator whose night plan depends only on the config under test.
+
+    No predictor and no energy object, so ``_expected_night_home_w`` falls
+    through to ``daily_home_consumption_estimate / 24`` — 18 kWh/day = 750 W,
+    a fixed, stated number rather than a learned one.
+    """
+    with patch.object(SEMCoordinator, "__init__", return_value=None):
+        coord = SEMCoordinator.__new__(SEMCoordinator)
+    cfg = {
+        "id": "keba",
+        "ev_min_current": 6,
+        "charge_mode": "min_plus_solar",
+    }
+    cfg.update(charger or {})
+    coord.config = {
+        "ev_chargers": [cfg],
+        "ev_max_current": 32,
+        "ev_phases": 1,          # single-phase, as on the reporter's install
+        "target_peak_limit": 6.0,
+        "daily_home_consumption_estimate": 18.0,
+    }
+    coord.config.update(fleet or {})
+
+    coord._load_manager = None
+    coord._surplus_controller = None
+    coord._night_committed_w = 0.0
+    coord._ev_device = None
+    coord.time_manager = MagicMock()
+    coord.time_manager.get_night_end_time = MagicMock(return_value="07:00")
+    coord.time_manager.get_night_window_hours = MagicMock(return_value=8.0)
+    coord.hass = MagicMock()
+    coord._tariff_provider = None
+    coord._state_machine = MagicMock()
+    coord._state_machine.current_state = ChargingState.SOLAR_IDLE
+    return coord, cfg
+
+
+def _top_up_amps(coord, cfg, remaining_kwh=10.0):
+    base = dt_util.now().replace(hour=22, minute=0, second=0, microsecond=0)
+    with patch.object(dt_util, "now", return_value=base):
+        return coord._compute_night_plan(cfg, remaining_to_min_kwh=remaining_kwh).top_up_amps
+
+
+class TestVoltageComesFromConfig:
+    """6000 W ceiling − 750 W home = 5250 W of headroom, single phase."""
+
+    def test_the_default_is_still_230_volts(self):
+        # Pin the unchanged case first: nothing set, nothing moves.
+        coord, cfg = _coordinator()
+        assert _top_up_amps(coord, cfg) == 23        # 5250 / 230 = 22.8
+
+    def test_a_fleet_voltage_is_honoured(self):
+        coord, cfg = _coordinator(fleet={"ev_voltage": 240})
+        assert _top_up_amps(coord, cfg) == 22        # 5250 / 240 = 21.9
+
+    def test_a_per_charger_voltage_beats_the_fleet_one(self):
+        coord, cfg = _coordinator(
+            fleet={"ev_voltage": 230}, charger={"ev_voltage": 240},
+        )
+        assert _top_up_amps(coord, cfg) == 22
+
+    def test_a_junk_voltage_falls_back_rather_than_failing_open(self):
+        # ``amps_from_headroom`` floors watts-per-amp at 1.0, so a zero here
+        # would not crash — it would saturate the charger to max current on
+        # a bad config value. That is the same fails-open shape the peak
+        # limit itself was hardened against in this issue. Fall back to the
+        # default instead: wrong-and-conservative beats wrong-and-unlimited.
+        coord, cfg = _coordinator(fleet={"ev_voltage": 0})
+        assert _top_up_amps(coord, cfg) == 23
+
+
+class TestMaxCurrentIsPerCharger:
+    """A ceiling declared on the charger is the charger's, not the fleet's."""
+
+    def test_a_per_charger_max_beats_the_fleet_max(self):
+        # 30 kW ceiling − 750 W home = 29250 W at 230 W/A = 127 A, so the
+        # result is whichever max applies. The charger says 16.
+        coord, cfg = _coordinator(
+            fleet={"target_peak_limit": 30.0, "ev_max_current": 32},
+            charger={"ev_max_current": 16},
+        )
+        assert _top_up_amps(coord, cfg) == 16
+
+    def test_the_fleet_max_still_applies_when_the_charger_is_silent(self):
+        coord, cfg = _coordinator(fleet={"target_peak_limit": 30.0, "ev_max_current": 32})
+        assert _top_up_amps(coord, cfg) == 32
+
+    def test_the_device_rating_still_wins_over_config(self):
+        # Unchanged precedence: what the hardware reports it can do is the
+        # last word, because config can out-claim the box.
+        coord, cfg = _coordinator(
+            fleet={"target_peak_limit": 30.0}, charger={"ev_max_current": 16},
+        )
+        coord._ev_device = MagicMock(max_current=20)
+        assert _top_up_amps(coord, cfg) == 20
+
+
+class TestTheReportedClamp:
+    """#716 — the 5 kW ceiling that lands on the 6 A floor, and why.
+
+    Characterisation, not a driver: both of these already hold, because the
+    reporter's 2.9x error comes from the phase count and not from the volts.
+    They are here so the arithmetic in the issue reply is pinned to running
+    code, and so the phases workaround cannot regress unnoticed.
+    """
+
+    # Reporter's numbers: 5 kW target peak, 6 A min, 240 V split-phase
+    # measured at 7800 W / 32 A = 244 W per amp.
+    FLEET = {"target_peak_limit": 5.0, "ev_voltage": 240}
+
+    def test_three_phases_starves_a_single_phase_charger(self):
+        # 4250 W of headroom at a believed 3 x 240 = 720 W/A is 5.9 A —
+        # under the floor. 6 A x 244 V is the ~1.5 kW the reporter saw.
+        coord, cfg = _coordinator(fleet=dict(self.FLEET, ev_phases=3))
+        assert _top_up_amps(coord, cfg) == 6
+
+    def test_declaring_one_phase_recovers_the_rate(self):
+        # The same headroom at the true 240 W/A is 17.7 A -> 18, about
+        # 4.3 kW. This is the workaround available today.
+        coord, cfg = _coordinator(fleet=dict(self.FLEET, ev_phases=1))
+        assert _top_up_amps(coord, cfg) == 18


### PR DESCRIPTION
Closes the sizing half of #716 (@Azlinon).

## The arithmetic

Overnight rate is `(peak_limit − house − committed) / watts_per_amp`. Reporter's install: 5 kW ceiling, ~800 W house, 6 A min, **single-phase 240 V** measured at 7800 W ÷ 32 A = 244 W/A. SEM believed `3 × 230 = 690`, so `4200 / 690 = 6.1 A` → the floor → ~1.5 kW. That is his report.

## Two wrong reads in `_compute_night_plan`

| Line | Was | Why it's wrong |
|---|---|---|
| `watts_per_amp` | hardcoded `230` | `ev_voltage` is read by `decide.py` ×3, `energy_calculator.py:1764`, `coordinator.py` ×2, and `_night_deliverable_kwh` **40 lines down the same file**. This one line was the odd one out. |
| `max_amps` | fleet `ev_max_current` | The line directly below reads `ev_phases` per-charger-then-fleet. `build_view.py` (#678) already made per-charger-then-fleet the contract for this key. A 16 A box planned as 32 A over-claims budget the next charger never sees. |

Both now go through the local `_pc()` helper. Non-positive/unparseable voltage falls back to the default rather than reaching `amps_from_headroom`'s 1.0 W/A floor — that floor wouldn't crash, it would *saturate the charger to max current* on a junk value, the same fails-open shape `_get_peak_limit_w` was hardened against in this issue. The device's own reported rating still wins over config.

## Scope — read this before assuming it fixes the report

Neither `ev_voltage` nor `ev_max_current` has a UI today, so **this alone changes no live install.** It's the plumbing, so the declared voltage / Max-Amps surface lands correctly on every path instead of one path silently ignoring it.

The reporter's 2.9× error is `ev_phases` defaulting to 3 on single-phase hardware. That entity *does* exist — setting it to 1 takes him from ~1.5 kW to ~4.3 kW today, and also drops the surplus-charging minimum from a fictional 4140 W to the 1380 W his box really draws at 6 A. Both numbers are pinned as characterisation tests.

## Bug classes

- **per-charger code path reading fleet-scope config** (`docs/BUG_CLASSES.md`; sibling of #678)
- **a config key honoured by some readers and hardcoded past by others**

## Deliberately not touched

`__init__.py:1799` builds `CurrentControlDevice(voltage=230.0)` as a literal, on the line after one that reads `ev_phases` from config. Same shape — but no production caller of the device's `voltage` could be established (`watts_to_current`/`current_to_watts`/`.voltage` have zero non-test callers outside `devices/base.py`). It goes with the surface work rather than being a fix spread somewhere unproven.

## Tests

9 in `tests/test_716_night_plan_hardware_model.py` — 4 drove the change (verified RED), 5 pin what must not move: the 230 default, the fleet max when the charger is silent, device-rating precedence, and both halves of the reporter's clamp.

Full suite **5931 passed, 2 skipped** (5922 + 9, no regressions).

Refs #716