### PR TITLE
A new install observes first; the stop-war warning names a rival controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+- 👀 **A new install observes first.** SEM now starts in observer mode: it
+  reads your system, builds the dashboard and publishes the decisions it
+  *would* make, without sending a single command to your hardware. When those
+  decisions look right, one switch (`switch.sem_observer_mode`) hands it
+  control. **Existing installs are unaffected** — this changes only what a
+  fresh install starts as, and any install that has ever recorded a choice
+  keeps it. The reason is a real incident: a fresh install on a machine wired
+  to a charger that another system was already controlling became a second
+  controller nobody chose, and the two fought over the car. An install default
+  should never be the thing that starts touching your hardware.
+
+- 🕵️ **The stop-war warning names the other likely culprit** — a second
+  controller commanding the same charger (another SEM instance, an automation,
+  a vendor app) looks *identical* from inside SEM to a wallbox re-closing its
+  own contactor. The warning now says so and points at the check that tells
+  them apart, instead of sending you to the hardware first.
+
 - 🧱 **The generic device layer now learns brands from the registry — stage 4
   closes the #855 arc**: the last brand knowledge that was *code* in the
   generic layer (the KEBA watchdog-refresh table and two log strings) moved

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Key settings you can adjust (all have sensible defaults):
 | Battery buffer SOC | 70% | Above this, battery can help charge the EV |
 | Battery auto-start SOC | 90% | Above this, EV starts even without solar surplus |
 | Min solar power | 500W | Minimum surplus before solar EV charging starts |
-| Observer mode | Off | Read-only mode for test systems (no hardware control) |
+| Observer mode | **On** | SEM watches and shows what it *would* do, commanding nothing. Turn it off when the decisions look right. |
 
 For detailed explanations of all settings, see the [Setup Guide](docs/SETUP_GUIDE.md).
 
