### PR TITLE
fix(#735): validate the charge-efficiency override, and pin the one site that refuses it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   38 %. An install with no reference yet still reports "unknown" rather than a
   guess (#245), and the 0 %-recovery path now anchors the value it writes so it
   keeps tracking for the rest of the charge instead of freezing.
+- 🔋 **A hand-set charge efficiency can no longer reach the SOC estimate
+  unchecked** (#735) — `ev_charger_efficiency` overrides the 0.92 AC→DC default
+  used to convert metered energy into pack energy. It has no settings field yet,
+  so the only way to set it is by editing stored configuration by hand, and
+  whatever was typed went straight into the arithmetic: `3.0` claimed the pack
+  absorbed three times what the charger measured, `0` froze the estimate, and a
+  stray word raised an error mid-cycle. Values outside the physical range now
+  fall back to the default. The two places that book delivered energy — every
+  cycle during a charge, and the first-session bootstrap for installs with no
+  SOC sensor — now resolve the setting through one accessor rather than
+  separately; #708 was precisely two halves of one calculation drifting apart.
+  The stop guard added in #708 deliberately keeps the fixed 0.92 and is now
+  pinned as such: it feeds a *ceiling*, so a lowered efficiency would charge
+  **longer**, and stopping late puts energy in the pack that cannot be taken
+  back out, where stopping early is corrected by the next sensor reading.
 
 # [1.7.6-beta.5] — 06.08.2026
 

--- a/coordinator/ev_taper_detector.py
+++ b/coordinator/ev_taper_detector.py
@@ -55,13 +55,24 @@ FULL_SESSION_ENERGY_FRAC_OF_CAPACITY = 0.025  # 2.5 % of pack capacity. Below
                                               # noise, not a completed charge.
 TAPER_RATIO_NEARLY_FULL = 50   # % — below this = nearly full
 TAPER_RATIO_DETECTED = 70     # % — below this + declining = taper confirmed
-CHARGE_EFFICIENCY = 0.92       # #708 — AC-side delivered → DC-pack fraction for
-                               # the energy-accounted SOC. Deliberately at the
-                               # optimistic end of the realistic 0.85–0.95 band:
-                               # over-estimating pack gain stops the charge AT or
-                               # slightly ABOVE the target, so "Min is a floor"
-                               # stays honest, while the stale-sensor overshoot
-                               # (lag × power, 7 % on the #708 report) is gone.
+CHARGE_EFFICIENCY = 0.92       # #708 — AC-side delivered → DC-pack fraction.
+                               # Default for the booked deficit (overridable via
+                               # ``ev_charger_efficiency``) AND the fixed value
+                               # for the stop ceiling (not overridable).
+                               #
+                               # #735 — why the ceiling refuses the override.
+                               # It feeds ``max(sensor, ceiling)``, so a LOWER
+                               # efficiency means a lower ceiling, more remaining
+                               # need, and a LONGER charge. The two errors are not
+                               # the same size: stopping early is recovered by the
+                               # next sensor reading (need goes positive, charging
+                               # resumes), while stopping late has already put the
+                               # energy in the pack — that is the #708 report, a
+                               # 30-min-stale reading at 11.5 kW running a 60 %
+                               # target to 67 %. So the ceiling sits at the
+                               # optimistic end of the realistic 0.85–0.95 band
+                               # and stays there: dialling it down would ship the
+                               # unrecoverable direction as a setting.
                                # Hard-coded by decision — no config knob.
 MAX_ETA_MINUTES = 60           # Cap completion estimate
 MAX_HEALTH_SAMPLES = 20        # Bounded battery health sample buffer
@@ -320,6 +331,43 @@ class EVTaperDetector:
             return 1.0 + (outdoor_temp_c - 28) * 0.046
         return 1.0
 
+    def _charge_efficiency(self) -> float:
+        """AC→DC fraction used when BOOKING delivered energy (#735).
+
+        The single resolver for ``ev_charger_efficiency``. Two sites answer
+        the same question about the same session — ``update_energy`` every
+        cycle and ``on_session_end``'s bootstrap — and #708 is the standing
+        reminder of what happens when two halves of one calculation drift.
+
+        The key has no config-flow field yet, so the only way to set it is by
+        hand-editing ``.storage/core.config_entries``: validate rather than
+        trust. Anything outside the band means somebody typed a percentage, a
+        sign, or a word — 3.0 would otherwise claim the pack absorbed three
+        times what the meter measured, and 0.001 would stall the estimate near
+        its starting value for a whole session while looking like it worked.
+
+        The floor is 0.5 rather than a bare ``> 0``: no EV onboard charger
+        throws away half its input, so anything under it is a typo, not a
+        rough install. ``bool`` is rejected before the float conversion — that
+        storage file is JSON, so a hand-edited ``true`` arrives as Python
+        ``True`` and ``float(True)`` is a perfectly valid-looking 1.0.
+
+        NOT used by ``energy_accounted_soc``: the stop ceiling deliberately
+        stays on the constant. See the CHARGE_EFFICIENCY comment for why the
+        override is refused there specifically.
+        """
+        raw = self._config.get("ev_charger_efficiency", CHARGE_EFFICIENCY)
+        if isinstance(raw, bool):
+            return CHARGE_EFFICIENCY
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            return CHARGE_EFFICIENCY
+        # NaN fails both comparisons, so this also screens it out.
+        if not 0.5 <= value <= 1.0:
+            return CHARGE_EFFICIENCY
+        return value
+
     def update_energy(
         self,
         ev_energy_increment_kwh: float,
@@ -391,7 +439,7 @@ class EVTaperDetector:
         if ev_energy_increment_kwh <= 0:
             return
 
-        efficiency = self._config.get("ev_charger_efficiency", CHARGE_EFFICIENCY)
+        efficiency = self._charge_efficiency()
         self._energy_since_full = max(
             0.0, self._energy_since_full - ev_energy_increment_kwh * efficiency
         )
@@ -553,7 +601,7 @@ class EVTaperDetector:
         # install ever gets a reference from.
         if not self._full_detected and not self._soc_anchored \
                 and session_energy_kwh > 0 and capacity > 0:
-            efficiency = self._config.get("ev_charger_efficiency", CHARGE_EFFICIENCY)
+            efficiency = self._charge_efficiency()
             energy_to_battery = session_energy_kwh * efficiency
             # Assume car arrived at target_soc minus what it accepted
             target = self._config.get("ev_target_soc", 80)

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -474,6 +474,11 @@ effective_soc = max(sensor, anchor + delivered_since_anchor_kwh × 0.92 ÷ capac
 - The anchor is **session-scoped only** — never persisted across restarts, and reset the moment
   the car disconnects (per charger, so a second charger's session can never leak into the first
   one's target decision).
+- The **0.92 here is fixed and not configurable**, deliberately. It sets a ceiling, so a lower
+  figure would make SEM charge *longer* — and the two mistakes are not equal. Stopping a little
+  early costs nothing: the next sensor reading lands under target and charging resumes. Stopping
+  late has already put the energy in the pack, and that is the overshoot this whole section
+  exists to prevent.
 - You'll see a mobile notification on both the early stop and any resume, and a small info line
   under the SOC gauge on the EV card (e.g. "Car: 55% (28 min ago) · est. now ~59%") — the gauge
   itself always shows the raw sensor value.

--- a/tests/test_735_efficiency_single_source.py
+++ b/tests/test_735_efficiency_single_source.py
@@ -1,0 +1,241 @@
+"""#735 — the two charge-efficiency answers are deliberate, and asymmetric.
+
+``ev_charger_efficiency`` overrides the 92 % AC→DC default. It reaches two of
+the three sites that convert metered AC energy into pack energy:
+
+    update_energy       booking the deficit    → honours the override
+    on_session_end      first-session bootstrap→ honours the override
+    energy_accounted_soc  the stop ceiling     → CONSTANT, by decision
+
+That looked like a plain inconsistency when #735 was filed. It is not, and
+this file exists so nobody "fixes" it — including whoever reads the three
+call sites next and sees two of them agree.
+
+The ceiling feeds ``effective_soc = max(sensor, ceiling)`` in
+``_calculate_remaining_need`` (coordinator.py:6014). Run the direction:
+
+    lower efficiency → lower ceiling → larger remaining need → charge LONGER
+    higher efficiency → higher ceiling → smaller need → stop EARLIER
+
+and the two errors are not the same size:
+
+  * Stopping early is **recoverable**. The sensor stays primary; when the
+    next real reading lands below target, remaining need goes positive and
+    charging resumes (coordinator.py:5742-5743 even un-latches the notify).
+  * Stopping late is **not**. The energy is already in the pack. That is the
+    whole #708 report — a 30-minute-stale OnStar reading at 11.5 kW ran a
+    60 % target to 67 %.
+
+So the ceiling deliberately sits at the optimistic end of the realistic
+0.85–0.95 band. Letting a user dial it down to 0.80 would hand them back the
+unrecoverable failure mode as a configuration option, which is not a knob
+worth shipping. The override still governs everything the user *reads* —
+which is what they actually wanted it for.
+"""
+import ast
+import pathlib
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.ev_taper_detector import (
+    CHARGE_EFFICIENCY,
+    EVTaperDetector,
+)
+
+from .test_708_soc_lag_ceiling import CAPACITY, _feed_energy
+
+
+LOW_EFF = 0.80          # single-phase, cold pack, preconditioning running
+ANCHOR = 55.0
+DELIVERED = 4.0
+
+
+def _detector(**extra):
+    return EVTaperDetector({"ev_battery_capacity_kwh": CAPACITY, **extra})
+
+
+class TestTheOverrideGovernsWhatTheUserReads:
+    def test_the_display_estimate_honours_the_override(self):
+        det = _detector(ev_charger_efficiency=LOW_EFF)
+        det.get_virtual_soc(ANCHOR)
+        det.update_energy(DELIVERED)
+        expected = ANCHOR + DELIVERED * LOW_EFF / CAPACITY * 100.0
+        assert det.get_virtual_soc(None) == pytest.approx(expected, abs=0.15)
+
+    def test_the_bootstrap_lands_on_target_whatever_the_efficiency(self):
+        """Not a tautology — a real property of the bootstrap, worth pinning.
+
+        It assumes the car arrived at ``target − soc_added`` and then gained
+        ``soc_added``, so the two terms cancel and the result is *exactly*
+        ``target`` for any efficiency, as long as the session did not deliver
+        more than the target itself. Efficiency only becomes observable in
+        the clamped branch below.
+
+        Recording it because it is a trap: the obvious "does the bootstrap
+        honour the override" test is written here, passes, and proves nothing.
+        """
+        results = []
+        for eff in (LOW_EFF, CHARGE_EFFICIENCY, 1.0):
+            det = EVTaperDetector({
+                "ev_battery_capacity_kwh": 40,
+                "ev_target_soc": 80,
+                "ev_charger_efficiency": eff,
+            })
+            det._session_peak_w = 7000.0
+            det.on_session_end(10.0)
+            results.append((det._estimated_soc, det._energy_since_full))
+        assert results == [pytest.approx(r) for r in [(80.0, 8.0)] * 3]
+
+    def test_the_bootstrap_honours_the_override_where_it_can_show(self):
+        """The clamped branch: session delivers more than the target itself.
+
+        ``pre_charge_soc`` floors at 0, the cancellation breaks, and the
+        efficiency finally reaches the result — 25 kWh into a 40 kWh pack is
+        50 % of it at 0.80 but 57.5 % at 0.92.
+        """
+        def _bootstrap(eff):
+            det = EVTaperDetector({
+                "ev_battery_capacity_kwh": 40,
+                "ev_target_soc": 50,
+                "ev_charger_efficiency": eff,
+            })
+            det._session_peak_w = 7000.0
+            det.on_session_end(25.0)
+            return det._estimated_soc
+
+        assert _bootstrap(LOW_EFF) == pytest.approx(50.0, abs=0.1)
+        assert _bootstrap(CHARGE_EFFICIENCY) == pytest.approx(57.5, abs=0.1)
+
+
+class TestTheStopCeilingIsDeliberatelyNotConfigurable:
+    def test_the_ceiling_ignores_a_lowered_override(self):
+        """Pin: a user cannot dial the stop guard back toward overshoot."""
+        det = _detector(ev_charger_efficiency=LOW_EFF)
+        det.get_virtual_soc(ANCHOR)
+        _feed_energy(det, DELIVERED)
+        at_constant = ANCHOR + DELIVERED * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert det.energy_accounted_soc() == pytest.approx(at_constant, abs=0.15)
+
+    def test_the_ceiling_ignores_a_raised_override(self):
+        det = _detector(ev_charger_efficiency=0.99)
+        det.get_virtual_soc(ANCHOR)
+        _feed_energy(det, DELIVERED)
+        at_constant = ANCHOR + DELIVERED * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert det.energy_accounted_soc() == pytest.approx(at_constant, abs=0.15)
+
+    def test_a_lower_override_would_have_charged_longer(self):
+        """The reason, made numeric rather than left in a comment.
+
+        If the ceiling honoured 0.80, the same delivered energy would leave
+        more 'remaining need' against the same target — i.e. keep charging.
+        Against a stale sensor that is exactly the #708 overshoot.
+        """
+        honoured = ANCHOR + DELIVERED * LOW_EFF / CAPACITY * 100.0
+        as_shipped = ANCHOR + DELIVERED * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert honoured < as_shipped, "premise of the whole decision"
+
+        target = 60.0
+        need_if_honoured = max(0.0, (target - honoured) / 100 * CAPACITY)
+        need_as_shipped = max(0.0, (target - as_shipped) / 100 * CAPACITY)
+        assert need_if_honoured > need_as_shipped
+
+    def test_the_constant_says_so_in_the_source(self):
+        """The decision lives in a comment; keep the comment load-bearing.
+
+        Read the whole trailing comment block rather than a fixed slice —
+        a character window silently stops covering the text it is meant to
+        guard the moment someone adds a line to it.
+        """
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "coordinator" / "ev_taper_detector.py").read_text()
+        lines = src.splitlines()
+        start = next(i for i, ln in enumerate(lines)
+                     if ln.startswith("CHARGE_EFFICIENCY = "))
+        block = [lines[start]]
+        for ln in lines[start + 1:]:
+            if not ln.strip().startswith("#"):
+                break
+            block.append(ln)
+        block = "\n".join(block)
+        assert "no config knob" in block, (
+            "CHARGE_EFFICIENCY's rationale comment was removed or reworded — "
+            f"if the decision changed, this test and #735 change with it:\n{block}"
+        )
+
+
+class TestTheTwoBookingSitesAgreeWithEachOther:
+    """The half that IS a single-source requirement.
+
+    ``update_energy`` and ``on_session_end`` answer the same question about
+    the same session. They may not drift apart — that is how #708's
+    cancelling pair survived a year.
+    """
+
+    ACCESSOR = "_charge_efficiency"
+
+    def _readers_of(self, needle, kind):
+        src = (pathlib.Path(__file__).resolve().parent.parent
+               / "coordinator" / "ev_taper_detector.py").read_text()
+        readers = set()
+        for fn in ast.walk(ast.parse(src)):
+            if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            for node in ast.walk(fn):
+                if kind == "name":
+                    if isinstance(node, ast.Name) and node.id == needle:
+                        readers.add(fn.name)
+                elif isinstance(node, ast.Constant) and node.value == needle:
+                    readers.add(fn.name)
+        return readers
+
+    def test_only_the_accessor_resolves_the_config_key(self):
+        readers = self._readers_of("ev_charger_efficiency", "const")
+        assert readers == {self.ACCESSOR}, (
+            "the override must be resolved (and validated) in one place. "
+            f"Readers: {sorted(readers)}. If you only wanted to LOG the "
+            "value, log the accessor's return instead of re-reading the key "
+            "— this guard cannot tell the two apart, and the raw value is "
+            "the unvalidated one anyway."
+        )
+
+    def test_the_ceiling_still_reads_the_bare_constant(self):
+        """Deliberate — and pinned, so the exception stays visible."""
+        readers = self._readers_of("CHARGE_EFFICIENCY", "name")
+        assert readers == {self.ACCESSOR, "energy_accounted_soc"}, (
+            "expected exactly two constant readers: the accessor's fallback "
+            f"and the deliberately-fixed ceiling. Found: {sorted(readers)}"
+        )
+
+    @pytest.mark.parametrize("bad", [
+        0, -0.5, "", None, "abc", 3.0, 92,
+        float("nan"), float("inf"),
+        0.001,      # would stall the estimate for a whole session
+        True,       # JSON `true` — float(True) is a valid-looking 1.0
+        False,
+        [0.9], {"v": 0.9},
+    ])
+    def test_a_nonsense_override_falls_back_to_the_default(self, bad):
+        """A hand-edited storage key is the only way in — assume nothing.
+
+        Zero or negative would freeze or invert the booking; >1 would claim
+        the pack absorbed more than the meter measured; 92 is the percentage
+        mistake; 0.001 looks like it works while going nowhere.
+        """
+        det = _detector(ev_charger_efficiency=bad)
+        det.get_virtual_soc(ANCHOR)
+        det.update_energy(DELIVERED)
+        expected = ANCHOR + DELIVERED * CHARGE_EFFICIENCY / CAPACITY * 100.0
+        assert det.get_virtual_soc(None) == pytest.approx(expected, abs=0.15)
+
+    @pytest.mark.parametrize("good", [0.5, 0.85, 1.0, "0.88"])
+    def test_a_plausible_override_is_accepted(self, good):
+        """The band has to stay wide enough to be useful, not just safe.
+
+        Includes the string form: a hand-edited JSON value is as likely to be
+        quoted as not, and rejecting `"0.88"` would make the key look broken.
+        """
+        det = _detector(ev_charger_efficiency=good)
+        det.get_virtual_soc(ANCHOR)
+        det.update_energy(DELIVERED)
+        expected = ANCHOR + DELIVERED * float(good) / CAPACITY * 100.0
+        assert det.get_virtual_soc(None) == pytest.approx(expected, abs=0.15)


### PR DESCRIPTION
Refs #735. Fix scope only — the config-flow field that issue actually asks for stays parked under the freeze.

Two real problems sat under the #735 filing, and one claim in that filing was wrong.

### The override was unvalidated

`ev_charger_efficiency` has no settings field, so the only way to set it is by hand-editing `.storage/core.config_entries` — which is precisely the reason to validate it rather than trust it. Whatever was typed went straight into the arithmetic behind a number users read off the dashboard:

| value | what it did |
|---|---|
| `3.0` | claimed the pack absorbed three times what the charger metered |
| `92` | the percentage mistake, same effect ×100 |
| `0` | froze the estimate for the whole session |
| `0.001` | crawled, while looking like it worked |
| `""` / `null` / `"abc"` | raised mid-cycle |
| `true` | JSON bool → `float(True)` is a valid-looking **1.0** |

Band is now 0.5–1.0 with bools rejected before conversion; anything else falls back to the default. The floor is 0.5 rather than a bare `> 0` because no onboard charger throws away half its input — under that it is a typo, not a rough install.

### The two booking sites resolved the key separately

`update_energy` (every cycle) and `on_session_end`'s bootstrap both answer the same question about the same session, and each read the config independently. #708 was exactly two halves of one calculation drifting apart, so they now share one accessor, with an AST test holding it at one reader.

### The third site keeps the hardcoded constant — deliberately

The original #735 filing called this an inconsistency and asked for all three to be routed through one accessor. **That was a misreading**, and the naive fix would have reintroduced #708 as a setting. `energy_accounted_soc()` feeds `max(sensor, ceiling)`:

```
lower efficiency → lower ceiling → larger remaining need → charge LONGER
higher efficiency → higher ceiling → smaller need → stop EARLIER
```

Stopping early is recovered by the next sensor reading. Stopping late has already put the energy in the pack — that *is* the #708 report, a 30-minute-stale reading at 11.5 kW running a 60 % target to 67 %. The hardcode is now pinned by test, and the rationale comment that argued for it — which stated the direction backwards while reaching the right conclusion — is rewritten. Issue body corrected too.

### Note on the tests

`on_session_end`'s bootstrap sets `pre_charge_soc = target − soc_added` and then adds `soc_added` back, so the two cancel to *exactly* `target` and efficiency is unobservable in the common case. The obvious "does the bootstrap honour the override" test passes there and proves nothing — caught in review. Routing is proven in the clamped branch instead (session delivers more than the target), and the invariance is recorded as its own test with a signpost so the next person doesn't fall in.

All three new guards mutation-checked: hardcoding `on_session_end` → 2 failures; floor 0.5 → 0.0 → the `0.001` case fails; bool guard removed → the `True` case fails.

### Scope

- No behaviour change for any install that has not hand-edited the key.
- `CHARGE_EFFICIENCY`'s value is unchanged.
- No config-flow field, no translation keys — that is the enhancement half of #735 and stays parked.