### PR TITLE
fix(#936): unloading SEM goes to observer mode first and hands back only what it commanded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+- 🛡️ **Removing or disabling SEM no longer commands a battery it never
+  commanded** (#936). Unload ran "restore discharge to max" on every battery
+  adapter, whatever mode SEM was in — an observer-mode test rig rewrote the
+  shared Huawei discharge-limit register on its way out while the production
+  instance was holding it at 750 W. SEM now switches itself to observer mode
+  first, then hands back only what it started in this lifetime (a forced
+  charge or discharge, a discharge limit it wrote) and leaves everything else
+  exactly as found — the #908 rule, extended from loads to batteries.
+
 # [2.1.0-beta.9] — 07.09.2026
 
 - 🛡️ **A battery still set to the retired "allow arbitrage" mode kept

--- a/__init__.py
+++ b/__init__.py
@@ -2967,23 +2967,23 @@ async def async_unload_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool
         # would otherwise grow the list. Guarded — coordinator may be
         # missing if setup never completed.
         if coordinator is not None:
-            # Part B (#589): clear any active force-op before dropping adapters.
-            # Prevents a reload mid-force-op stranding the inverter in a
-            # forced charge/discharge mode that SEM will no longer manage.
-            # Only issues a STOP (command_normal) — never a new command.
-            # Failures are swallowed so a flaky Modbus never blocks unload.
-            _battery_adapters = getattr(coordinator, "_battery_adapters", {}) or {}
-            for _bid, _adapter in _battery_adapters.items():
-                try:
-                    await _adapter.command_normal()
-                    _LOGGER.debug(
-                        "Battery adapter %s: command_normal on unload", _bid,
-                    )
-                except Exception as _e:  # noqa: BLE001
-                    _LOGGER.debug(
-                        "Battery adapter %s: command_normal on unload failed "
-                        "(non-blocking): %s", _bid, _e,
-                    )
+            # (#936 — Guido, 08.09.2026: "on uninstall SEM should go to
+            # observation mode on and then uninstall.") Observer ON first, so
+            # nothing still in flight commands anything; then hand back ONLY
+            # what SEM itself commanded in this lifetime — a force op it
+            # started (#589 Part B: never strand the inverter in a forced
+            # mode), a discharge limit it wrote. A battery SEM never
+            # commanded, and every battery of a rig that already was in
+            # observer mode, is left exactly as found. Before this,
+            # command_normal ran on every adapter on every unload, and the
+            # .46 observer rig rewrote the SHARED Huawei discharge-limit
+            # register (750 → 5000 W) while PROD was holding it. The #908
+            # rule, extended from loads to batteries.
+            from .coordinator.battery_adapters.base import (
+                async_release_batteries_on_unload,
+            )
+            for _bid, _what in (await async_release_batteries_on_unload(coordinator)).items():
+                _LOGGER.info("Battery adapter %s on unload: %s", _bid, _what)
 
             # #656 — loads must not be stranded ON when SEM goes away.
             #

--- a/coordinator/battery_adapters/base.py
+++ b/coordinator/battery_adapters/base.py
@@ -27,6 +27,72 @@ from ..charger_types import BatteryIntent
 _LOGGER = logging.getLogger(__name__)
 
 
+def unload_release_reason(adapter, was_observer: bool) -> Optional[str]:
+    """(#936) Why THIS adapter must be commanded once more on unload — or
+    ``None``: leave the battery exactly as found.
+
+    Unload used to run ``command_normal()`` ("restore discharge to max") on
+    every adapter, whatever SEM had or had not done. On 08.09.2026 the .46
+    test rig — observer mode ON, so SEM had commanded nothing, ever — wrote
+    the SHARED Huawei discharge-limit register from 750 to 5000 W on its
+    way out, while PROD was holding it at 750. The #908 rule for loads
+    applies here word for word: release what SEM started, leave the rest.
+
+    - observer was on → nothing. Observer commands nothing, including on
+      the way out.
+    - a forcible charge / discharge SEM started is still active → stop it
+      (the inverter must not be left in a forced mode nobody manages).
+    - a discharge limit SEM wrote in this lifetime is still in force → hand
+      it back (``command_normal`` restores the maximum; the same-value skip
+      makes it a no-op when it already is).
+    - otherwise → nothing. SEM never commanded this battery.
+    """
+    if was_observer:
+        return None
+    if getattr(adapter, "_forcible_charging", False) or getattr(adapter, "_forcible_discharging", False):
+        return "a forcible operation SEM started is still active"
+    charge = getattr(adapter, "_charge_adapter", None)
+    if charge is not None and bool(getattr(charge, "is_active", False)):
+        return "a forced charge SEM started is still active"
+    try:
+        last = float(getattr(adapter, "_last_discharge_limit_w", -1.0))
+    except (TypeError, ValueError):
+        last = -1.0
+    if last >= 0:
+        return f"a discharge limit SEM wrote ({last:.0f} W) is still in force"
+    return None
+
+
+async def async_release_batteries_on_unload(coordinator) -> dict:
+    """(#936 — Guido, 08.09.2026: *"on uninstall SEM should go to observation
+    mode on and then uninstall"*.) Flip the coordinator to observer mode
+    FIRST, so no cycle still in flight commands anything, then hand back only
+    what SEM itself commanded (see :func:`unload_release_reason`).
+
+    Returns ``{battery_id: what happened}`` for the caller to log. Never
+    raises: a flaky Modbus must not block an unload.
+    """
+    was_observer = bool(getattr(coordinator, "_observer_mode", False))
+    try:
+        coordinator._observer_mode = True
+    except Exception:  # noqa: BLE001 — a read-only stand-in in tests
+        pass
+    outcome: dict = {}
+    adapters = getattr(coordinator, "_battery_adapters", {}) or {}
+    for bid, adapter in adapters.items():
+        why = unload_release_reason(adapter, was_observer)
+        if why is None:
+            outcome[bid] = ("observer mode — nothing was ever commanded, nothing written"
+                            if was_observer else "nothing commanded in this lifetime — left as found")
+            continue
+        try:
+            await adapter.command_normal()
+            outcome[bid] = f"released: {why}"
+        except Exception as e:  # noqa: BLE001
+            outcome[bid] = f"release failed (non-blocking): {e}"
+    return outcome
+
+
 class BatteryControlAdapter(ABC):
     """One adapter per battery brand. Mirrors
     :class:`ChargerAdapter` on the EV side.

--- a/tests/test_589_battery_command_honesty.py
+++ b/tests/test_589_battery_command_honesty.py
@@ -458,23 +458,43 @@ class TestGenericForceChargeHonesty:
 
 # ── Part B: unload teardown ───────────────────────────────────────────────────
 
+def _unload_adapter(**bookkeeping):
+    """A battery adapter as the unload rule sees it (#936): explicit
+    bookkeeping, because a bare MagicMock reads every attribute as truthy —
+    which would make a never-commanded battery look like one mid-force-op."""
+    from unittest.mock import AsyncMock as AM
+
+    a = MagicMock()
+    a.command_normal = AM(return_value=None)
+    a._forcible_charging = False
+    a._forcible_discharging = False
+    a._charge_adapter = None
+    a._last_discharge_limit_w = -1.0
+    for k, v in bookkeeping.items():
+        setattr(a, k, v)
+    return a
+
+
 class TestUnloadTeardown:
-    """UL1/UL2 — async_unload_entry calls command_normal on adapters."""
+    """UL1/UL2 — async_unload_entry hands the batteries back (#589 Part B),
+    but since #936 ONLY those SEM itself commanded: a force op it started is
+    stopped, a never-commanded battery is left exactly as found, and the
+    coordinator is switched to observer mode first."""
 
     @pytest.mark.asyncio
-    async def test_ul1_command_normal_called_on_each_adapter(self) -> None:
-        """UL1: unload iterates _battery_adapters and calls command_normal."""
+    async def test_ul1_unload_stops_what_sem_started_and_leaves_the_rest(self) -> None:
+        """UL1 (#589 Part B + #936): a forcible charge SEM started is stopped
+        on unload; a battery SEM never commanded gets no command at all."""
         from unittest.mock import AsyncMock as AM
 
-        mock_adapter_a = MagicMock()
-        mock_adapter_a.command_normal = AM(return_value=None)
-        mock_adapter_b = MagicMock()
-        mock_adapter_b.command_normal = AM(return_value=None)
+        forcing = _unload_adapter(_forcible_charging=True)
+        untouched = _unload_adapter()
 
         mock_coord = MagicMock()
+        mock_coord._observer_mode = False
         mock_coord._battery_adapters = {
-            "primary": mock_adapter_a,
-            "secondary": mock_adapter_b,
+            "primary": forcing,
+            "secondary": untouched,
         }
         mock_coord._surplus_controller = None
 
@@ -492,19 +512,49 @@ class TestUnloadTeardown:
         result = await async_unload_entry(hass, entry)
 
         assert result is True
-        mock_adapter_a.command_normal.assert_awaited_once()
-        mock_adapter_b.command_normal.assert_awaited_once()
+        forcing.command_normal.assert_awaited_once()
+        untouched.command_normal.assert_not_called()
+        # "go to observation mode on and then uninstall" (Guido, 08.09.2026)
+        assert mock_coord._observer_mode is True
+
+    @pytest.mark.asyncio
+    async def test_ul1b_observer_rig_commands_nothing_on_unload(self) -> None:
+        """UL1b (#936): a coordinator already in observer mode never
+        commands a battery on unload — the .46 rig rewrote PROD's shared
+        discharge-limit register this way on 08.09.2026."""
+        from unittest.mock import AsyncMock as AM
+
+        forcing = _unload_adapter(_forcible_charging=True, _last_discharge_limit_w=750.0)
+        mock_coord = MagicMock()
+        mock_coord._observer_mode = True
+        mock_coord._battery_adapters = {"primary": forcing}
+        mock_coord._surplus_controller = None
+
+        hass = MagicMock()
+        hass.data = {"solar_energy_management": {"entry-1": mock_coord}}
+        hass.config_entries = MagicMock()
+        hass.config_entries.async_unload_platforms = AM(return_value=True)
+        hass.services = MagicMock()
+        hass.services.async_remove = Mock()
+        entry = MagicMock()
+        entry.entry_id = "entry-1"
+
+        from custom_components.solar_energy_management import async_unload_entry
+        assert await async_unload_entry(hass, entry) is True
+        forcing.command_normal.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_ul2_adapter_exception_does_not_block_unload(self) -> None:
         """UL2: adapter raising in command_normal never blocks unload."""
         from unittest.mock import AsyncMock as AM
 
-        mock_adapter = MagicMock()
+        # A limit SEM wrote → the hand-back IS attempted (and raises).
+        mock_adapter = _unload_adapter(_last_discharge_limit_w=750.0)
         mock_adapter.command_normal = AM(
             side_effect=RuntimeError("flaky Modbus"),
         )
         mock_coord = MagicMock()
+        mock_coord._observer_mode = False
         mock_coord._battery_adapters = {"primary": mock_adapter}
         mock_coord._surplus_controller = None
 

--- a/tests/test_936_unload_observer_first.py
+++ b/tests/test_936_unload_observer_first.py
@@ -1,0 +1,116 @@
+"""#936 — unloading SEM must not command a battery SEM never commanded.
+
+08.09.2026, test rig .46, observer mode ON: the clean-install routine deleted
+the SEM entry, ``async_unload_entry`` ran ``command_normal()`` on both battery
+adapters, and the rig's history shows the SHARED Huawei discharge-limit
+register going 750 → 5000 W at that second — while PROD was holding it at
+750. An observer rig, which by definition commands nothing, wrote PROD's
+battery on its way out.
+
+Guido's rule (08.09.2026): *"on uninstall SEM should go to observation mode
+on and then uninstall."* Together with #908 (release what SEM started, leave
+the rest): flip observer on first, then hand back ONLY what SEM itself
+commanded in this lifetime.
+
+The rule is a pure function on the adapter's own bookkeeping, so it is
+tested with stand-ins that carry exactly the attributes the rule reads — a
+real adapter would need a hass and a Modbus link, and the whole bug is in
+WHEN the command is issued, not in what the command does.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.solar_energy_management.coordinator.battery_adapters.base import (
+    async_release_batteries_on_unload,
+    unload_release_reason,
+)
+
+
+def _adapter(**state):
+    """A battery adapter as the rule sees it: only the bookkeeping fields."""
+    defaults = dict(_forcible_charging=False, _forcible_discharging=False,
+                    _charge_adapter=None, _last_discharge_limit_w=-1.0)
+    defaults.update(state)
+    a = SimpleNamespace(**defaults)
+    a.command_normal = AsyncMock()
+    return a
+
+
+class TestTheRule:
+    def test_observer_mode_never_commands_even_with_a_limit_on_record(self):
+        # The .46 shape: observer on, and whatever the bookkeeping says, nothing goes out.
+        a = _adapter(_last_discharge_limit_w=750.0, _forcible_charging=True)
+        assert unload_release_reason(a, was_observer=True) is None
+
+    def test_a_battery_sem_never_commanded_is_left_as_found(self):
+        assert unload_release_reason(_adapter(), was_observer=False) is None
+
+    def test_a_discharge_limit_sem_wrote_is_handed_back(self):
+        why = unload_release_reason(_adapter(_last_discharge_limit_w=750.0), was_observer=False)
+        assert why and "750" in why
+
+    def test_a_limit_of_zero_counts_as_written(self):
+        # 0 W is a real limit SEM may have set (full discharge stop); -1 is "never".
+        assert unload_release_reason(_adapter(_last_discharge_limit_w=0.0), was_observer=False)
+
+    def test_a_forcible_operation_sem_started_is_stopped(self):
+        assert unload_release_reason(_adapter(_forcible_charging=True), was_observer=False)
+        assert unload_release_reason(_adapter(_forcible_discharging=True), was_observer=False)
+
+    def test_an_active_forced_charge_on_the_charge_adapter_is_stopped(self):
+        a = _adapter(_charge_adapter=SimpleNamespace(is_active=True))
+        assert unload_release_reason(a, was_observer=False)
+
+    def test_an_idle_charge_adapter_is_not_a_reason(self):
+        a = _adapter(_charge_adapter=SimpleNamespace(is_active=False))
+        assert unload_release_reason(a, was_observer=False) is None
+
+    def test_garbage_bookkeeping_reads_as_never_written(self):
+        a = _adapter(_last_discharge_limit_w="n/a")
+        assert unload_release_reason(a, was_observer=False) is None
+
+
+class TestTheUnloadHelper:
+    @pytest.mark.asyncio
+    async def test_observer_is_switched_on_first_and_nothing_is_written(self):
+        b1, b2 = _adapter(_last_discharge_limit_w=750.0), _adapter(_forcible_charging=True)
+        coord = SimpleNamespace(_observer_mode=True, _battery_adapters={"b1": b1, "b2": b2})
+        outcome = await async_release_batteries_on_unload(coord)
+        assert coord._observer_mode is True
+        b1.command_normal.assert_not_called()
+        b2.command_normal.assert_not_called()
+        assert all("observer" in v for v in outcome.values())
+
+    @pytest.mark.asyncio
+    async def test_active_install_releases_only_what_it_commanded(self):
+        wrote = _adapter(_last_discharge_limit_w=750.0)
+        untouched = _adapter()
+        forcing = _adapter(_forcible_discharging=True)
+        coord = SimpleNamespace(_observer_mode=False,
+                                _battery_adapters={"wrote": wrote, "untouched": untouched, "forcing": forcing})
+        outcome = await async_release_batteries_on_unload(coord)
+        wrote.command_normal.assert_awaited_once()
+        forcing.command_normal.assert_awaited_once()
+        untouched.command_normal.assert_not_called()
+        assert outcome["untouched"].startswith("nothing commanded")
+        assert outcome["wrote"].startswith("released")
+        # and the coordinator is in observer mode from here on
+        assert coord._observer_mode is True
+
+    @pytest.mark.asyncio
+    async def test_a_failing_release_never_raises(self):
+        bad = _adapter(_last_discharge_limit_w=750.0)
+        bad.command_normal = AsyncMock(side_effect=RuntimeError("modbus timeout"))
+        coord = SimpleNamespace(_observer_mode=False, _battery_adapters={"b1": bad})
+        outcome = await async_release_batteries_on_unload(coord)
+        assert "failed" in outcome["b1"]
+
+    @pytest.mark.asyncio
+    async def test_no_adapters_is_a_quiet_no_op(self):
+        coord = SimpleNamespace(_observer_mode=False, _battery_adapters={})
+        assert await async_release_batteries_on_unload(coord) == {}
+        assert coord._observer_mode is True


### PR DESCRIPTION
Fixes #936.

Unload ran `command_normal()` on every battery adapter whatever mode SEM was in. On 08.09.2026 the .46 rig — observer mode on — rewrote the shared Huawei discharge-limit register from 750 to 5000 W on its way out while PROD was holding it at 750.

Rule (Guido, 08.09.2026): *"on uninstall SEM should go to observation mode on and then uninstall."* With the #908 rule: release what SEM started, leave the rest.

- `unload_release_reason(adapter, was_observer)` — pure rule on the adapter's bookkeeping: observer → never; a forcible op SEM started → stop; a discharge limit SEM wrote → hand back; otherwise nothing.
- `async_release_batteries_on_unload(coordinator)` — flips observer on first, then applies the rule per adapter; never raises.
- `async_unload_entry` uses it and logs one INFO line per battery.
- 11 tests in `tests/test_936_unload_observer_first.py`; #908, #656 and the unload/reload suites still pass.

Live proof: uninstall of this code on the observer rig .46 — the shared register must not change (checked from PROD's side too). Recorded on #936 once run.