@@ -191,7 +191,7 @@ SEM is designed to be mostly automatic. The controls that matter (v1.6.3 — tog
 
 | Entity | Default | What it does |
 |--------|---------|-------------|
-| `switch.sem_observer_mode` | OFF | Read-only mode — SEM monitors but doesn't control hardware (global) |
+| `switch.sem_observer_mode` | **ON** on a new install | Read-only mode — SEM monitors and publishes its would-decisions but sends no commands (global) |
 | `select.sem_charger_<id>_charge_mode` | `Min + Solar` | **Per-charger.** One named selector carries the night-charging, smart-night, and tariff-window intent that used to live on three separate switches. Options: *Solar only* / *Solar + cheapest hours* / *Min + Solar* / *Always (max)* / *Off*. |
 
 EV charge targets, currents, phases and consumption are all **per-charger** entities too (`number.sem_charger_<id>_…`, `select.sem_charger_<id>_…`) — the global EV settings were removed in #255 (per-charger is the source of truth; globals are read-only summaries). Everything else — solar charging, surplus distribution, battery protection, peak management — is fully automatic.

--- a/config_flow.py
+++ b/config_flow.py
@@ -467,7 +467,8 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             # Store Energy Dashboard sensor config + the observer_mode toggle
             self._data.update(self._energy_dashboard_config.to_dict())
-            self._data["observer_mode"] = user_input.get("observer_mode", False)
+            self._data["observer_mode"] = user_input.get(
+                "observer_mode", DEFAULT_OBSERVER_MODE)
             # (#777) Record ALL persisted-switch defaults explicitly at
             # install: a key present in entry data means "this install
             # chose", so a dead install's restore-store ghost can never
@@ -538,13 +539,14 @@ class SolarEnergyManagementConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=vol.Schema({
-                # Single safety toggle. Defaulted OFF so a real install
-                # actually controls hardware. Set to ON for test/staging
-                # instances that mirror a production HA — observer mode
-                # blocks every outbound service call from SEM.
+                # Single safety toggle, defaulted ON: a new install shows
+                # what it WOULD do and commands nothing until its owner
+                # turns this off. Reads the constant rather than repeating
+                # it — the literal here and the constant elsewhere are how
+                # the two drifted before.
                 vol.Optional(
                     "observer_mode",
-                    default=False,
+                    default=DEFAULT_OBSERVER_MODE,
                 ): selector.BooleanSelector(),
             }),
             description_placeholders={

--- a/consts/core.py
+++ b/consts/core.py
@@ -6,7 +6,12 @@ DOMAIN: Final = "solar_energy_management"
 # ============================================
 # UPDATE & DELTA THRESHOLDS
 # ============================================
-DEFAULT_OBSERVER_MODE: Final = False  # When True, skip all hardware control (read-only monitoring)
+DEFAULT_OBSERVER_MODE: Final = True  # A new install OBSERVES first — it
+# shows what it WOULD do and waits for one deliberate switch before it
+# commands anything. Was False until 29.08.2026, when a fresh install on
+# a rig wired to a real KEBA became a second controller nobody chose and
+# fed a car ~5 kWh in Off mode. An install default should never be the
+# thing that starts touching someone's hardware.
 DEFAULT_UPDATE_INTERVAL: Final = 10  # seconds - 10 seconds for highly accurate energy integration
 # Missing legacy config must not silently require an inverter/load sensor lane.
 # Grid-only remains fail-closed for the installation's upstream phase limit and

--- a/coordinator/charger_reconciler.py
+++ b/coordinator/charger_reconciler.py
@@ -667,11 +667,18 @@ class ChargerReconciler:
                         "restarting itself against SEM's stop (%d stop→redraw "
                         "round-trips). Standing down for %.0f min so the car "
                         "is not strobed into a charging fault; it may charge "
-                        "at the box's stored minimum meanwhile. Likely cause: "
-                        "the wallbox's own auto-start/authorization re-closes "
-                        "the contactor on the car's retry — disable charger-"
-                        "side auto-start, or give SEM a stop mechanism the "
-                        "box respects. — %s",
+                        "at the box's stored minimum meanwhile. Two causes "
+                        "look IDENTICAL from here. (1) The wallbox's own "
+                        "auto-start/authorization re-closes the contactor on "
+                        "the car's retry — disable charger-side auto-start, or "
+                        "give SEM a stop mechanism the box respects. (2) "
+                        "ANOTHER controller is commanding this same charger — "
+                        "a second SEM instance (a test rig sharing the "
+                        "hardware, with observer mode off), an HA automation, "
+                        "or a vendor app. Check that first if one could "
+                        "exist: it is cheap to rule out, and a stop that "
+                        "starts holding the moment the other writer is "
+                        "silenced is the proof. — %s",
                         self.charger_id, self._stop_war_rounds,
                         STOP_WAR_BACKOFF_S / 60.0, decision.reason)
                 else:

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -143,7 +143,7 @@ The controls that matter most:
 |--------|---------|---------|
 | `select.sem_charger_<id>_charge_mode` | `Min + Solar` | Per-charger charging mode: **Solar only** / **Solar + cheapest hours** / **Min + Solar** (grid minimum 6A + surplus) / **Always max** / **Off**. Pick based on your needs; see [Charging Modes](SETUP_GUIDE.md#8-ev-charging-modes) in the Setup Guide. |
 | `number.sem_battery_assist_min_surplus` | 1200 W | **Solar Gate**: minimum real solar surplus to enable battery assist for the EV. Set to 0 W to allow battery support everywhere (previous behaviour). Prevents battery drain into the car at night. |
-| `switch.sem_observer_mode` | OFF | Monitor-only, no hardware control |
+| `switch.sem_observer_mode` | **ON** (new installs) | Monitor-only — turn it OFF to let SEM control hardware |
 
 Everything else is automatic.
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -164,7 +164,7 @@ solar production, grid import/export, battery charge/discharge, and EV charger.
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| **Observer mode** | Off | When ON, SEM only reads data and provides the dashboard — it will not send any commands to your hardware. Use this for testing, secondary HA instances, or monitoring-only setups. You can toggle it later via `switch.sem_observer_mode`. |
+| **Observer mode** | **On** | A new install observes first: SEM reads your system, builds the dashboard, and publishes the decisions it *would* make — without sending a single command to your hardware. Look at those decisions, and when they match what you'd want, turn observer mode off (`switch.sem_observer_mode`) to let SEM act. Leave it on permanently for test rigs, secondary HA instances that mirror a production one, or monitoring-only setups. |
 
 > **Tip:** If a sensor you expect is missing from the detection summary,
 > check your Energy Dashboard (**Settings > Dashboards > Energy**) and ensure

--- a/persisted_flags.py
+++ b/persisted_flags.py
@@ -41,7 +41,9 @@ _LOGGER = logging.getLogger(__name__)
 # is the kill-switch, and a default-off would leave a solar_plus_cheap
 # install with no cheap-window timing at all).
 PERSISTED_FLAG_DEFAULTS: Final[Dict[str, bool]] = {
-    "observer_mode": False,
+    # (29.08.2026) Observe first — see DEFAULT_OBSERVER_MODE. Kept in step
+    # with the constant by tests/test_new_install_observes_first.py.
+    "observer_mode": True,
     "vacation_mode": False,
     "energy_plan_actuation": True,
     # (#778) Forecast-led spending ships INERT: the whole arc measures and

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -141,11 +141,21 @@ class TestSwitchDefaults:
     # ``charge_mode`` default (``min_plus_solar`` permits night;
     # users opting out pick ``solar_only`` / ``off`` in the selector).
 
-    def test_observer_mode_default_off(self, mock_coordinator):
+    def test_observer_mode_defaults_to_the_constant(self, mock_coordinator):
+        """With nothing configured the switch follows DEFAULT_OBSERVER_MODE.
+
+        Asserted against the constant, not a literal: this test pins that
+        the switch READS the product default, and must not freeze whatever
+        that default happened to be when it was written. (It said False
+        until 29.08.2026, when a new install started observing first.)
+        """
+        from custom_components.solar_energy_management.consts.core import (
+            DEFAULT_OBSERVER_MODE,
+        )
         mock_coordinator.config_entry.options = {}
         desc = SWITCH_TYPES[0]  # observer_mode (only remaining global switch)
         switch = SEMSolarSwitch(mock_coordinator, desc, "test")
-        assert switch._is_on is False
+        assert switch._is_on is DEFAULT_OBSERVER_MODE
 
 
 # ============================================================

--- a/tests/test_new_install_observes_first.py
+++ b/tests/test_new_install_observes_first.py
@@ -1,0 +1,61 @@
+"""A new install starts OBSERVING — it looks before it touches (Guido, 29.08).
+
+The old default was off, reasoning that "a real install actually controls
+hardware". Live on PROD 29.08 showed the cost of that reasoning: a fresh
+install on a rig wired to a real KEBA silently became a SECOND controller,
+fought the production instance's stop for 40 minutes, and put ~5 kWh into a
+car whose charge mode was Off. Nobody chose that; an install default did.
+
+Observing first is the honest order of operations. SEM's whole first-run
+story is "here is what I found, here is what I would do" — and observer mode
+is precisely that sentence in executable form. The user turns actuation on
+when the WOULD-decisions look right, which is one switch on the dashboard,
+and a decision they made rather than one made for them.
+
+This is a default, not a lock: nothing about the switch, the options flow, or
+the actuation path changes.
+"""
+from __future__ import annotations
+
+from custom_components.solar_energy_management.consts.core import (
+    DEFAULT_OBSERVER_MODE,
+)
+from custom_components.solar_energy_management.persisted_flags import (
+    PERSISTED_FLAG_DEFAULTS,
+)
+
+
+def test_the_constant_says_observe():
+    assert DEFAULT_OBSERVER_MODE is True, (
+        "a fresh install observes until its owner says otherwise"
+    )
+
+
+def test_the_persisted_flag_table_agrees():
+    """The table and the constant are two doors to one answer; #777 exists
+    because they once disagreed and a restore-store ghost walked through."""
+    assert PERSISTED_FLAG_DEFAULTS["observer_mode"] is DEFAULT_OBSERVER_MODE
+
+
+def test_the_flow_schema_offers_the_same_default():
+    """What the install form shows must match what the code assumes — a
+    checkbox that says off while the constant says on is the #819 shape."""
+    import inspect
+    from custom_components.solar_energy_management import config_flow as cf
+    src = inspect.getsource(cf)
+    marker = 'vol.Optional(\n                    "observer_mode",'
+    assert marker in src, "the install step's observer toggle moved — re-pin it"
+    tail = src[src.index(marker):src.index(marker) + 260]
+    assert "default=DEFAULT_OBSERVER_MODE" in tail, (
+        "the form must read the constant, not carry its own literal — that "
+        "is how the two drifted in the first place"
+    )
+
+
+def test_actuation_is_still_reachable_in_one_switch():
+    """Observing first must not mean 'hard to start': the switch entity is
+    the one deliberate action, unchanged."""
+    from custom_components.solar_energy_management.persisted_flags import (
+        switch_entity_id,
+    )
+    assert switch_entity_id("observer_mode") == "switch.sem_observer_mode"

--- a/tests/test_stop_war_names_rival_controller.py
+++ b/tests/test_stop_war_names_rival_controller.py
@@ -1,0 +1,56 @@
+"""The stop-war warning must name a rival controller as a candidate cause.
+
+Live on PROD 29.08.2026: a second SEM instance (a test rig wired to the same
+physical KEBA, left actuating after a clean install) fought PROD's stop for
+40 minutes — four stop→redraw round-trips, the #763 ceasefire stood down, and
+~5 kWh went into a car whose charge mode was Off.
+
+From inside one instance a rival controller is INDISTINGUISHABLE from the
+wallbox's own auto-start: both look like "the box re-closes the contactor
+after my stop". The warning named only the wallbox, so the diagnosis went to
+the hardware first and cost an hour. The evidence that settles it is cheap —
+a stop that starts holding the moment the other controller is silenced — but
+only if the reader is told to look.
+
+This pins the second candidate into the message. It is a diagnosability fix:
+no control-flow changes, the ceasefire is untouched.
+"""
+from __future__ import annotations
+
+import pathlib
+import re
+
+SRC = (pathlib.Path(__file__).resolve().parent.parent
+       / "coordinator" / "charger_reconciler.py")
+
+
+def _stop_war_message() -> str:
+    """The warning's literal text, joined across its implicit concatenation."""
+    text = SRC.read_text()
+    start = text.index("stop war detected")
+    end = text.index("self.charger_id", start)
+    # The literal spans several implicitly-concatenated lines; strip the
+    # quoting and indentation rather than trying to re-parse it.
+    return re.sub(r'["\s]+', " ", text[start:end])
+
+
+class TestTheWarningNamesBothCauses:
+    def test_the_wallbox_autostart_cause_survives(self):
+        msg = _stop_war_message().lower()
+        assert "auto-start" in msg, (
+            "the original cause is still the most common one — it stays"
+        )
+
+    def test_a_second_controller_is_named(self):
+        msg = _stop_war_message().lower()
+        assert "controller" in msg or "instance" in msg, (
+            "a rival controller writing to the same charger looks identical "
+            "from here and must be offered as a candidate — PROD 29.08"
+        )
+
+    def test_it_tells_the_reader_how_to_tell_them_apart(self):
+        msg = _stop_war_message().lower()
+        assert any(k in msg for k in ("another", "second", "other")), (
+            "naming the cause is not enough; the message must point at the "
+            "check that separates the two"
+        )

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -63,9 +63,14 @@ class TestSEMSwitches:
         switch = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
         assert switch._is_on is True
 
+        # Nothing configured — the switch follows the product default,
+        # read from the constant so this test never freezes it.
+        from custom_components.solar_energy_management.consts.core import (
+            DEFAULT_OBSERVER_MODE,
+        )
         mock_coordinator.config_entry.options = {}
         switch2 = SEMSolarSwitch(mock_coordinator, description, "test_entry_id")
-        assert switch2._is_on is False
+        assert switch2._is_on is DEFAULT_OBSERVER_MODE
 
     @pytest.mark.asyncio
     async def test_switch_is_on(self, mock_coordinator):
@@ -353,9 +358,13 @@ class TestExplicitConfigBeatsGhostRestore777:
         assert sw._is_on is True
 
     def test_no_config_and_no_ghost_is_the_default(self):
+        """#777's floor: nothing recorded anywhere → the product default."""
+        from custom_components.solar_energy_management.consts.core import (
+            DEFAULT_OBSERVER_MODE,
+        )
         sw = _sw("observer_mode")
         sw._apply_restored_state(None)
-        assert sw._is_on is False
+        assert sw._is_on is DEFAULT_OBSERVER_MODE
 
     def test_actuation_ghost_off_yields_to_explicit_config(self):
         """Same precedence for the siblings: an old install's


### PR DESCRIPTION
Fallout from a real PROD incident tonight: the car charged 40 minutes in Off mode because a clean install on the HA-TEST rig — wired to the same physical KEBA — came up **actuating**. Two SEM instances fought over one charger; PROD's #763 ceasefire correctly stood down; ~5 kWh went into the car. Silencing the second writer made a single `keba.disable` hold instantly.

**A new install now observes first** (Guido's call). It reads the system, builds the dashboard, publishes the decisions it *would* make, and commands nothing until one switch says otherwise. Existing installs are untouched — #777 means any install that ever recorded a choice keeps it. The persisted-flag table and the install form both read `DEFAULT_OBSERVER_MODE` now instead of repeating a literal, which is how they drifted in the first place.

**The stop-war warning names both causes.** A rival controller is indistinguishable from a wallbox re-closing its own contactor, from inside SEM. Blaming the hardware first cost an hour; the message now points at the cheap check.

Also fixed outside this repo: `deploy-test.sh` was posting `{"observer_mode": false}` during the config flow — actively disabling observation on a real-hardware rig — and now posts `true` and asserts the switch afterwards.

Three tests asserted the old literal default; they now assert the constant, so they pin *"the switch follows the product default"* rather than freezing a decision they don't own. Full suite green apart from those three, which this commit updates.