### PR TITLE
fix(#942): charge mode Off stops the car again, whoever started the session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+- 🚗 **Charge mode *Off* stops the car again** (#942). Since 02.09 the one
+  closing stop was only sent when SEM believed it had started the session —
+  so on a wallbox that had restarted itself, selecting Off did nothing at
+  all, and the car went on charging from the house battery and the grid. The
+  transition into Off now stops whatever is drawing, whoever started it;
+  after that SEM issues nothing, so a charge you start at the box yourself
+  is still left alone (#898), including across a restart.
+
 - 🛡️ **Removing or disabling SEM no longer commands a battery it never
   commanded** (#936). Unload ran "restore discharge to max" on every battery
   adapter, whatever mode SEM was in — an observer-mode test rig rewrote the

--- a/coordinator/charger_reconciler.py
+++ b/coordinator/charger_reconciler.py
@@ -254,6 +254,14 @@ class ChargerReconciler:
         self._failsafe_settled_since_disable: bool = False
         self._last_disable_issued_at: float = 0.0
         self._last_disable_at: float = float("-inf")
+        # (10.09.2026) Off issues ONE stop, then never again — see the
+        # RELEASED row. Starts LATCHED on purpose: a reconciler that opens
+        # its eyes already in Off cannot know whether the user chose Off just
+        # now or an hour ago, and #898's case (a charge started at the box
+        # while Off was already set) must survive a restart. Only the
+        # TRANSITION into Off — a cycle that saw some other desired state
+        # first — clears it and earns the one stop.
+        self._released_stop_issued = True
 
     def snapshot_war(self, now: float) -> dict:
         """(#763 beta.7) The war state for the diagnostics download.
@@ -322,6 +330,25 @@ class ChargerReconciler:
         # DISABLE (the user asked for Off, not for the car to finish); from
         # then on SEM issues nothing — no park-off on unplug, no failsafe
         # naming, no stop-war rounds. Whatever draws, draws.
+        # (10.09.2026) The one closing stop was conditional on
+        # ``_charging_intent_active``, which narrowed Off from "the car
+        # stops" to "the car stops IF SEM believes it started the session".
+        # The commit said as much: "whatever draws, draws". On a live install
+        # that cost 80 minutes of unattended charging — the box auto-restarts
+        # every ~10 min, SEM had stopped it seven times, then stood down from
+        # the stop-war ceasefire (so intent was False), and the owner selected
+        # Off to stop the car. Precisely the case where the session is not
+        # SEM's, so this row answered NONE.
+        #
+        # #898 reported a DIFFERENT moment: "if the charger is now started
+        # elsewhere in HA, SEM stops it soon after" — a session that begins
+        # AFTER Off was chosen. One rule serves both:
+        #   entering Off → ONE stop for whatever is charging, whoever started
+        #                  it, because that is what the user just asked for;
+        #   from then on → nothing, ever, so a charge the user starts at the
+        #                  box afterwards is left alone (#898 stays fixed).
+        # ``_released_stop_issued`` is that latch, cleared below when the mode
+        # leaves Off so the NEXT Off is again an instruction to stop.
         if desired is DesiredState.RELEASED:
             self._end_stop_war()
             self._consecutive_idle_count = 0
@@ -329,14 +356,19 @@ class ChargerReconciler:
             if observed.connected:
                 self._seen_connected = True
                 self._disconnect_run = 0
-            if self._charging_intent_active:
+            if not self._released_stop_issued and (
+                    self._charging_intent_active or observed.charging):
                 self._charging_intent_active = False
+                self._released_stop_issued = True
                 self._enable_attempts = 0
                 self._enable_gave_up_at = 0.0
                 self._last_disable_at = now
                 self._last_disable_issued_at = now
                 return [Action(ActionKind.DISABLE)]
+            self._released_stop_issued = True
             return [Action(ActionKind.NONE)]
+        # Left Off: the next Off selection is a fresh instruction to stop.
+        self._released_stop_issued = False
         # (#823) Recovery: a reported failsafe whose LAST stop has now held
         # quiet for twice the learned interval means the user fixed the box —
         # retire the Repair and re-arm the recogniser, so a later relapse is

--- a/tests/test_898_off_is_hands_off.py
+++ b/tests/test_898_off_is_hands_off.py
@@ -177,3 +177,75 @@ class TestVppPauseKeepsItsStop:
         src = inspect.getsource(coordinator.SEMCoordinator._effective_charge_mode_for)
         assert 'return "off"' not in src
         assert "vpp_pause_override(" in inspect.getsource(coordinator)
+
+
+class TestOffStopsACarThatSemDidNotStart:
+    """(10.09.2026, PROD) Selecting Off must stop whatever is charging.
+
+    #898 narrowed the one closing stop to sessions SEM believed it had
+    started (``_charging_intent_active``), and the commit said what that
+    meant: *"whatever draws, draws"*. On real hardware it meant this:
+
+      16:13–17:48  the KEBA auto-restarts itself every ~10 min; SEM stops it
+                   seven times, every stop taking within seconds
+      18:29:41     the box restarts once more
+      18:29:56     stop-war ceasefire — SEM stands down (intent now False)
+      19:25        the owner selects Off to stop the car
+      → the RELEASED row answered NONE, and the car charged on the house
+        battery and the grid until 19:49, when it was stopped by hand.
+
+    The rule that serves both reports: the TRANSITION into Off issues one
+    stop for whatever is drawing, whoever started it; from then on SEM issues
+    nothing, so #898's own case — a charge started at the box while Off was
+    already set — is still left alone, across restarts too.
+    """
+
+    def test_off_stops_a_box_that_started_itself(self):
+        """The PROD shape: SEM is not charging-intent-active (it had given
+        up), the box is drawing, the user selects Off."""
+        rec = _rec()
+        # a cycle in some other state: this is what makes the next Off a
+        # transition rather than a continuation
+        rec.reconcile(DesiredState.IDLE, 0, _obs(charging=True, power=3100.0),
+                      now=0.0)
+        actions = rec.reconcile(DesiredState.RELEASED, 0,
+                                _obs(charging=True, power=3100.0), now=10.0)
+        assert [a.kind for a in actions] == [ActionKind.DISABLE], (
+            "selecting Off left a drawing charger alone — the #898 regression "
+            "that cost a live install 80 minutes of charging")
+
+    def test_and_then_never_again(self):
+        """#898's rule survives: after that one stop, nothing — including a
+        charge the user starts at the box afterwards."""
+        rec = _rec()
+        rec.reconcile(DesiredState.IDLE, 0, _obs(charging=True, power=3100.0),
+                      now=0.0)
+        rec.reconcile(DesiredState.RELEASED, 0,
+                      _obs(charging=True, power=3100.0), now=10.0)
+        for i in range(6):
+            actions = rec.reconcile(DesiredState.RELEASED, 0,
+                                    _obs(charging=True, power=4000.0),
+                                    now=20.0 + i * 10)
+            assert [a.kind for a in actions] == [ActionKind.NONE]
+
+    def test_a_reconciler_that_wakes_up_in_off_leaves_it_alone(self):
+        """A restart while Off is already selected must not stop the user's
+        charge — the reconciler cannot tell 'chosen just now' from 'chosen an
+        hour ago', so it assumes the safe one."""
+        rec = _rec()
+        actions = rec.reconcile(DesiredState.RELEASED, 0,
+                                _obs(charging=True, power=4000.0), now=0.0)
+        assert [a.kind for a in actions] == [ActionKind.NONE]
+
+    def test_leaving_off_re_arms_the_stop(self):
+        """Off → charge → Off again is a second instruction to stop."""
+        rec = _rec()
+        rec.reconcile(DesiredState.IDLE, 0, _obs(charging=True, power=3100.0), now=0.0)
+        assert [a.kind for a in rec.reconcile(
+            DesiredState.RELEASED, 0, _obs(charging=True, power=3100.0), now=10.0)
+        ] == [ActionKind.DISABLE]
+        rec.reconcile(DesiredState.CHARGE, 10, _obs(charging=False), now=20.0)
+        rec.reconcile(DesiredState.CHARGE, 10, _obs(charging=True, power=4000.0), now=30.0)
+        assert [a.kind for a in rec.reconcile(
+            DesiredState.RELEASED, 0, _obs(charging=True, power=4000.0), now=40.0)
+        ] == [ActionKind.DISABLE]


### PR DESCRIPTION
Fixes #942.

`e60b7fec` (#898, 02.09) made the one closing stop conditional on `_charging_intent_active`, redefining Off from *"the car stops"* to *"the car stops if SEM believes it started the session"* — its own commit message said the consequence: **"whatever draws, draws."**

On PROD tonight the KEBA auto-restarted itself every ~10 min and SEM stopped it seven times; at 18:29 the stop-war ceasefire stood down, so the intent was False; the owner selected Off at 19:25 to save the house battery, and the RELEASED row answered NONE. The car drew 3.1 kW from the battery and the grid until it was stopped by hand at 19:49.

**One rule for both reports.** #898's case is a session started *after* Off was chosen; this is a session running *when* Off is chosen:

- transition into Off → one stop for whatever is drawing, whoever started it;
- from then on → nothing, ever, so a charge started at the box afterwards is left alone.

`_released_stop_issued` starts **armed**, so a reconciler waking up already in Off leaves a running charge alone — it cannot tell "chosen a second ago" from "chosen an hour ago", and #898 must survive a restart.

**Verification**
- Four regression tests carrying the timeline; mutation-checked — restore the old condition and exactly the two pinning this failure go red, every #898 case stays green.
- Full suite 9857 passed / 1 skipped / 0 failed.
- Deployed to .46 (observer): entry loaded, 314 entities, 0 SEM errors, validation 6 passed.

**Not in this PR** (same night, separate): the ceasefire stands down silently while the car draws — that is what let it run from 18:29 to 19:25 before Off was even tried.