### PR TITLE
#855 stage 4: brand quirks are registry rows — the generic layer reads, never knows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+- 🧱 **The generic device layer now learns brands from the registry — stage 4
+  closes the #855 arc**: the last brand knowledge that was *code* in the
+  generic layer (the KEBA watchdog-refresh table and two log strings) moved
+  into the hardware matrix as data on the brand's own row. A future brand
+  with a failsafe quirk adds a row, never a line of generic code. Behaviour
+  is byte-identical — the measured 5 s KEBA heartbeat, the failsafe arming,
+  and the #740 dead-man are all pinned by the existing tests, which pass
+  untouched.
+
 - 🔭 **Every installed forecast source is scored against your actual roof**
   (#822): SEM now reads what *all* your solar-forecast integrations say, not
   only the one it uses, and publishes them beside the accuracy each has

--- a/consts/hardware_matrix.py
+++ b/consts/hardware_matrix.py
@@ -30,6 +30,18 @@ tests/test_split_grid_integration.py (A-F); ``ED`` = handled generically
 through the HA Energy Dashboard mapping with sign auto-detection.
 """
 
+
+def charger_watchdog_refresh_map() -> dict:
+    """token -> seconds, from every charger row that declares the quirk
+    (#855 stage 4). This is how ``devices/base.py`` learns which brands
+    need a faster write heartbeat — a new brand adds a ROW here, never a
+    line in the generic layer."""
+    return {
+        r["domain_token"]: float(r["watchdog_refresh_s"])
+        for r in CHARGERS
+        if r.get("domain_token") and r.get("watchdog_refresh_s")
+    }
+
 INVERTERS = [
     {"brand": "Huawei Solar", "integration": "huawei_solar", "pattern": "A",
      "discharge_control": True, "status": "tested-live",
@@ -119,6 +131,12 @@ INVERTERS = [
 
 CHARGERS = [
     {"brand": "KEBA P30/P40", "control": "service: keba.set_current",
+     # Operational quirk (#855 stage 4): the P30's device-side failsafe can
+     # trip under the generic 60 s write heartbeat — PROD showed it reverting
+     # to its 6 A failsafe current in well under 30 s (the 6<->9 A flap), so
+     # steady-state commands are re-asserted every coordinator cycle. The
+     # generic device layer READS this from the row; it hardcodes no brand.
+     "domain_token": "keba", "watchdog_refresh_s": 5.0,
      "status": "tested-live",
      "evidence": "SEM production wallbox, daily; #616/#763 (onkelfu) two "
                  "P30 C driven over plain Modbus, not the KEBA integration"},

--- a/devices/base.py
+++ b/devices/base.py
@@ -45,9 +45,13 @@ WRITE_HEARTBEAT_INTERVAL_S = DEFAULT_WRITE_HEARTBEAT_INTERVAL_S
 # pausing the car to ~120 W), so 30 s still raced it. Per-cycle re-writes outrun
 # any failsafe with a timeout ≥ ~1 cycle; a box that reverts sub-cycle is a
 # device-side failsafe-config problem SEM cannot out-write.
-_BRAND_WATCHDOG_REFRESH_S = {
-    "keba": 5.0,
-}
+# (#855 stage 4) Built from the hardware matrix — the one brand registry.
+# A brand whose failsafe needs a faster heartbeat declares
+# ``domain_token`` + ``watchdog_refresh_s`` on its CHARGERS row; this file
+# never learns a new brand again.
+from ..consts.hardware_matrix import charger_watchdog_refresh_map
+
+_BRAND_WATCHDOG_REFRESH_S = charger_watchdog_refresh_map()
 
 # #546 — managed-neutralize failsafe timeout. Long enough that the per-cycle
 # current writes never let it trip during normal charging (vs the old 30 s that
@@ -2577,8 +2581,9 @@ class CurrentControlDevice(ControllableDevice):
         disable it. ``steady_failsafe`` (default on) controls persistence."""
         if not bool(getattr(self, "arm_failsafe_enabled", True)):
             _LOGGER.debug(
-                "%s: not arming the charger failsafe (keba_arm_failsafe off) — "
-                "a Repair guides disabling the box's own failsafe", self.name,
+                "%s: not arming the charger failsafe (arm-failsafe option "
+                "off) — a Repair guides disabling the box's own failsafe",
+                self.name,
             )
             return
         domain = (self.charger_service or "").split(".", 1)[0]
@@ -2591,8 +2596,9 @@ class CurrentControlDevice(ControllableDevice):
             await self.send(domain, "set_failsafe", {"failsafe_timeout": FAILSAFE_TIMEOUT_S,
                  "failsafe_fallback": fallback_a, "failsafe_persist": persist})
             _LOGGER.info(
-                "%s: KEBA failsafe set non-tripping (timeout=%ds, fallback=%dA, "
-                "persist=%d)", self.name, FAILSAFE_TIMEOUT_S, fallback_a, persist,
+                "%s: charger failsafe set non-tripping via %s.set_failsafe "
+                "(timeout=%ds, fallback=%dA, persist=%d)", self.name, domain,
+                FAILSAFE_TIMEOUT_S, fallback_a, persist,
             )
         except Exception as e:  # noqa: BLE001
             _LOGGER.warning("Failed to set charger failsafe: %s", e)
@@ -2980,7 +2986,8 @@ class CurrentControlDevice(ControllableDevice):
                     _LOGGER.warning(
                         "stop_session(%s): charger_service=%s configured but "
                         "%s.disable service is not registered — falling back to "
-                        "_set_current(0) which does NOT stop KEBA-style contactors. "
+                        "_set_current(0), which does NOT open a service-"
+                        "controlled contactor. "
                         "Check that the underlying charger integration is loaded.",
                         self.name, self.charger_service, domain,
                     )

--- a/tests/brand_footprint_baseline.json
+++ b/tests/brand_footprint_baseline.json
@@ -1,19 +1,19 @@
 {
   "_comment": [
     "#855 shrink-only ratchet: brand names in the GENERIC device layer.",
-    "devices/base.py is meant to know about DEVICES, not about brands —",
+    "devices/base.py is meant to know about DEVICES, not about brands \u2014",
     "the adapters in coordinator/charger_adapters/ exist for brand quirks.",
     "Every entry here is brand knowledge sitting one layer too low.",
     "ADDING one is how the split got this bad; removing one is the point.",
     "Regenerate after a move:  python3 scripts/audit_brand_footprint.py --baseline"
   ],
-  "total": 74,
+  "total": 70,
   "per_brand": {
     "chargepoint": 1,
     "easee": 6,
     "go-e": 3,
     "heidelberg": 1,
-    "keba": 48,
+    "keba": 44,
     "openevse": 1,
     "openwb": 2,
     "wallbox": 6,

--- a/tests/test_855_stage4_registry_quirks.py
+++ b/tests/test_855_stage4_registry_quirks.py
@@ -1,0 +1,80 @@
+"""#855 stage 4 — the generic device layer learns brands from the REGISTRY,
+never from its own code.
+
+Stage 1 froze the count (ratchet), stage 3 gave observer mode the seam.
+Stage 4 finishes the original plan: the brand knowledge that was CODE in
+`devices/base.py` — the watchdog-refresh table and two log strings claiming
+KEBA — moves out. The mechanics were already generic (they gate on
+`has_service(domain, "set_failsafe")`); only the DATA was hardcoded. Its
+home is the one brand registry the arc already built (#814/#848,
+`consts/hardware_matrix.py`): a brand with a failsafe quirk adds a ROW, and
+`devices/base.py` never changes again for a new brand.
+
+Behavioral safety net: `tests/test_392_keba_heartbeat.py` pins the numbers
+(KEBA 5.0 s, generic default, override wins) and must stay green untouched
+through this move — this file pins only WHERE the knowledge lives.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+from custom_components.solar_energy_management.consts.hardware_matrix import (
+    CHARGERS,
+    charger_watchdog_refresh_map,
+)
+
+BASE_PY = pathlib.Path(__file__).resolve().parent.parent / "devices" / "base.py"
+
+
+class TestTheRegistryCarriesTheQuirk:
+    def test_keba_row_declares_its_watchdog_refresh(self):
+        row = next(r for r in CHARGERS if "KEBA" in r["brand"])
+        assert row.get("domain_token") == "keba"
+        assert row.get("watchdog_refresh_s") == 5.0, (
+            "the measured value — PROD showed the P30 reverting to its 6 A "
+            "failsafe in well under 30 s, so the refresh sits below the "
+            "~10 s coordinator cycle"
+        )
+
+    def test_the_map_is_built_from_rows_not_hardcoded(self):
+        m = charger_watchdog_refresh_map()
+        assert m.get("keba") == 5.0
+        # Every entry must trace to a row that declares both fields.
+        for token, seconds in m.items():
+            row = next(r for r in CHARGERS if r.get("domain_token") == token)
+            assert row["watchdog_refresh_s"] == seconds
+
+
+class TestBaseKnowsNoBrandInCode:
+    def test_no_brand_string_constants_outside_docstrings(self):
+        """The stage-4 pin: comments and docstrings may keep their history
+        (the ratchet watches their total), but CODE — string constants,
+        dict keys, log messages — names no brand."""
+        tree = ast.parse(BASE_PY.read_text())
+        doc_positions = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef,
+                                 ast.FunctionDef, ast.AsyncFunctionDef)):
+                body = getattr(node, "body", [])
+                if body and isinstance(body[0], ast.Expr) and isinstance(
+                        body[0].value, ast.Constant) and isinstance(
+                        body[0].value.value, str):
+                    doc_positions.add(id(body[0].value))
+        offenders = []
+        for node in ast.walk(tree):
+            if (isinstance(node, ast.Constant) and isinstance(node.value, str)
+                    and id(node) not in doc_positions
+                    and "keba" in node.value.lower()):
+                offenders.append(f"L{node.lineno}: {node.value[:60]!r}")
+        assert not offenders, (
+            "brand names in devices/base.py CODE — move the knowledge to "
+            "the hardware matrix (a row), not the generic layer:\n"
+            + "\n".join(offenders)
+        )
+
+    def test_the_hardcoded_table_is_gone(self):
+        src = BASE_PY.read_text()
+        assert '_BRAND_WATCHDOG_REFRESH_S = {\n    "keba"' not in src, (
+            "the table must be BUILT from the registry, not typed here"
+        )


### PR DESCRIPTION
Finishes the arc as originally planned (Guido, 29.08: *"why do you not finish it as originally planned"*). The last brand CODE in `devices/base.py` — the KEBA watchdog-refresh table and two brand-naming log strings — moves to the hardware matrix as data on the KEBA row. Behaviour byte-identical, pinned by the untouched `test_392_keba_heartbeat` + `test_854_stop_never_enables`; new `test_855_stage4_registry_quirks` pins where the knowledge lives (AST scan: no brand string constants in base.py code). Ratchet baseline 74 → 70. The failsafe behaviour and the `keba_arm_failsafe` config key are deliberately unchanged.