### PR TITLE
fix(#708): charging raises the SOC estimate — it had been lowering it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > `(by @author in #PR)` attribution. Older entries (≤ beta.13) stay in the
 > prose-paragraph style they were written in.
 
+# [1.7.6-beta.6] — 06.08.2026
+
+### 🐛 Fixes
+- 🔋 **Estimated EV SOC walked *down* while the car was charging**
+  (#708, reported by @Azlinon) — with the vehicle-SOC sensor quiet, SEM tracks
+  the pack against an internal "how far below full is it" figure. Every path
+  treated that as a deficit — driving raises it, a real reading recalibrates it,
+  reaching full zeroes it, a finished session subtracts what it delivered —
+  except the one that runs each cycle *during* a charge, which **added** the
+  delivered kWh instead. The estimate fell by exactly what went into the pack:
+  11.5 kWh into a blinded 85 kWh pack read 24 % where the car was near 50 %. It
+  stayed hidden because a session that reaches full resets the figure anyway; it
+  takes a charge that stops short **and** a sensor that goes quiet to leave the
+  inverted value on screen. Charging now subtracts, with the 0.92 charge
+  efficiency, so the big "SOC (EST.)" number and the "est. now ~54 %" hint beside
+  it are the same arithmetic by two routes instead of two answers. The disconnect
+  step no longer re-applies the finished session on top of what the live path
+  already booked — subtracting it there had been quietly cancelling half the
+  error, which is why the number looked plausible again once the car was
+  unplugged. A charger's lifetime total-energy counter still anchors the taper
+  but no longer feeds this figure at all: it measures what was put back **in**,
+  never how far the car was driven, and that mismatch is what made it the sign
+  error — on a charger exposing such a counter it could override a fresh real
+  SOC reading outright, showing 94 % for a pack the car had just reported at
+  38 %. An install with no reference yet still reports "unknown" rather than a
+  guess (#245), and the 0 %-recovery path now anchors the value it writes so it
+  keeps tracking for the rest of the charge instead of freezing.
+
 # [1.7.6-beta.5] — 06.08.2026
 
 ### 🐛 Fixes

--- a/coordinator/coordinator.py
+++ b/coordinator/coordinator.py
@@ -7013,6 +7013,12 @@ class SEMCoordinator(DataUpdateCoordinator, EVControlMixin):
             session_soc = min(95.0, self._session_data.energy_kwh / capacity * 100 * 0.92) if capacity > 0 else 0.0
             self._ev_taper_detector._energy_since_full = (100 - session_soc) / 100 * capacity
             self._ev_taper_detector._estimated_soc = session_soc
+            # #708 — anchor what we just wrote. ``update_energy`` is inert
+            # until the detector is anchored, so a healed-but-unanchored
+            # estimate would FREEZE for the rest of the charge: worse than
+            # the moving-but-wrong value it replaced. The stall→full anchor
+            # below sets this for the same reason.
+            self._ev_taper_detector._soc_anchored = True
             estimated_soc = session_soc
             _LOGGER.warning(
                 "SOC self-healed: was 0%% after %.1f kWh session → %.0f%%",

--- a/coordinator/ev_taper_detector.py
+++ b/coordinator/ev_taper_detector.py
@@ -325,15 +325,36 @@ class EVTaperDetector:
         ev_energy_increment_kwh: float,
         hw_total_energy_kwh: Optional[float] = None,
     ) -> None:
-        """Update energy since full charge, preferring hardware counter.
+        """Book delivered energy against the deficit below full.
 
-        When a hardware total energy counter is available (e.g. KEBA
-        total_energy), uses the delta since last full charge for drift-free
-        tracking. Falls back to power integration when hardware unavailable.
+        ``_energy_since_full`` is how many kWh the pack sits BELOW full:
+        ``apply_daily_decay`` adds driving consumption to it, the sensor
+        calibration sets it to ``(100 − soc)/100 × capacity``, the taper/stall
+        anchor zeroes it at 100 %, and every display divides it out of 100.
+        Charging therefore SUBTRACTS, and this is the ONLY path that books it:
+        ``on_session_end`` used to subtract the session total again at
+        disconnect, which was the other half of a cancelling pair (see there).
+
+        This path used to add the delivered kWh instead, so a live charge
+        walked the estimate down by exactly what went into the pack (#708).
+        It stayed hidden because a session that reaches full resets the
+        deficit to zero anyway; it takes a charge that stops short AND a
+        vehicle-SOC sensor that goes quiet to leave the inverted value on
+        screen. 11.5 kWh into a blinded 85 kWh pack read 24 % instead of 50 %.
+
+        The hardware total-energy counter is still tracked (the taper anchor
+        ``_hw_total_at_full`` needs it) but no longer books the deficit. It
+        measures energy put back IN, never how far the car was driven — that
+        mismatch IS the sign error. Its per-cycle delta is not a safe
+        substitute either: a counter that goes unavailable for a stretch and
+        then returns re-books the whole gap the integral already covered, and
+        nothing normalizes its unit, so a charger publishing Wh delivers
+        ~4 Wh cycles as the bare number 4.0 — under any plausible sanity
+        bound, and enough to fill the pack in a handful of cycles.
 
         Args:
-            ev_energy_increment_kwh: Power-integrated increment (fallback).
-            hw_total_energy_kwh: Current charger lifetime total (ground truth).
+            ev_energy_increment_kwh: Power-integrated increment — the source.
+            hw_total_energy_kwh: Current charger lifetime total, tracked only.
         """
         capacity = self._config.get("ev_battery_capacity_kwh", 40)
 
@@ -355,26 +376,28 @@ class EVTaperDetector:
                     )
             return
 
-        # Reconcile energy_since_full from hardware total energy counter
-        # This corrects drift from the daily decay prediction (#174)
-        if self._hw_total_at_full is not None and hw_total_energy_kwh is not None:
-            hw_energy = hw_total_energy_kwh - self._hw_total_at_full
-            if capacity > 0 and 0 <= hw_energy <= capacity:
-                if abs(hw_energy - self._energy_since_full) > 0.5:
-                    _LOGGER.info(
-                        "SOC reconciled from hardware: %.1f kWh (was %.1f from decay)",
-                        hw_energy, self._energy_since_full,
-                    )
-                self._energy_since_full = hw_energy
-                self._estimated_soc = max(
-                    0.0, 100.0 - (self._energy_since_full / capacity * 100.0)
-                )
-                return
+        if capacity <= 0:
+            return
 
-        # Fallback: power integration
-        if ev_energy_increment_kwh > 0:
-            self._energy_since_full += ev_energy_increment_kwh
-            self._energy_since_full = min(self._energy_since_full, capacity)
+        # #245: an unanchored detector has no reference to move. Booking into
+        # it would write ``_estimated_soc = 100`` — and that field is
+        # PERSISTED, so it would outlive the ``_soc_anchored`` display gate
+        # that is currently the only thing hiding it. An install with no
+        # vehicle-SOC sensor gets anchored by its first COMPLETED session
+        # (``on_session_end``'s bootstrap), not mid-charge.
+        if not self._soc_anchored:
+            return
+
+        if ev_energy_increment_kwh <= 0:
+            return
+
+        efficiency = self._config.get("ev_charger_efficiency", CHARGE_EFFICIENCY)
+        self._energy_since_full = max(
+            0.0, self._energy_since_full - ev_energy_increment_kwh * efficiency
+        )
+        self._estimated_soc = min(
+            100.0, 100.0 - (self._energy_since_full / capacity * 100.0)
+        )
 
     def get_virtual_soc(self, vehicle_soc: Optional[float] = None) -> float:
         """Get estimated SOC, preferring real vehicle SOC if available.
@@ -516,34 +539,34 @@ class EVTaperDetector:
                 self._battery_health_samples = self._battery_health_samples[-MAX_HEALTH_SAMPLES:]
             self._calculate_battery_health()
 
-        # Update virtual SOC: charging adds energy back
-        # (taper/full detection already handled above — this covers partial charges)
-        if not self._full_detected and session_energy_kwh > 0 and capacity > 0:
-            efficiency = self._config.get("ev_charger_efficiency", 0.92)
+        # Bootstrap: the first completed session anchors SOC when nothing
+        # else can. This block used to ALSO subtract the session energy for
+        # an already-anchored detector, and that was the other half of a
+        # cancelling pair (#708): the live path added it (wrong sign), this
+        # one took it away, so the value at disconnect landed near the truth
+        # while the on-screen number stayed inverted for the whole charge.
+        # With ``update_energy`` booking each cycle correctly, subtracting
+        # the total again here is a straight double-count — 5 kWh into a
+        # 40 kWh pack at 50 % would read 73 % instead of 61.5 %. The
+        # bootstrap stays because ``update_energy`` is deliberately inert
+        # while unanchored, which makes this the only path a sensorless
+        # install ever gets a reference from.
+        if not self._full_detected and not self._soc_anchored \
+                and session_energy_kwh > 0 and capacity > 0:
+            efficiency = self._config.get("ev_charger_efficiency", CHARGE_EFFICIENCY)
             energy_to_battery = session_energy_kwh * efficiency
-            self._energy_since_full = max(0, self._energy_since_full - energy_to_battery)
-            self._estimated_soc = min(
-                100.0, 100.0 - (self._energy_since_full / capacity * 100.0)
+            # Assume car arrived at target_soc minus what it accepted
+            target = self._config.get("ev_target_soc", 80)
+            soc_added = energy_to_battery / capacity * 100.0
+            pre_charge_soc = max(0, target - soc_added)
+            self._estimated_soc = min(100.0, pre_charge_soc + soc_added)
+            self._energy_since_full = (100.0 - self._estimated_soc) / 100.0 * capacity
+            self._soc_anchored = True
+            _LOGGER.info(
+                "SOC bootstrapped from first session: %.1f kWh delivered "
+                "(%.1f%% added) → estimated SOC %.1f%%",
+                session_energy_kwh, soc_added, self._estimated_soc,
             )
-            # Bootstrap: first session anchors SOC if no prior reference
-            if not self._soc_anchored:
-                # Assume car arrived at target_soc minus what it accepted
-                target = self._config.get("ev_target_soc", 80)
-                soc_added = energy_to_battery / capacity * 100.0
-                pre_charge_soc = max(0, target - soc_added)
-                self._estimated_soc = min(100.0, pre_charge_soc + soc_added)
-                self._energy_since_full = (100.0 - self._estimated_soc) / 100.0 * capacity
-                self._soc_anchored = True
-                _LOGGER.info(
-                    "SOC bootstrapped from first session: %.1f kWh delivered "
-                    "(%.1f%% added) → estimated SOC %.1f%%",
-                    session_energy_kwh, soc_added, self._estimated_soc,
-                )
-            else:
-                _LOGGER.info(
-                    "SOC updated after charge: +%.1f kWh (%.0f%% eff) → SOC %.1f%%",
-                    session_energy_kwh, efficiency * 100, self._estimated_soc,
-                )
 
         self._session_start_soc = None
 
@@ -756,6 +779,13 @@ class EVTaperDetector:
                     if s["end"] > latest_full["end"]
                 )
                 capacity = self._config.get("ev_battery_capacity_kwh", 40)
+                # Cold-start seed, NOT the deficit accumulator (#708). At boot
+                # all recorder history offers is "the car took this much back
+                # since it was last full"; how far it was driven in between is
+                # unknowable, so this is a heuristic stand-in, not a measured
+                # deficit. Do not "correct" it to subtract like update_energy
+                # does — that yields SOC 100 % forever, the #245 failure. The
+                # first real SOC reading or taper overwrites it either way.
                 self._energy_since_full = energy_after
                 self._estimated_soc = max(
                     0.0, 100.0 - (energy_after / capacity * 100.0)

--- a/docs/BUG_CLASSES.md
+++ b/docs/BUG_CLASSES.md
@@ -925,6 +925,80 @@ user would most naturally put under each name, or only the one shape the first p
 use? And: does the "unrecognised" diagnostic distinguish *name* from *shape*, or blame the name for a
 shape gap?
 
+### 35. Signed accumulator whose direction is carried by a name, not asserted anywhere — GUARDED
+**Symptom:** one field holds a signed physical quantity (a deficit, a balance, a remaining amount)
+and several sites write it. Most agree on the convention; one books its input with the opposite
+sign. Nothing raises, nothing goes unavailable — the number simply walks the wrong way, and only in
+the state where the *other* writers aren't there to overwrite it. Because that state is a corner
+(sensor offline, session that stops short), the bug can ship for a year. **Root shape:** the field's
+meaning lives in its NAME, and the name is ambiguous. `_energy_since_full` reads equally well as
+"energy *consumed* since full" (a deficit, which charging repays) and "energy *delivered* since
+full" (throughput, which charging grows). Each writer silently picks whichever reading fits its
+local source; no single call site looks wrong.
+**Live catch (#708, @Azlinon, 85 kWh Blazer EV / JuiceBox / OnStar):** `EVTaperDetector.update_energy` —
+the one path that runs *every cycle while charging* — **added** the delivered kWh to the deficit. Seven
+other sites treat the field as a deficit (day-rollover decay adds driving, the sensor calibration
+sets `(100−soc)/100 × capacity`, the taper/stall anchor zeroes it at 100 %, `on_session_end`
+*subtracts* a session, every display divides it out of 100). The reporter stopped his SOC
+integration mid-charge and watched "SOC (EST.)" walk from 32 % down to 25 % while 11.5 kWh went
+into the pack: `11.5 / 85 × 0.92 ≈ 12.4 %`, "almost exactly the amount of *decrease* I'm seeing".
+The `#715` energy-accounted *ceiling*, added to the same file weeks earlier, had the sign right; the
+reporter noticed the two disagreed on his own dashboard.
+**Why it survived a year — the cancelling pair.** The wrong-sign writer had a partner: `update_energy`
+added the delivered kWh during the session, then at disconnect `on_session_end` **subtracted** the
+session total. Two errors in opposite directions, so the value at disconnect landed back near the
+truth and only the *live* number was inverted. It takes a charge that stops short **and** a
+vehicle-SOC sensor that goes quiet to leave the wrong value visible at rest. **This is the trap in
+the fix, not just in the bug:** correcting one half alone converts a hidden error into a loud one of
+the same magnitude in the other direction (here: 5 kWh into a 40 kWh pack at 50 % would have read
+73 % instead of 61.5 %). When a signed accumulator has two writers that disagree, find the *pair*
+before editing either.
+**How the suite defended it:** six call sites across four tests in `test_ev_taper_detector.py` passed
+`update_energy(8.0)` and asserted SOC *fell*, commented "Simulate 8 kWh consumed" — while both
+production call sites pass `ev_power × interval_hours / 1000`, i.e. energy **delivered**. The tests
+encoded the misreading and went green on it. A test that assumes something about its caller is only
+as good as the last time someone checked the caller.
+**The counter branch was the same error, wearing a unit.** Alongside the `+=` fallback sat a
+"reconcile from the hardware counter" branch (#174): `deficit = hw_total − hw_total_at_full`, i.e.
+*energy put back in since the pack was last full* assigned to *how far below full it is*. Those are
+opposites. It is reachable across sessions — `reset_session` clears `_full_detected` but the taper's
+`_hw_total_at_full` survives — so on a charger exposing a lifetime total it OVERRIDES a fresh real
+SOC reading: a pack a sensor just put at 38 % reads 94 %, then walks down as it charges. Same
+symptom, immune to any per-cycle fix.
+**Where it lives:** `coordinator/ev_taper_detector.py`. **Closure:** charging subtracts, with the
+charge efficiency; `on_session_end` keeps only its *bootstrap* branch (the sole way an install with
+no SOC sensor ever gets anchored) and no longer re-books the session; the deficit is booked from the
+power integral alone. The hardware counter is still tracked for the taper anchor but no longer feeds
+the deficit in any form. Its per-cycle *delta* looked like the obvious salvage and is not: a counter
+that goes unavailable and returns re-books the gap the integral already covered, and nothing
+normalizes its unit, so a charger publishing Wh delivers ~4 Wh cycles as the bare number `4.0` —
+under any plausible sanity bound, and enough to fill the pack in seconds.
+**Second-order trap — a new guard can freeze what it was protecting.** Booking now returns early
+while `not _soc_anchored` (writing `_estimated_soc = 100` into a PERSISTED field for an install with
+no reference was its own bug). That early return silently changed two coordinator sites that reach
+past every method and set the detector's privates directly: the stall→full anchor sets
+`_soc_anchored` and is fine; the SOC **self-heal** set only the deficit and the estimate, so after
+the gate its healed value stops moving for the rest of the charge — worse than the wrong-but-moving
+number it replaced. **Tell:** a gate added inside a class changes the contract for everyone who
+mutates that class from outside, and those callers are invisible to the class's own tests.
+**Assessed and left as-is:** the recorder-history cold-start seed in `async_seed_from_history` sets
+the field from summed post-full session energy — the same conflation, but a one-shot boot heuristic
+with no better information available; flipping it there yields "SOC 100 % forever" (#245). Marked in
+place so nobody "corrects" it to match. **Guard:**
+`tests/test_708_estimate_falls_while_charging.py` — a monotonicity pin (*the estimate may never fall
+while the charger delivers*, checked every cycle), the reporter's own arithmetic as the expected
+value, a disconnect pin that fails on the double-count, a taper-anchored-counter pin (verified RED
+against the restored branch: 94 % vs 38 %), a Wh-shaped counter pin, a #245-unanchored pin on the
+*persisted* `_estimated_soc` (not just the deficit — a display gate hides a bad value, it does not
+stop it being written), and an AST pin over the coordinator's self-heal block asserting it anchors
+what it writes. Refs #708 #715 #174 #245.
+**Sweep question:** for every field that accumulates a signed physical quantity — is its direction
+asserted by a test that would fail if one writer flipped, or is it only implied by the field's name?
+And: which writer runs in a state where no other writer will overwrite it? That one is unguarded by
+construction. Once you find a wrong sign: **is there a second writer whose opposite error has been
+cancelling it?** And before shipping the guard: **who mutates this object's fields from outside the
+class, and does the new precondition hold for them?**
+
 ---
 
 ## Meta-classes (the coherence audit hunts these too)

--- a/tests/test_708_estimate_falls_while_charging.py
+++ b/tests/test_708_estimate_falls_while_charging.py
@@ -1,0 +1,278 @@
+"""#708 — delivered energy was applied with the sign of *consumed* energy.
+
+Reporter (@Azlinon, 85 kWh Blazer EV, JuiceBox): started a session at 36 %,
+let it reach 38 %, then stopped the OnStar integration so the SOC sensor
+froze. The car kept charging — the EVSE metered 11.5 kWh — and "SOC (EST.)"
+walked *down* from 32 % to 25 %. His arithmetic: 11.5 / 85 × 0.92 ≈ 12.4 %,
+"almost exactly the amount of *decrease* I'm seeing".
+
+``_energy_since_full`` is a **deficit** — kWh the pack is below full. Seven
+sites agree on that reading: the day-rollover decay adds driving consumption,
+the sensor calibration sets ``(100 − soc)/100 × capacity``, the stall/taper
+anchor zeroes it at 100 %, ``on_session_end`` *subtracts* what a session
+delivered, and every display divides it out of 100.
+
+``update_energy`` — the one path that runs every cycle *while charging* —
+added the delivered kWh instead. So each cycle of a real charge pushed the
+estimate down by exactly what went into the pack. It never surfaced before
+because the taper detector normally reaches full and resets the deficit to
+zero; it takes a session that charges *without* topping out AND a sensor
+that stops updating to leave the inverted value on screen. That is the test
+the reporter ran.
+"""
+import ast
+import pathlib
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.ev_taper_detector import (
+    CHARGE_EFFICIENCY,
+    EVTaperDetector,
+)
+
+
+CAPACITY = 85.0          # reporter's pack
+ANCHOR_SOC = 38.0        # last reading before OnStar was stopped
+DELIVERED = 11.5         # kWh the EVSE metered while the sensor was frozen
+
+
+def _detector(capacity=CAPACITY):
+    return EVTaperDetector({"ev_battery_capacity_kwh": capacity})
+
+
+def _anchored():
+    """A detector calibrated by a real reading, then blinded (sensor gone)."""
+    det = _detector()
+    det.get_virtual_soc(ANCHOR_SOC)
+    return det
+
+
+def _expected(delivered_kwh, start=ANCHOR_SOC):
+    """The energy-accounted route to the same number.
+
+    ``anchor + delivered × eff / capacity`` is algebraically identical to the
+    deficit route (``100 − (deficit − delivered × eff) / capacity``) once the
+    deficit was set from that anchor — which is the point: the big "SOC
+    (EST.)" figure and the small "est. now ~54 %" hint stop being two
+    answers. The ±0.5 tolerance the callers use is float accumulation over a
+    few hundred incremental steps, nothing physical.
+    """
+    return start + delivered_kwh * CHARGE_EFFICIENCY / CAPACITY * 100.0
+
+
+# ──────────────────────────────────────────────
+# The reported bug
+# ──────────────────────────────────────────────
+class TestChargingRaisesTheEstimate:
+    def test_reporter_scenario_power_integration(self):
+        """11.5 kWh into a blinded 38 % pack lands near 50 %, not near 25 %."""
+        det = _anchored()
+        assert det.get_virtual_soc(None) == pytest.approx(ANCHOR_SOC, abs=0.1)
+
+        # ~10 s cycles at 11.5 kW, the way the coordinator feeds it
+        step = DELIVERED / 360.0
+        for _ in range(360):
+            det.update_energy(step)
+
+        # Reporter's own hand-calculation: "I should now be up to about 50%"
+        assert det.get_virtual_soc(None) == pytest.approx(_expected(DELIVERED), abs=0.5)
+
+    def test_estimate_never_walks_down_while_charging(self):
+        det = _anchored()
+        previous = det.get_virtual_soc(None)
+        for _ in range(60):
+            det.update_energy(0.05)
+            current = det.get_virtual_soc(None)
+            assert current >= previous - 1e-9, (
+                f"estimate fell from {previous:.2f}% to {current:.2f}% "
+                "while the charger was delivering energy"
+            )
+            previous = current
+        assert previous > ANCHOR_SOC
+
+    def test_the_counter_is_tracked_but_does_not_book_the_deficit(self):
+        """A lifetime counter measures energy put IN, never distance driven.
+
+        Reading it as the deficit is exactly what produced the sign error,
+        and its per-cycle delta is no safer a substitute: a counter that goes
+        unavailable for a stretch and then returns re-books the whole gap the
+        power integral already covered, and a charger publishing Wh has its
+        ~4 Wh cycles booked as 4 kWh — small enough to pass a "≤ capacity"
+        sanity bound and pin the estimate at 100 %. The counter keeps its
+        real job here, the taper anchor (``_hw_total_at_full``); the deficit
+        is booked from the integral alone.
+
+        Fed here in that second shape: nothing at the read site normalizes
+        the unit (``float(hw_state.state)``, raw), so a Wh counter's cycles
+        arrive as the bare number 4.0.
+        """
+        det = _anchored()
+        for i in range(1, 24):
+            det.update_energy(0.5, hw_total_energy_kwh=1_000_000.0 + i * 4.0)
+        assert det.get_virtual_soc(None) == pytest.approx(_expected(11.5), abs=0.5)
+        assert det._hw_total_last == pytest.approx(1_000_092.0)
+
+    def test_disconnect_does_not_book_the_session_a_second_time(self):
+        """``on_session_end`` used to be the other half of the cancelling pair.
+
+        Pre-fix the two errors hid each other: the live path ADDED the session
+        to the deficit, then at disconnect ``on_session_end`` SUBTRACTED it —
+        so the end state landed back near the truth and only the *live* number
+        was inverted. That is why this shipped. With the live path corrected,
+        the session-end subtraction is a straight double-count.
+
+        The primary charger's detector is the fleet detector
+        (``coordinator._ev_taper_detector`` resolves to
+        ``_ev_taper_detectors[primary_id]``), so both calls land on the same
+        object on every real install.
+        """
+        det = _anchored()
+        det._session_peak_w = 7000.0     # on_session_end ignores sub-500 W sessions
+        step = DELIVERED / 100.0
+        for _ in range(100):
+            det.update_energy(step)
+        during = det.get_virtual_soc(None)
+
+        det.on_session_end(DELIVERED)
+
+        assert det.get_virtual_soc(None) == pytest.approx(during, abs=0.1), (
+            "disconnect re-applied the whole session on top of what the live "
+            "path already booked"
+        )
+
+    def test_a_full_pack_clamps_at_100(self):
+        det = _anchored()
+        det.update_energy(200.0)          # far more than the pack can hold
+        assert det.get_virtual_soc(None) == pytest.approx(100.0, abs=0.01)
+        assert det.energy_since_full >= 0.0
+
+
+# ──────────────────────────────────────────────
+# Signs that must NOT flip (pins, green before and after)
+# ──────────────────────────────────────────────
+class TestSignsThatMustNotFlip:
+    def test_driving_still_lowers_the_estimate(self):
+        det = _anchored()
+        det.apply_daily_decay(8.5, 10.0)
+        assert det.get_virtual_soc(None) == pytest.approx(
+            ANCHOR_SOC - 8.5 / CAPACITY * 100.0, abs=0.1
+        )
+
+    def test_a_counter_that_reboots_is_ignored(self):
+        """A charger that resets its lifetime total must not move the estimate."""
+        det = _anchored()
+        det.update_energy(0.0, hw_total_energy_kwh=1000.0)
+        before = det.get_virtual_soc(None)
+        det.update_energy(0.0, hw_total_energy_kwh=0.0)      # rebooted to zero
+        det.update_energy(0.0, hw_total_energy_kwh=0.2)
+        assert det.get_virtual_soc(None) == pytest.approx(before, abs=0.01)
+
+    def test_unanchored_detector_stays_unanchored(self):
+        """#245: no reference yet → nothing to estimate from.
+
+        ``_estimated_soc`` is the persisted field, so it is the one that
+        matters: writing 100.0 into it here would survive the restart and
+        outlive the ``_soc_anchored`` display gate that is currently hiding
+        it. Leave both the deficit and the estimate untouched — an install
+        with no vehicle-SOC sensor is anchored by its first COMPLETED
+        session (``on_session_end``'s bootstrap), not mid-charge.
+        """
+        det = _detector()
+        det.update_energy(5.0)
+        assert det.energy_since_full == 0.0
+        assert det._estimated_soc == 0.0
+        assert det._soc_anchored is False
+
+    def test_first_session_still_bootstraps_without_a_soc_sensor(self):
+        """The bootstrap is now the ONLY way a sensorless install anchors.
+
+        ``update_energy`` is deliberately inert while unanchored, so removing
+        the session-end subtraction must not take the bootstrap with it.
+        """
+        det = EVTaperDetector(
+            {"ev_battery_capacity_kwh": 40, "ev_target_soc": 80}
+        )
+        det._session_peak_w = 7000.0
+        for _ in range(100):
+            det.update_energy(0.095)         # 9.5 kWh over the session
+        # ...every one of which was a no-op, by design — that is exactly why
+        # the bootstrap below cannot go with the double-count it was tangled
+        # up in.
+        assert det._energy_since_full == 0.0
+        assert det._soc_anchored is False
+
+        det.on_session_end(9.5)
+
+        assert det._soc_anchored is True
+        assert det._estimated_soc == pytest.approx(80.0, abs=2.0)
+
+    def test_full_detected_short_circuits(self):
+        det = _anchored()
+        det._full_detected = True
+        det._energy_since_full = 0.0
+        det.update_energy(5.0)
+        assert det.energy_since_full == 0.0
+
+    def test_a_taper_anchored_counter_no_longer_reconciles_the_deficit(self):
+        """The branch the reporter most likely actually hit.
+
+        Once a taper sets ``_hw_total_at_full``, that anchor OUTLIVES the
+        session (``reset_session`` clears ``_full_detected`` but not the hw
+        anchor), so the next session took the "reconcile from the counter"
+        branch: ``deficit = hw_total − hw_total_at_full``, i.e. *energy put
+        back in since the pack was last full* assigned to *how far below full
+        it is*. Those are opposites. A car that has been driven since full
+        reads deficit ≈ 0 (SOC 100 %) and then walks DOWN as it charges —
+        precisely the reported symptom, and immune to any per-cycle fix.
+        """
+        det = _detector()
+        det._hw_total_at_full = 1000.0      # taper anchored here last session
+        det.get_virtual_soc(ANCHOR_SOC)     # real reading: pack is at 38 %
+        det.update_energy(0.5, hw_total_energy_kwh=1005.0)
+
+        assert det.get_virtual_soc(None) == pytest.approx(_expected(0.5), abs=0.1), (
+            "the lifetime counter was reconciled back into the deficit — "
+            "delivered-since-full is not distance-below-full"
+        )
+
+
+# ──────────────────────────────────────────────
+# The coordinator's out-of-band writes
+# ──────────────────────────────────────────────
+class TestCoordinatorReachIns:
+    """Two coordinator sites set the detector's estimate from outside: the
+    stall→full anchor and the SOC self-heal. Both bypass every method on the
+    class, so the fields they must keep consistent are only enforced here.
+    """
+
+    def _self_heal_block(self):
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "coordinator" / "coordinator.py").read_text()
+        for node in ast.walk(ast.parse(src)):
+            if (isinstance(node, ast.If)
+                    and "SOC self-healed" in ast.dump(node)):
+                return node
+        raise AssertionError("SOC self-heal block not found in coordinator.py")
+
+    def test_the_self_heal_anchors_what_it_writes(self):
+        """#708 — ``update_energy`` is inert until ``_soc_anchored``.
+
+        The self-heal writes a plausible deficit and estimate when SOC has
+        bottomed out at 0 % while the car is demonstrably taking charge. If
+        it does not also anchor, every later cycle of that session skips the
+        booking and the healed number FREEZES for the rest of the charge —
+        which is worse than the wrong-but-moving value it replaced. Its
+        sibling twenty lines below (the stall→full anchor) already sets all
+        four fields; this is the one that forgot.
+        """
+        written = {
+            t.attr
+            for node in ast.walk(self._self_heal_block())
+            if isinstance(node, ast.Assign)
+            for t in node.targets
+            if isinstance(t, ast.Attribute)
+        }
+        assert "_soc_anchored" in written, (
+            "self-heal sets the estimate but never anchors it — update_energy "
+            f"will skip every subsequent cycle. Writes: {sorted(written)}"
+        )

--- a/tests/test_ev_taper_detector.py
+++ b/tests/test_ev_taper_detector.py
@@ -239,13 +239,19 @@ class TestVirtualSOC:
         assert det._energy_since_full == 0.0
 
     def test_soc_decreases_with_energy(self):
-        """SOC should decrease as energy is consumed."""
+        """SOC should decrease as energy is consumed.
+
+        Consumption enters through ``apply_daily_decay`` — the day-rollover
+        estimate of what the car drove. ``update_energy`` is the opposite
+        direction: it is fed ``ev_power × interval`` by the coordinator, i.e.
+        kWh the charger DELIVERED, and those repay the deficit (#708).
+        """
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)
 
         # Simulate 8 kWh consumed (20% of 40 kWh)
         det.reset_session()  # Clear full_detected for energy tracking
-        det.update_energy(8.0)
+        det.apply_daily_decay(8.0, 0.0)
         soc = det.get_virtual_soc()
         assert soc == pytest.approx(80.0, abs=0.5)
 
@@ -254,7 +260,7 @@ class TestVirtualSOC:
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)
         det.reset_session()  # Clear full_detected for energy tracking
-        det.update_energy(50.0)  # More than capacity
+        det.apply_daily_decay(50.0, 0.0)  # More than capacity
         soc = det.get_virtual_soc()
         assert soc == 0.0
 
@@ -263,7 +269,7 @@ class TestVirtualSOC:
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)
         det.reset_session()  # Clear full_detected for energy tracking
-        det.update_energy(8.0)
+        det.apply_daily_decay(8.0, 0.0)
 
         # Virtual would be 80%, but real is 65%
         soc = det.get_virtual_soc(vehicle_soc=65.0)
@@ -274,7 +280,7 @@ class TestVirtualSOC:
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)
         det.reset_session()  # Clear full_detected for energy tracking
-        det.update_energy(8.0)
+        det.apply_daily_decay(8.0, 0.0)
 
         # Real SOC = 72% → internal state should sync
         det.get_virtual_soc(vehicle_soc=72.0)
@@ -283,7 +289,7 @@ class TestVirtualSOC:
         assert det._energy_since_full == pytest.approx(11.2, abs=0.1)
 
         # Now if car API goes offline, virtual continues from 72%
-        det.update_energy(4.0)  # +4 kWh consumed
+        det.apply_daily_decay(4.0, 0.0)  # +4 kWh consumed
         soc = det.get_virtual_soc(vehicle_soc=None)
         # Should be ~62% (11.2 + 4 = 15.2 kWh → 100 - 15.2/40*100 = 62%)
         assert soc == pytest.approx(62.0, abs=0.5)
@@ -293,7 +299,7 @@ class TestVirtualSOC:
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)
         det.reset_session()  # Clear full_detected for energy tracking
-        det.update_energy(20.0)
+        det.apply_daily_decay(20.0, 0.0)
         assert det.get_virtual_soc() == pytest.approx(50.0, abs=0.5)
 
         # New session — reset and do another taper
@@ -324,7 +330,12 @@ class TestSessionAnchor:
         assert det._estimated_soc == pytest.approx(80.0, abs=2.0)
 
     def test_partial_charge_increases_soc(self):
-        """Charging should increase SOC by delivered energy."""
+        """Charging should increase SOC by delivered energy.
+
+        Booked through ``update_energy`` — the live path the coordinator
+        calls every cycle — not ``on_session_end``. Until #708 the two
+        disagreed in sign and the session end was the half that read right.
+        """
         det = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det)  # Anchor at 100%
 
@@ -336,6 +347,8 @@ class TestSessionAnchor:
 
         # Night charge delivers 9.5 kWh → +21.85% (with 92% efficiency)
         _feed_constant(det, 7000, 16, 10)
+        for _ in range(95):
+            det.update_energy(0.1)
         det.on_session_end(9.5)
         assert det._estimated_soc == pytest.approx(61.8, abs=2.0)
 
@@ -385,8 +398,10 @@ class TestSessionAnchor:
             temp_factor = EVTaperDetector.temperature_correction_factor(0)  # Winter
             det.apply_daily_decay(8.0, 10.0, temp_factor)
 
-            # Evening: night charge
+            # Evening: night charge (booked live, cycle by cycle)
             _feed_constant(det, 7000, 16, 10)
+            for _ in range(95):
+                det.update_energy(0.1)
             det.on_session_end(9.5)
 
         # SOC should not be negative — clamped at 0
@@ -419,7 +434,7 @@ class TestPersistence:
         det1 = EVTaperDetector(DEFAULT_CONFIG)
         _feed_taper_profile(det1)
         det1.reset_session()  # Clear full_detected for energy tracking
-        det1.update_energy(8.0)
+        det1.apply_daily_decay(8.0, 0.0)  # non-zero deficit to round-trip
         det1.get_virtual_soc()
 
         state = det1.get_state()


### PR DESCRIPTION
Closes the sign error @Azlinon reported in #708.

## The bug

`_energy_since_full` is a **deficit** — kWh the pack sits below full. Seven sites agree on that reading (decay adds driving consumption, calibration sets `(100−soc)/100 × capacity`, the taper/stall anchor zeroes it, every display divides it out of 100).

`update_energy` — the one path that runs **every cycle while charging** — added the delivered kWh instead. The reporter stopped his OnStar integration mid-charge and watched "SOC (EST.)" walk from 32 % down to 25 % while 11.5 kWh went into an 85 kWh pack: `11.5 / 85 × 0.92 ≈ 12.4 %`, *"almost exactly the amount of decrease I'm seeing"*.

## Why it shipped — the cancelling pair

The wrong-sign writer had a partner. `on_session_end` **subtracted** the session total at disconnect, so the value at rest landed back near the truth and only the *live* number was inverted. It takes a charge that stops short **and** a sensor that goes quiet to leave the wrong value visible.

That matters for the fix, not just the bug: correcting one half alone converts a hidden error into a loud one of the same size in the other direction — 5 kWh into a 40 kWh pack at 50 % would have read 73 % instead of 61.5 %. Both halves move together here.

## What changed

- **`update_energy`** subtracts, with the charge efficiency. It is now the only path that books.
- **`on_session_end`** keeps only its *bootstrap* branch — the sole way an install with no SOC sensor ever gets anchored, since booking is inert until anchored. It no longer re-books the session.
- **The hardware counter no longer feeds the deficit at all.** `deficit = hw_total − hw_total_at_full` assigns *energy put back in* to *distance below full* — the same error wearing a unit. It is reachable across sessions (`reset_session` clears `_full_detected`, not the taper's hw anchor), where it **overrides a fresh real reading**: 94 % for a pack the car had just reported at 38 %. Its per-cycle delta is no salvage either — it re-books the gap after a counter outage, and nothing normalizes units, so a Wh-publishing charger delivers 4 Wh as the bare number `4.0`. The counter is still tracked for the taper anchor.
- **Booking returns early while unanchored** — it had been writing `_estimated_soc = 100` into a *persisted* field, outliving the display gate that hides it (#245).
- **The SOC self-heal now anchors what it writes** (`coordinator.py`). The early return above changed the contract for the two coordinator sites that set the detector's privates from outside; the stall→full anchor already anchored, the self-heal did not, so its healed value would have frozen for the rest of the charge.

## Tests

Six call sites in `test_ev_taper_detector.py` had encoded the misreading (`update_energy(8.0)`, commented *"Simulate 8 kWh consumed"*, asserting SOC fell) and went green on it — corrected to `apply_daily_decay`; two more routed through the live path so they exercise what production calls.

New guard `tests/test_708_estimate_falls_while_charging.py` (12 tests): monotonicity per cycle, the reporter's own arithmetic as the expected value, the disconnect double-count, the taper-anchored counter (verified RED against the restored branch at 94 % vs 38 %), a Wh-shaped counter, `#245`-unanchored on the persisted field, and an AST pin that the self-heal anchors what it writes.

**5973 passed, 2 skipped, 0 failed** locally (3.12).

## Scope

Display-only. `_calculate_remaining_need` never reads `estimated_soc` (#446-banned) and the #715 stop-authority ceiling `energy_accounted_soc()` uses independent state, so charge decisions are unaffected. After the fix those two routes are algebraically identical — the big "SOC (EST.)" figure and the "est. now ~54 %" hint stop being two answers, which is the disagreement the reporter spotted on his own dashboard.

Bug class 35 added to `docs/BUG_CLASSES.md`.

Refs #708 #715 #174 #245