### PR TITLE
docs: fix four broken links (Solcast, HACS install, project board, dead 1.7 tags)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6424,7 +6424,7 @@ Also unblocks #453 by structurally fixing #457 in the same release: the diagram 
 
 ## 🎉 Stable Release
 
-_Consolidates [1.7.2-beta.1](https://github.com/traktore-org/sem-community/releases/tag/v1.7.2-beta.1) through [1.7.2-beta.7](https://github.com/traktore-org/sem-community/releases/tag/v1.7.2-beta.7). 19 commits since [1.7.1](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1). 24 hours of HA-PROD soak with zero errors._
+_Consolidates `1.7.2-beta.1` through [1.7.2-beta.7](https://github.com/traktore-org/sem-community/releases/tag/v1.7.2-beta.7). 19 commits since [1.7.1](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1). 24 hours of HA-PROD soak with zero errors._
 
 ### 🔥 New: Hot Water boiler control (#454)
 
@@ -6823,7 +6823,7 @@ Massive thanks to @RienduPre for the persistent #432 reports — they directly d
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.16](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.16)_
+_Changes since `1.7.1-beta.16`_
 
 ### 🔍 Heat-pump observability — diagnose silent registration failures remotely (#432)
 
@@ -6869,7 +6869,7 @@ Full suite: **3239 pass, 9 skipped, 0 fail** (was 3217 — net +22 after the hea
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.15](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.15)_
+_Changes since `1.7.1-beta.15`_
 
 ### 🐛 EV charging logic strictly honours `ev_target_type` per charger (#446)
 
@@ -6918,7 +6918,7 @@ PROD had `ev_target_type="soc"` saved but no `vehicle_soc_entity` configured (a 
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.14](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.14)_
+_Changes since `1.7.1-beta.14`_
 
 ### 🐛 Reliable home consumption — two-tier hold against sensor-staleness skew (#444)
 
@@ -6946,7 +6946,7 @@ The inconsistency tier only fires when the raw balance is strongly negative — 
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.13](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.13)_
+_Changes since `1.7.1-beta.13`_
 
 ### 🐛 Stop KEBA solar-path current oscillation that aborts EV sessions
 
@@ -7014,7 +7014,7 @@ Walked every available charge mode on PROD (target raised from 2 kWh → 10 kWh 
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.12](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.12)_
+_Changes since `1.7.1-beta.12`_
 
 ### 🐛 Configuration tab save pipeline — actually works now (#442)
 
@@ -7042,7 +7042,7 @@ Sections covered: tariff (export rate + mode select), heat pump (priority slider
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.11](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.11)_
+_Changes since `1.7.1-beta.11`_
 
 ### ✨ Every OptionsFlow step now inline in the Configuration tab (#442)
 
@@ -7098,7 +7098,7 @@ Fresh installs now take **2 forms instead of 3**, and every later tweak lives **
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.9](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.9)_
+_Changes since `1.7.1-beta.9`_
 
 ### 🚀 HA Repairs — graceful unavailability channel
 
@@ -7120,7 +7120,7 @@ Honors the HA quality-check feedback "should handle unavailability gracefully in
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.8](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.8)_
+_Changes since `1.7.1-beta.8`_
 
 ### 🐛 Bugfix — quiet sensor-recovery log spam (HA quality-check feedback)
 
@@ -7174,7 +7174,7 @@ _Changes since [1.7.1-beta.5](https://github.com/traktore-org/sem-community/rele
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.4](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.4)_
+_Changes since `1.7.1-beta.4`_
 
 ### 🚀 Renames + polish
 
@@ -7210,7 +7210,7 @@ _Changes since [1.7.1-beta.3](https://github.com/traktore-org/sem-community/rele
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.2](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.2)_
+_Changes since `1.7.1-beta.2`_
 
 ### 🐛 Bugfixes
 
@@ -7224,7 +7224,7 @@ _Changes since [1.7.1-beta.2](https://github.com/traktore-org/sem-community/rele
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.1-beta.1](https://github.com/traktore-org/sem-community/releases/tag/v1.7.1-beta.1)_
+_Changes since `1.7.1-beta.1`_
 
 ### 🐛 Bugfixes
 
@@ -7297,7 +7297,7 @@ Following the `classifier_path` pattern introduced in #359, **10 stale modules**
 
 ## 🧪 Beta Release — v1.7.1 audit batch 4
 
-_Changes since [1.7.0-beta.25](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.25)_
+_Changes since `1.7.0-beta.25`_
 
 Two more modules audited beyond the original Top-12, picked up by widening the staleness cutoff from 30 days to 2 weeks. Big-module focus on highest-leverage decisions, medium-module full coverage.
 
@@ -7314,7 +7314,7 @@ Two more modules audited beyond the original Top-12, picked up by widening the s
 
 ## 🧪 Beta Release — v1.7.1 audit batch 3
 
-_Changes since [1.7.0-beta.24](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.24)_
+_Changes since `1.7.0-beta.24`_
 
 Third batch of v1.7.1 audit telemetry. Closes the rest of the Top-12 backlog: two modules get telemetry surfaces, four close as no-change (pure data registries + a stateless translation helper that doesn't fit the path-attribute pattern). Pure additive observability, zero behavior change.
 
@@ -7332,7 +7332,7 @@ Third batch of v1.7.1 audit telemetry. Closes the rest of the Top-12 backlog: tw
 
 ## 🧪 Beta Release — v1.7.1 audit batch 2
 
-_Changes since [1.7.0-beta.23](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.23)_
+_Changes since `1.7.0-beta.23`_
 
 Second batch of v1.7.1 audit telemetry — four modules in one beta because they don't share state. Pure additive observability, zero behavior change in published return values.
 
@@ -7351,7 +7351,7 @@ Second batch of v1.7.1 audit telemetry — four modules in one beta because they
 
 ## 🧪 Beta Release — first v1.7.1 audit
 
-_Changes since [1.7.0-beta.22](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.22)_
+_Changes since `1.7.0-beta.22`_
 
 First behavioral audit of the v1.7.1 stabilization program (umbrella #419). Pure additive observability on `HotWaterController` — zero behavior change.
 
@@ -7456,7 +7456,7 @@ The #404 per-battery direction bug on Sessy installs is **not fixed yet** in thi
 
 ## 🧪 Beta Release
 
-_Changes since [1.7.0-beta.16](https://github.com/traktore-org/sem-community/releases/tag/v1.7.0-beta.16)_
+_Changes since `1.7.0-beta.16`_
 
 ### 🐛 Bugfixes
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Before setting up SEM, make sure you have:
 - **Optional but recommended:**
   - Battery SOC (%) and power (W) sensors
   - An EV charger controllable via HA (KEBA, Wallbox, go-eCharger, Easee, Zaptec, ChargePoint, Heidelberg, etc.)
-  - [Solcast PV Solar](https://github.com/oziee/ha-solcast-solar), [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) or [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) for solar forecasts
+  - [Solcast PV Solar](https://github.com/BJReplay/ha-solcast-solar), [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) or [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) for solar forecasts
   - Tibber, Nordpool, or aWATTar integration for dynamic tariffs
 
 ---
@@ -627,9 +627,10 @@ checklist is exactly what the review holds you to.
 
 ### How work is tracked
 
-Every open issue and PR carries a state label, mirrored onto the
-[SEM Board](https://github.com/users/traktore-org/projects/2). The label is
-the source of truth.
+Every open issue and PR carries a state label, mirrored onto a maintainer
+project board. **The label is the source of truth** — it is on the issue
+itself, so you can always see the state of anything you reported without
+needing access to the board.
 
 | State | Meaning |
 |---|---|

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -18,7 +18,7 @@ Go to **Settings > Dashboards > Energy**. You must have at least a solar product
 
 **2. HACS installed**
 
-SEM is distributed through HACS. If you have not installed HACS, follow the [HACS installation guide](https://hacs.xyz/docs/setup/download/) first.
+SEM is distributed through HACS. If you have not installed HACS, follow the [HACS installation guide](https://hacs.xyz/docs/use/download/download/) first.
 
 **3. No EV charger? That is fine**
 

--- a/docs/RELEASE_NOTES_2.0_DRAFT.md
+++ b/docs/RELEASE_NOTES_2.0_DRAFT.md
@@ -1,5 +1,11 @@
 # v2.0.0 — Trustworthy
 
+<!-- NOTE: this file is used verbatim as a GitHub RELEASE BODY, where
+     relative links resolve against the REPO ROOT, not against docs/.
+     Use ABSOLUTE links here even for files in this directory — a
+     relative one passes the docs-link test and then 404s in the
+     published release (hit on v2.0.0). -->
+
 SEM 2.0 adds almost nothing you have to learn. It makes what SEM already did
 **believable**: the same decisions, no longer changing their mind for reasons
 nobody can see.
@@ -92,7 +98,7 @@ They paid for the work *and* did some of it.
 
 Thank you — and thank you equally to everyone who reported something broken and
 then patiently re-tested a fix on a real house. The ✅ column of the
-[supported hardware table](SUPPORTED_HARDWARE.md) is entirely made of
+[supported hardware table](https://github.com/traktore-org/sem-community/blob/main/docs/SUPPORTED_HARDWARE.md) is entirely made of
 those people.
 
 ## Requirements

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -941,7 +941,7 @@ Set tariff mode to "Calendar" for custom time-of-use schedules. Define rules lik
 
 ## Solar Forecast
 
-Install [Solcast PV Solar](https://github.com/oziee/ha-solcast-solar), [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) or [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) for forecast-based features:
+Install [Solcast PV Solar](https://github.com/BJReplay/ha-solcast-solar), [Forecast.Solar](https://www.home-assistant.io/integrations/forecast_solar/) or [Open-Meteo Solar Forecast](https://github.com/rany2/ha-open-meteo-solar-forecast) for forecast-based features:
 
 - `sensor.sem_forecast_today_kwh` — expected total production today (kWh)
 - `sensor.sem_forecast_tomorrow_kwh` — expected total production tomorrow (kWh)


### PR DESCRIPTION
Four broken links, three of them on pages a new user reads first. Found by fetching all 92 external links in the docs rather than eyeballing them.

| link | was | now |
|---|---|---|
| Solcast PV Solar | `oziee/ha-solcast-solar` → **404** (project moved) | `BJReplay/ha-solcast-solar` |
| HACS install guide | `hacs.xyz/docs/setup/download/` → **404** (site restructured) | `hacs.xyz/docs/use/download/download/` |
| SEM Board | private project → **404** for every reader | link removed; text now says the true thing — the state label lives on the issue itself |
| 17 CHANGELOG links | deleted 1.7 pre-release tags → **404** | delinked, version text kept |

The Solcast and HACS ones are in README / USER_GUIDE / QUICK_START — i.e. step one of setting SEM up.

Also documents the trap that put a bad link in the v2.0.0 release body (already fixed on the release itself): `docs/RELEASE_NOTES_2.0_DRAFT.md` is used **verbatim** as a GitHub release body, where relative links resolve against the **repo root** — so a link that is correct for a file in `docs/` (and passes the docs-link test) 404s once published. That file now warns about it and uses absolute links.

Docs only — no code changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Solcast PV Solar integration links to the current repository.
  * Updated the HACS installation guide link in the Quick Start Guide.
  * Clarified issue tracking guidance and identified the state label as the source of truth.
  * Corrected the supported hardware link in the draft release notes for published release compatibility.
  * Improved changelog formatting by displaying referenced versions without hyperlinks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->