### PR TITLE
feat(#935): clean uninstall — SEM hands the house back and takes its own files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 # [Unreleased]
 
+- ✨ **Removing SEM now hands the house back** (#935, #908). SEM used to leave
+  behind everything it had written: its stores, its version marker, its
+  Repairs, dashboard resources pointing at files that no longer existed, and
+  — if it had parked your wallbox — a charger holding a standing "no" with
+  nothing left on the system to lift it. Removal now takes SEM's own files and
+  re-enables a box only SEM parked. A re-install sweeps the stores of installs
+  that came before (files it does not recognise are logged, never deleted).
+  Your history is still yours: the long-term statistics and the generated
+  dashboard are removed only by the new **Remove leftovers** action, which is
+  worth running *before* you uninstall.
+
 # [2.1.0-beta.18] — 12.09.2026
 
 - 🐛 **Huawei owners: check your battery target SOC** (#950). SEM's hardware

--- a/__init__.py
+++ b/__init__.py
@@ -126,6 +126,11 @@ _PENDING_LOAD_TEARDOWN: Dict[str, List["ControllableDevice"]] = {}
 # adopt the engagement, so without this the register keeps SEM's cap for good.
 _PENDING_PACING_RESTORE: Dict[str, tuple] = {}
 
+# (#935) And the same for a wallbox SEM parked: the box holds a standing "no"
+# — disabled contactor, 0 A stored, a persisted dead-man failsafe — which is
+# the point while SEM is away for a moment, and abandonment once SEM is gone.
+_PENDING_CHARGER_RELEASE: Dict[str, List[Any]] = {}
+
 
 async def _maybe_emit_upgrade_notification(hass, entry) -> None:
     """Fire a one-shot persistent notification when SEM has upgraded.
@@ -2101,6 +2106,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     # (#949) Same reasoning for the paced charge limit: SEM is back, and the
     # fresh writer adopts the engagement from its own record.
     _PENDING_PACING_RESTORE.pop(entry.entry_id, None)
+    # (#935) A reload is not an abandonment: the charger stays parked and the
+    # fresh cycle decides again in seconds.
+    _PENDING_CHARGER_RELEASE.pop(entry.entry_id, None)
 
     # (#935) Sweep the stores of SEM entries that no longer exist. A removed
     # and re-added install keeps the previous entry id's pair for ever — the
@@ -3047,6 +3055,16 @@ async def async_remove_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> None
     # leaves the inverter's max-charge-power at its last cap throttles the
     # battery with nothing left on the system that knows why, and a re-install
     # would capture that cap as the hardware maximum.
+    # (#935) The wallbox first: it is the one leftover a person meets rather
+    # than finds — a box that will not charge and gives no reason.
+    for _dev in _PENDING_CHARGER_RELEASE.pop(entry.entry_id, None) or []:
+        try:
+            said = await _dev.release_to_user(reason="integration removed")
+            if said:
+                _LOGGER.info("SEM removed: %s", said)
+        except Exception as e:  # noqa: BLE001 — a removal always completes
+            _LOGGER.warning("SEM removed: charger hand-back failed: %s", e)
+
     held = _PENDING_PACING_RESTORE.pop(entry.entry_id, None)
     if held:
         from .coordinator.charge_pacing import async_release_pacing
@@ -3107,7 +3125,8 @@ async def _async_sweep_orphan_stores(hass: HomeAssistant) -> None:
 
     try:
         live = [e.entry_id for e in hass.config_entries.async_entries(DOMAIN)]
-        orphans = cleanup.orphan_store_keys(hass, live)
+        on_disk = await cleanup.async_existing_store_files(hass)
+        orphans = cleanup.orphan_store_keys(on_disk, live)
         if not orphans:
             return
         removed = await cleanup.async_delete_stores(hass, orphans)
@@ -3152,6 +3171,25 @@ async def async_unload_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool
             from .coordinator.charge_pacing import (
                 async_release_pacing, pending_pacing_release,
             )
+            # (#935) The charger, on the same "only what SEM commanded"
+            # rule and the same branch structure: a reload leaves a parked
+            # box parked (SEM is coming back in seconds and will decide
+            # again), a disable hands it back now, a removal replays it
+            # from async_remove_entry.
+            _parked = [
+                dev for dev in (getattr(coordinator, "_ev_devices", None)
+                                or {}).values()
+                if getattr(dev, "_sem_parked", False)
+            ]
+            if _parked:
+                if entry.disabled_by is not None:
+                    for _dev in _parked:
+                        _said = await _dev.release_to_user(reason="disabled")
+                        if _said:
+                            _LOGGER.info("SEM disabled: %s", _said)
+                else:
+                    _PENDING_CHARGER_RELEASE[entry.entry_id] = _parked
+
             _held = pending_pacing_release(coordinator)
             if _held:
                 if entry.disabled_by is not None:
@@ -3213,6 +3251,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool
             "register_surplus_device",
             "schedule_appliance",
             "cancel_appliance_schedule",
+            "remove_leftovers",
         ):
             hass.services.async_remove(DOMAIN, service_name)
 

--- a/__init__.py
+++ b/__init__.py
@@ -2555,6 +2555,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
 
             coordinator._surplus_controller.register_device(ev_device)
             coordinator._ev_devices[charger_id] = ev_device
+            # (#935) The park debt has to outlive the process that took it —
+            # see `_remember_parked`. One store per entry, every charger in
+            # it; adopted just below, once, when they are all built.
+            ev_device._park_store = _park_store(hass, entry)
+            ev_device.charger_id = charger_id
             ev_device.managed_externally = True
             _LOGGER.info(
                 "EV charger '%s' registered as CurrentControlDevice "
@@ -2756,6 +2761,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
             "Load management initialization failed (non-critical). "
             "Load management features will be unavailable."
         )
+
+    # (#935) Every charger is built by now, so take back any park a previous
+    # lifetime left on the hardware — the reconciler cannot re-derive it
+    # (PARK_OFF fires on an edge; an already-empty box at boot is not one).
+    hass.async_create_task(_async_adopt_parked_chargers(hass, entry, coordinator))
 
     # (#923) ONE module verdict for every platform: captured here, after the
     # Energy Dashboard read above and before any platform builds entities —
@@ -3110,6 +3120,47 @@ async def _async_take_sems_own_files(hass: HomeAssistant,
             "" if remaining else " (last entry: install-wide stores too)")
     except Exception as e:  # noqa: BLE001 — a removal must always complete
         _LOGGER.warning("SEM removed: cleanup incomplete (non-blocking): %s", e)
+
+
+def _park_store(hass: HomeAssistant, entry: SEMConfigEntry):
+    """(#935) Where "SEM parked this box" lives across restarts."""
+    entry_id = str(getattr(entry, "entry_id", "") or "")
+    if not entry_id:
+        return None
+    try:
+        from homeassistant.helpers.storage import Store
+        return Store(hass, 1, f"sem.parked.{entry_id}")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def _async_adopt_parked_chargers(hass: HomeAssistant,
+                                       entry: SEMConfigEntry,
+                                       coordinator) -> None:
+    """(#935) Take over the parks a previous lifetime left on the hardware.
+
+    The reconciler cannot re-derive them: PARK_OFF fires on the
+    connect→disconnect EDGE, and a box that is already empty at boot is a
+    steady state. Without this, park → restart → remove left the charger
+    disabled with its own persisted dead-man failsafe holding it at 0 A, and
+    nothing left on the system that knew why.
+    """
+    store = _park_store(hass, entry)
+    if store is None:
+        return
+    try:
+        record = await store.async_load() or {}
+        ids = record.get("parked") or []
+        if not ids:
+            return
+        for dev in (getattr(coordinator, "_ev_devices", None) or {}).values():
+            adopt = getattr(dev, "adopt_park_state", None)
+            if callable(adopt):
+                adopt(ids)
+        _LOGGER.info("#935 — adopted %d charger park(s) this install was "
+                     "left with: %s", len(ids), ", ".join(map(str, ids)))
+    except Exception as e:  # noqa: BLE001 — never block a setup
+        _LOGGER.debug("#935 park adoption skipped: %s", e)
 
 
 async def _async_sweep_orphan_stores(hass: HomeAssistant) -> None:
@@ -3530,7 +3581,11 @@ async def _async_register_services(
         done = {"statistics": 0, "dashboard": False}
 
         if want_stats:
-            ids = cleanup.sem_statistic_ids(hass)
+            # Scoped to THIS entry: a second SEM entry's history is not part
+            # of this entry's leftovers (#935 review).
+            _entry_id = str(getattr(
+                getattr(coordinator, "config_entry", None), "entry_id", "") or "")
+            ids = cleanup.sem_statistic_ids(hass, _entry_id or None)
             done["statistics"] = await cleanup.async_clear_statistics(hass, ids)
         if want_dashboard:
             done["dashboard"] = await cleanup.async_remove_dashboard(hass)

--- a/__init__.py
+++ b/__init__.py
@@ -2102,6 +2102,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
     # fresh writer adopts the engagement from its own record.
     _PENDING_PACING_RESTORE.pop(entry.entry_id, None)
 
+    # (#935) Sweep the stores of SEM entries that no longer exist. A removed
+    # and re-added install keeps the previous entry id's pair for ever — the
+    # .46 rig carried seven pairs and ninety-six version markers — and they
+    # make "is this a fresh install?" unanswerable. SEM's OWN files, so they
+    # go without asking; what is the user's is offered instead (the Repair
+    # below points at `remove_leftovers`).
+    hass.async_create_task(_async_sweep_orphan_stores(hass))
+
     # In-memory SEM log ring buffer for the diagnose surface (#461/#462
     # triage gap on Supervisor installs — no flat log file to tail).
     # Idempotent across reloads. Stored under its own key so code that
@@ -3047,9 +3055,73 @@ async def async_remove_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> None
             _LOGGER.info("SEM removed: %s", said)
 
     devices = _PENDING_LOAD_TEARDOWN.pop(entry.entry_id, None)
-    if not devices:
-        return
-    await _async_deactivate_surplus_loads(devices, "integration removed")
+    if devices:
+        await _async_deactivate_surplus_loads(devices, "integration removed")
+
+    # (#935) ...and then SEM takes its OWN files. Everything below belongs to
+    # SEM and to nobody else: this entry's stores, its version marker, its
+    # Repairs, and the Lovelace resources pointing at a module that is about
+    # to stop existing. What is the USER's — the generated dashboard, the
+    # long-term statistics — is deliberately NOT here; it goes through the
+    # `remove_leftovers` service, on an explicit choice.
+    await _async_take_sems_own_files(hass, entry)
+
+
+async def _async_take_sems_own_files(hass: HomeAssistant,
+                                     entry: SEMConfigEntry) -> None:
+    """(#935) Delete what SEM created, on removal. Never raises."""
+    from . import cleanup
+
+    try:
+        stores = await cleanup.async_entry_stores_removed(hass, entry.entry_id)
+        # Install-wide stores go with the LAST entry only: a second SEM entry
+        # still needs the device mappings and the load priorities.
+        remaining = [
+            e for e in hass.config_entries.async_entries(DOMAIN)
+            if e.entry_id != entry.entry_id
+        ]
+        if not remaining:
+            stores += await cleanup.async_delete_stores(
+                hass, cleanup.install_wide_store_keys())
+        repairs = cleanup.delete_repairs(hass)
+        resources = await cleanup.async_deregister_resources(hass)
+        _LOGGER.info(
+            "SEM removed: took its own files — %d store(s), %d repair(s), "
+            "%d frontend resource(s)%s",
+            len(stores), repairs, len(resources),
+            "" if remaining else " (last entry: install-wide stores too)")
+    except Exception as e:  # noqa: BLE001 — a removal must always complete
+        _LOGGER.warning("SEM removed: cleanup incomplete (non-blocking): %s", e)
+
+
+async def _async_sweep_orphan_stores(hass: HomeAssistant) -> None:
+    """(#935) Delete SEM stores whose config entry is gone, and say so.
+
+    Runs on setup rather than on removal, because the install that left them
+    behind is the one that could not clean up: every SEM before this change,
+    and any removal that never reached ``async_remove_entry`` (a disk full, a
+    kill during shutdown). Files SEM does not recognise are never touched —
+    they are named in the log and left where they are.
+    """
+    from . import cleanup
+
+    try:
+        live = [e.entry_id for e in hass.config_entries.async_entries(DOMAIN)]
+        orphans = cleanup.orphan_store_keys(hass, live)
+        if not orphans:
+            return
+        removed = await cleanup.async_delete_stores(hass, orphans)
+        _LOGGER.info(
+            "#935 — removed %d store(s) left by a previous SEM install: %s",
+            len(removed), ", ".join(removed[:6])
+            + ("…" if len(removed) > 6 else ""))
+        # What is the USER's cannot be swept: a previous install's dashboard
+        # and its long-term statistics are theirs to keep or drop. Say that
+        # once, where they will see it, and give them the one-click path.
+        from .coordinator.repair_issues import raise_previous_install_leftovers
+        raise_previous_install_leftovers(hass, len(removed))
+    except Exception as e:  # noqa: BLE001 — a sweep never blocks a setup
+        _LOGGER.debug("#935 orphan sweep skipped: %s", e)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: SEMConfigEntry) -> bool:
@@ -3397,6 +3469,44 @@ async def _async_register_services(
         _LOGGER.debug("Registered service: %s.replan", DOMAIN)
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to register replan service: %s", err)
+
+    async def async_remove_leftovers_service(call) -> None:
+        """(#935) Delete what is the USER's, on their explicit say-so.
+
+        SEM takes its own files on removal without asking. This service is the
+        other half: the generated dashboard and the long-term statistics of
+        SEM's entities are the user's history — a year of solar yield is not
+        SEM's to throw away because it is being uninstalled — so they are only
+        ever removed by someone choosing to remove them.
+
+        Documented as "run this BEFORE removing SEM", because after removal
+        there is no SEM left to run it.
+        """
+        from . import cleanup
+        from .coordinator.repair_issues import clear_previous_install_leftovers
+
+        want_stats = bool(call.data.get("statistics", True))
+        want_dashboard = bool(call.data.get("dashboard", False))
+        done = {"statistics": 0, "dashboard": False}
+
+        if want_stats:
+            ids = cleanup.sem_statistic_ids(hass)
+            done["statistics"] = await cleanup.async_clear_statistics(hass, ids)
+        if want_dashboard:
+            done["dashboard"] = await cleanup.async_remove_dashboard(hass)
+
+        clear_previous_install_leftovers(hass)
+        _LOGGER.info(
+            "#935 remove_leftovers: cleared %d statistic(s), dashboard %s",
+            done["statistics"],
+            "removed" if done["dashboard"] else "kept")
+
+    try:
+        hass.services.async_register(
+            DOMAIN, "remove_leftovers", async_remove_leftovers_service)
+        _LOGGER.debug("Registered service: %s.remove_leftovers", DOMAIN)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.error("Failed to register remove_leftovers service: %s", err)
 
     # Check if services are already registered (prevents conflicts on reload)
     services_already_registered = hass.services.has_service(DOMAIN, "sync_priorities_from_dashboard")

--- a/__init__.py
+++ b/__init__.py
@@ -3524,8 +3524,9 @@ async def _async_register_services(
         from . import cleanup
         from .coordinator.repair_issues import clear_previous_install_leftovers
 
-        want_stats = bool(call.data.get("statistics", True))
-        want_dashboard = bool(call.data.get("dashboard", False))
+        # The schema has already coerced and defaulted these.
+        want_stats = call.data["statistics"]
+        want_dashboard = call.data["dashboard"]
         done = {"statistics": 0, "dashboard": False}
 
         if want_stats:
@@ -3541,8 +3542,22 @@ async def _async_register_services(
             "removed" if done["dashboard"] else "kept")
 
     try:
+        # (#935) A SCHEMA, because the two fields are destructive and their
+        # asymmetry is the safety: statistics default on, the dashboard off.
+        # Registered bare, `dashboard: 12345` reached `bool(12345)` and the
+        # off-by-default option armed itself — the rig's dashboard was
+        # deleted by a junk value in a fault-injection call (13.09).
         hass.services.async_register(
-            DOMAIN, "remove_leftovers", async_remove_leftovers_service)
+            DOMAIN, "remove_leftovers", async_remove_leftovers_service,
+            schema=vol.Schema({
+                # A real boolean, not cv.boolean: that accepts any non-zero
+                # NUMBER as yes (cv.boolean(12345) is True), and a truthy
+                # number is not consent to an irreversible delete. Both of
+                # these throw away history that cannot be got back, so they
+                # take true or false and nothing else.
+                vol.Optional("statistics", default=True): bool,
+                vol.Optional("dashboard", default=False): bool,
+            }))
         _LOGGER.debug("Registered service: %s.remove_leftovers", DOMAIN)
     except Exception as err:  # noqa: BLE001
         _LOGGER.error("Failed to register remove_leftovers service: %s", err)

--- a/cleanup.py
+++ b/cleanup.py
@@ -1,0 +1,331 @@
+"""#935 — what SEM leaves behind, in ONE place.
+
+Removing SEM today deletes a config entry and releases the loads it started.
+Everything else it created stays: the per-entry stores, the version marker,
+its Repairs, the Lovelace resources pointing at files that are about to
+vanish, and — when SEM parked a wallbox — a charger holding "no" with nothing
+left on the system to say "yes". @markusschloesser's Spook run on #908 found
+119 leftover statistics; the statistics turned out to be the smallest part.
+
+Three rules, from the issue:
+
+* **Hand the hardware back** — and only what SEM itself commanded. That is
+  #908's rule (loads), extended by #936 (batteries) and #949 (the charge
+  pacer). The charger is the last one.
+* **Take its own files** — this entry's stores, its version marker, its
+  Repairs, its Lovelace resources. Orphans of older entry ids are swept on
+  the next setup and reported, never silently.
+* **Offer what is the user's** — the generated dashboard and the long-term
+  statistics belong to them. Those are deleted only on an explicit choice.
+
+This module is the INVENTORY and the mechanics; the lifecycle hooks in
+``__init__.py`` decide when to call them. Nothing here raises: a teardown
+that fails half way must still let HA remove the entry.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterable, List, Optional, Sequence
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+#: Per-entry stores, by the key each owner builds. Kept as format strings so
+#: the inventory reads like the code that creates them:
+#:   coordinator/storage.py  -> f"{DOMAIN}_{entry_id}_energy" / "_daily"
+#:   __init__.py             -> f"sem_seen_version_{entry_id}"
+#:   coordinator/coordinator.py (#949) -> f"sem.pacing.{entry_id}"
+_PER_ENTRY_STORE_FORMATS: tuple[str, ...] = (
+    f"{DOMAIN}_{{entry_id}}_energy",
+    f"{DOMAIN}_{{entry_id}}_daily",
+    "sem_seen_version_{entry_id}",
+    "sem.pacing.{entry_id}",
+)
+
+#: Per-entry stores whose key carries a SECOND scope (a battery id), so they
+#: are matched by prefix rather than built by name.
+#:   coordinator/battery_adapters/deye_snapshot_store.py
+_PER_ENTRY_STORE_PREFIXES: tuple[str, ...] = (
+    "sem.deye.snapshot.{entry_id}.",
+    "sem.deye.unsafe.{entry_id}.",
+)
+
+#: Stores SEM keeps ONCE for the whole installation, not per entry. They are
+#: removed only when the LAST SEM entry goes — a second entry still needs its
+#: device mappings and its load priorities.
+_INSTALL_WIDE_STORES: tuple[str, ...] = (
+    "sem_device_mappings",
+    f"{DOMAIN}_load_management_devices",
+)
+
+#: Names SEM used before the per-entry scheme and no longer writes. They are
+#: pure leftovers on any install old enough to have them (both are live on
+#: PROD today), so they go with the last entry like the install-wide ones.
+_LEGACY_STORES: tuple[str, ...] = (
+    f"{DOMAIN}_daily_storage",
+    f"{DOMAIN}_energy_totals",
+)
+
+
+def per_entry_store_keys(entry_id: str) -> List[str]:
+    """Every store key that belongs to exactly this config entry."""
+    entry_id = str(entry_id or "")
+    if not entry_id:
+        # A degenerate id would match the prefix of every entry's stores.
+        return []
+    return [fmt.format(entry_id=entry_id) for fmt in _PER_ENTRY_STORE_FORMATS]
+
+
+def per_entry_store_prefixes(entry_id: str) -> List[str]:
+    """Key prefixes whose matches belong to this entry (Deye, per battery)."""
+    entry_id = str(entry_id or "")
+    if not entry_id:
+        return []
+    return [fmt.format(entry_id=entry_id) for fmt in _PER_ENTRY_STORE_PREFIXES]
+
+
+def install_wide_store_keys() -> List[str]:
+    """Stores shared by every SEM entry, plus the retired names."""
+    return [*_INSTALL_WIDE_STORES, *_LEGACY_STORES]
+
+
+def _storage_dir(hass) -> Optional[str]:
+    try:
+        return os.path.join(hass.config.config_dir, ".storage")
+    except Exception:  # noqa: BLE001 — a stand-in hass in tests
+        return None
+
+
+def existing_store_files(hass) -> List[str]:
+    """The SEM-looking store keys actually present on disk.
+
+    Reading the directory rather than trusting the inventory is deliberate:
+    the point of the orphan sweep is to find files whose owner no longer
+    exists, and an owner that no longer exists cannot name its own key.
+    """
+    path = _storage_dir(hass)
+    if not path:
+        return []
+    try:
+        names = os.listdir(path)
+    except OSError:
+        return []
+    return sorted(
+        n for n in names
+        if (n.startswith((f"{DOMAIN}_", "sem_", "sem.")) and "." != n[-1])
+        and not n.endswith(".bak")
+        and ".bak." not in n
+    )
+
+
+def orphan_store_keys(hass, live_entry_ids: Iterable[str]) -> List[str]:
+    """SEM store files on disk that no live config entry owns.
+
+    An install that has been removed and re-added carries the previous entry
+    id's pair for ever — seven of them on the .46 rig, ninety-six version
+    markers. They are dead weight, and worse, they make "is this a fresh
+    install?" unanswerable.
+
+    Install-wide and legacy stores are NOT orphans while any entry lives:
+    they have no entry id in their name and are still in use.
+    """
+    live = {str(e) for e in live_entry_ids if e}
+    keep_whole = set(install_wide_store_keys())
+    owned: set[str] = set()
+    prefixes: List[str] = []
+    for entry_id in live:
+        owned.update(per_entry_store_keys(entry_id))
+        prefixes.extend(per_entry_store_prefixes(entry_id))
+    out = []
+    for name in existing_store_files(hass):
+        if name in keep_whole or name in owned:
+            continue
+        if any(name.startswith(p) for p in prefixes):
+            continue
+        # Only files that CARRY an entry-scoped shape can be orphans. A SEM
+        # store nobody has taught this module about is left alone and named
+        # in the report — deleting an unrecognised file is how a cleanup
+        # becomes the problem it was written to solve.
+        if _looks_entry_scoped(name):
+            out.append(name)
+    return out
+
+
+def _looks_entry_scoped(name: str) -> bool:
+    """True when the key carries a config-entry id in one of SEM's shapes."""
+    if name.startswith("sem_seen_version_"):
+        return len(name) > len("sem_seen_version_")
+    if name.startswith(("sem.pacing.", "sem.deye.snapshot.", "sem.deye.unsafe.")):
+        return True
+    if name.startswith(f"{DOMAIN}_") and name.endswith(("_energy", "_daily")):
+        middle = name[len(DOMAIN) + 1:].rsplit("_", 1)[0]
+        return bool(middle) and middle not in ("load_management", "totals")
+    return False
+
+
+async def async_delete_stores(hass, keys: Sequence[str]) -> List[str]:
+    """Remove each store by key. Returns the keys actually removed."""
+    from homeassistant.helpers.storage import Store
+
+    removed: List[str] = []
+    for key in keys:
+        try:
+            await Store(hass, 1, key).async_remove()
+            removed.append(key)
+        except Exception:  # noqa: BLE001 — one bad file never stops the rest
+            _LOGGER.debug("SEM cleanup: could not remove store %s", key,
+                          exc_info=True)
+    return removed
+
+
+async def async_entry_stores_removed(hass, entry_id: str) -> List[str]:
+    """Delete everything this entry owns, including its prefix-scoped stores."""
+    keys = list(per_entry_store_keys(entry_id))
+    prefixes = per_entry_store_prefixes(entry_id)
+    if prefixes:
+        keys.extend(
+            n for n in existing_store_files(hass)
+            if any(n.startswith(p) for p in prefixes)
+        )
+    return await async_delete_stores(hass, keys)
+
+
+def delete_repairs(hass) -> int:
+    """Delete every Repair issue SEM raised. Returns how many.
+
+    SEM's issues are all created under its own domain, so the domain IS the
+    inventory — no list to keep in step with ``repair_issues.py``, which has
+    a dozen issue-id builders and grows.
+    """
+    try:
+        from homeassistant.helpers import issue_registry as ir
+
+        registry = ir.async_get(hass)
+        mine = [
+            key[1] for key in list(getattr(registry, "issues", {}))
+            if isinstance(key, tuple) and len(key) == 2 and key[0] == DOMAIN
+        ]
+        for issue_id in mine:
+            ir.async_delete_issue(hass, DOMAIN, issue_id)
+        return len(mine)
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("SEM cleanup: could not clear repairs", exc_info=True)
+        return 0
+
+
+def _is_sem_resource(url: str) -> bool:
+    """A Lovelace resource URL SEM registered.
+
+    Matched on SEM's own path, not on the file name: a user who hand-added a
+    resource of their own that happens to be called ``sem-cards.js`` from
+    somewhere else keeps it.
+    """
+    url = str(url or "")
+    return f"/{DOMAIN}/dashboard/card/" in url or url.startswith(
+        f"/local/{DOMAIN}/")
+
+
+async def async_deregister_resources(hass) -> List[str]:
+    """Drop SEM's Lovelace resource rows. Returns the URLs removed.
+
+    Registration happens on every setup and nothing ever undid it, so after a
+    removal every dashboard load fetched a module that is gone — a console
+    error on a system that no longer has SEM installed to explain it.
+    """
+    from homeassistant.helpers.storage import Store
+
+    try:
+        store = Store(hass, 1, "lovelace_resources")
+        data = await store.async_load() or {}
+        items = list(data.get("items") or [])
+        keep = [i for i in items if not _is_sem_resource(i.get("url"))]
+        dropped = [str(i.get("url")) for i in items if _is_sem_resource(i.get("url"))]
+        if dropped:
+            data["items"] = keep
+            await store.async_save(data)
+        return dropped
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("SEM cleanup: could not deregister resources",
+                      exc_info=True)
+        return []
+
+
+def sem_statistic_ids(hass) -> List[str]:
+    """The long-term statistic ids that belong to SEM's own entities.
+
+    Read from the entity registry, so it is this install's actual entities
+    and not a guess from a name pattern.
+    """
+    try:
+        from homeassistant.helpers import entity_registry as er
+
+        return sorted(
+            e.entity_id for e in er.async_get(hass).entities.values()
+            if e.platform == DOMAIN
+        )
+    except Exception:  # noqa: BLE001
+        return []
+
+
+async def async_clear_statistics(hass, statistic_ids: Sequence[str]) -> int:
+    """Clear SEM's long-term statistics — ONLY ever on an explicit choice.
+
+    Home Assistant keeps statistics after an entity is removed on purpose:
+    they are the user's history, and a year of solar yield is not SEM's to
+    throw away because SEM is being uninstalled. So this is never part of the
+    automatic teardown; it is behind the ``remove_leftovers`` service.
+    """
+    ids = [s for s in statistic_ids if s]
+    if not ids:
+        return 0
+    try:
+        await hass.services.async_call(
+            "recorder", "clear_statistics", {"statistic_ids": ids},
+            blocking=True)
+        return len(ids)
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning("SEM cleanup: could not clear statistics (recorder "
+                        "may be disabled)")
+        return 0
+
+
+#: The dashboard SEM generates, and its sidebar entry. Both are the USER's
+#: once created — they may have edited it — so nothing here runs without an
+#: explicit ``remove_leftovers`` call.
+_DASHBOARD_PATH = "sem-dashboard"
+_DASHBOARD_STORE = f"lovelace.{_DASHBOARD_PATH}"
+
+
+async def async_remove_dashboard(hass, path: str = _DASHBOARD_PATH) -> bool:
+    """Delete the generated dashboard and its sidebar entry. Explicit only.
+
+    Returns True when something was removed. The two halves are separate
+    files — the view config (``lovelace.sem-dashboard``) and the row in
+    ``lovelace_dashboards`` that puts it in the sidebar — and leaving either
+    behind gives a broken sidebar entry or an invisible orphan, so both go or
+    neither does.
+    """
+    from homeassistant.helpers.storage import Store
+
+    removed = False
+    try:
+        await Store(hass, 1, f"lovelace.{path}").async_remove()
+        removed = True
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("SEM cleanup: no dashboard store to remove",
+                      exc_info=True)
+    try:
+        store = Store(hass, 1, "lovelace_dashboards")
+        data = await store.async_load() or {}
+        items = list(data.get("items") or [])
+        keep = [i for i in items if i.get("id") != path]
+        if len(keep) != len(items):
+            data["items"] = keep
+            await store.async_save(data)
+            removed = True
+    except Exception:  # noqa: BLE001
+        _LOGGER.debug("SEM cleanup: could not drop the sidebar entry",
+                      exc_info=True)
+    return removed

--- a/cleanup.py
+++ b/cleanup.py
@@ -291,11 +291,19 @@ async def async_deregister_resources(hass) -> List[str]:
         return []
 
 
-def sem_statistic_ids(hass) -> List[str]:
+def sem_statistic_ids(hass, entry_id: Optional[str] = None) -> List[str]:
     """The long-term statistic ids that belong to SEM's own entities.
 
     Read from the entity registry, so it is this install's actual entities
     and not a guess from a name pattern.
+
+    Scoped to ONE config entry when given one. Filtering on the platform
+    alone was right for the common single-entry install and wrong for the
+    only case that matters here: with two SEM entries, clearing "the
+    leftovers" before removing the first would have taken the whole history
+    of the second, which has no leftover problem and was never mentioned in
+    the call (#935 review). An entry that owns no entities returns nothing,
+    which is the honest answer and clears nothing.
     """
     try:
         from homeassistant.helpers import entity_registry as er
@@ -303,6 +311,7 @@ def sem_statistic_ids(hass) -> List[str]:
         return sorted(
             e.entity_id for e in er.async_get(hass).entities.values()
             if e.platform == DOMAIN
+            and (entry_id is None or e.config_entry_id == entry_id)
         )
     except Exception:  # noqa: BLE001
         return []

--- a/cleanup.py
+++ b/cleanup.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Iterable, List, Optional, Sequence
 
 from .const import DOMAIN
@@ -170,15 +171,35 @@ def orphan_store_keys(names: Iterable[str],
     return out
 
 
+#: What a Home Assistant config-entry id looks like: a 26-character ULID
+#: (``01M2BQ1A7MWSNS021PMT5XQMQA``), or the 32-hex-character ids older
+#: installs still carry.
+_ENTRY_ID_RE = re.compile(r"^(?:[0-9A-Z]{26}|[0-9a-f]{32})$")
+
+
+def _is_entry_id(text: str) -> bool:
+    return bool(_ENTRY_ID_RE.match(text or ""))
+
+
 def _looks_entry_scoped(name: str) -> bool:
-    """True when the key carries a config-entry id in one of SEM's shapes."""
+    """True when the key carries a real config-entry id in one of SEM's shapes.
+
+    The id must LOOK like one. The first cut accepted any middle segment, and
+    a fault-injection run on the .46 rig (13.09) deleted a file a user had
+    copied aside by hand as ``solar_energy_management_mybackup_energy`` — it
+    read as an orphaned install's store. A sweep that deletes someone's own
+    file is the exact problem this module exists to avoid, so the shape is
+    checked rather than assumed: anything else is unrecognised, and
+    unrecognised is left alone and named in the log.
+    """
+    for prefix in ("sem.pacing.", "sem.deye.snapshot.", "sem.deye.unsafe."):
+        if name.startswith(prefix):
+            # deye keys carry a second scope (the battery id) after the entry
+            return _is_entry_id(name[len(prefix):].split(".", 1)[0])
     if name.startswith("sem_seen_version_"):
-        return len(name) > len("sem_seen_version_")
-    if name.startswith(("sem.pacing.", "sem.deye.snapshot.", "sem.deye.unsafe.")):
-        return True
+        return _is_entry_id(name[len("sem_seen_version_"):])
     if name.startswith(f"{DOMAIN}_") and name.endswith(("_energy", "_daily")):
-        middle = name[len(DOMAIN) + 1:].rsplit("_", 1)[0]
-        return bool(middle) and middle not in ("load_management", "totals")
+        return _is_entry_id(name[len(DOMAIN) + 1:].rsplit("_", 1)[0])
     return False
 
 

--- a/cleanup.py
+++ b/cleanup.py
@@ -315,19 +315,34 @@ async def async_clear_statistics(hass, statistic_ids: Sequence[str]) -> int:
     they are the user's history, and a year of solar yield is not SEM's to
     throw away because SEM is being uninstalled. So this is never part of the
     automatic teardown; it is behind the ``remove_leftovers`` service.
+
+    Through the recorder's own API, not a service call. The first cut called
+    ``recorder.clear_statistics``, which does not exist — the recorder
+    publishes purge / purge_entities / enable / disable / get_statistics and
+    clears statistics over its WEBSOCKET api. So every call failed, warned
+    "recorder may be disabled" about a recorder that was loaded and running,
+    and reported nothing cleared. Live on the .46 rig, 13.09.
     """
     ids = [s for s in statistic_ids if s]
     if not ids:
         return 0
     try:
-        await hass.services.async_call(
-            "recorder", "clear_statistics", {"statistic_ids": ids},
-            blocking=True)
-        return len(ids)
-    except Exception:  # noqa: BLE001
-        _LOGGER.warning("SEM cleanup: could not clear statistics (recorder "
-                        "may be disabled)")
+        from homeassistant.components.recorder import get_instance
+
+        instance = get_instance(hass)
+    except Exception:  # noqa: BLE001 — recorder genuinely absent
+        _LOGGER.warning(
+            "SEM cleanup: the recorder is not loaded — %d statistic id(s) "
+            "left untouched", len(ids))
         return 0
+    try:
+        # Queued on the recorder's own thread; the call returns once the task
+        # is accepted, which is why the count is what was HANDED OVER.
+        instance.async_clear_statistics(ids)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.warning("SEM cleanup: the recorder refused the clear: %s", e)
+        return 0
+    return len(ids)
 
 
 #: The dashboard SEM generates, and its sidebar entry. Both are the USER's

--- a/cleanup.py
+++ b/cleanup.py
@@ -98,30 +98,47 @@ def _storage_dir(hass) -> Optional[str]:
         return None
 
 
-def existing_store_files(hass) -> List[str]:
-    """The SEM-looking store keys actually present on disk.
+def sem_store_names(names: Iterable[str]) -> List[str]:
+    """The SEM-looking store keys out of a raw directory listing.
 
-    Reading the directory rather than trusting the inventory is deliberate:
-    the point of the orphan sweep is to find files whose owner no longer
-    exists, and an owner that no longer exists cannot name its own key.
+    Pure, so the sweep's judgement can be tested without a filesystem — and
+    so the one call that touches the disk has a single home (below).
     """
-    path = _storage_dir(hass)
-    if not path:
-        return []
-    try:
-        names = os.listdir(path)
-    except OSError:
-        return []
     return sorted(
         n for n in names
-        if (n.startswith((f"{DOMAIN}_", "sem_", "sem.")) and "." != n[-1])
+        if (n.startswith((f"{DOMAIN}_", "sem_", "sem.")) and not n.endswith("."))
         and not n.endswith(".bak")
         and ".bak." not in n
     )
 
 
-def orphan_store_keys(hass, live_entry_ids: Iterable[str]) -> List[str]:
-    """SEM store files on disk that no live config entry owns.
+def _listdir(path: str) -> List[str]:
+    try:
+        return os.listdir(path)
+    except OSError:
+        return []
+
+
+async def async_existing_store_files(hass) -> List[str]:
+    """The SEM store keys actually present on disk.
+
+    Reading the directory rather than trusting the inventory is deliberate:
+    the point of the orphan sweep is to find files whose owner no longer
+    exists, and an owner that no longer exists cannot name its own key.
+
+    Off the event loop — a config directory on a slow SD card is exactly the
+    kind of listing HA's blocking-call guard exists to catch.
+    """
+    path = _storage_dir(hass)
+    if not path:
+        return []
+    names = await hass.async_add_executor_job(_listdir, path)
+    return sem_store_names(names)
+
+
+def orphan_store_keys(names: Iterable[str],
+                      live_entry_ids: Iterable[str]) -> List[str]:
+    """Which of ``names`` no live config entry owns.
 
     An install that has been removed and re-added carries the previous entry
     id's pair for ever — seven of them on the .46 rig, ninety-six version
@@ -139,7 +156,7 @@ def orphan_store_keys(hass, live_entry_ids: Iterable[str]) -> List[str]:
         owned.update(per_entry_store_keys(entry_id))
         prefixes.extend(per_entry_store_prefixes(entry_id))
     out = []
-    for name in existing_store_files(hass):
+    for name in sem_store_names(names):
         if name in keep_whole or name in owned:
             continue
         if any(name.startswith(p) for p in prefixes):
@@ -185,8 +202,9 @@ async def async_entry_stores_removed(hass, entry_id: str) -> List[str]:
     keys = list(per_entry_store_keys(entry_id))
     prefixes = per_entry_store_prefixes(entry_id)
     if prefixes:
+        on_disk = await async_existing_store_files(hass)
         keys.extend(
-            n for n in existing_store_files(hass)
+            n for n in on_disk
             if any(n.startswith(p) for p in prefixes)
         )
     return await async_delete_stores(hass, keys)

--- a/coordinator/repair_issues.py
+++ b/coordinator/repair_issues.py
@@ -1538,3 +1538,44 @@ def clear_charger_control_entity_broken(
             hass, DOMAIN, _control_entity_issue_id(device_id, entity_id))
     except Exception as e:  # noqa: BLE001
         _LOGGER.debug("issue_registry.delete failed for %s: %s", entity_id, e)
+
+
+_PREVIOUS_INSTALL_ISSUE_ID = "previous_install_leftovers"
+
+
+def raise_previous_install_leftovers(hass: HomeAssistant, removed: int) -> None:
+    """(#935) SEM found and removed files a previous install left behind.
+
+    The stores are SEM's own and go without asking. What this card is for is
+    the half SEM must NOT take: the generated dashboard and the long-term
+    statistics of the old install's entities are the user's history, and a
+    year of solar yield is not SEM's to delete because a config entry was
+    re-created. So: say what was cleaned, name what was left, and give the one
+    action that clears the rest — ``solar_energy_management.remove_leftovers``.
+
+    Not fixable in place on purpose: the answer is a choice, not a repair, and
+    it is reversible only in the direction of keeping.
+    """
+    try:
+        ir.async_create_issue(
+            hass,
+            domain=DOMAIN,
+            issue_id=_PREVIOUS_INSTALL_ISSUE_ID,
+            is_fixable=False,
+            is_persistent=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="previous_install_leftovers",
+            learn_more_url=next_step_url(
+                "docs", "previous_install_leftovers", **_versions(hass)),
+            translation_placeholders={"removed": str(removed)},
+        )
+    except Exception as e:  # noqa: BLE001 — never fail a setup over a repair
+        _LOGGER.debug("issue_registry.create failed for leftovers: %s", e)
+
+
+def clear_previous_install_leftovers(hass: HomeAssistant) -> None:
+    """The user answered — by running the service, or by not caring."""
+    try:
+        ir.async_delete_issue(hass, DOMAIN, _PREVIOUS_INSTALL_ISSUE_ID)
+    except Exception as e:  # noqa: BLE001
+        _LOGGER.debug("issue_registry.delete failed for leftovers: %s", e)

--- a/coordinator/repair_issues.py
+++ b/coordinator/repair_issues.py
@@ -230,6 +230,8 @@ _DOCS_ANCHORS = {
     "soc_zones_out_of_order": "your-battery-soc-zones-are-out-of-order",
     # (#911) the grid meters were guessed by name — set them explicitly
     "split_grid_guessed": "sem-guessed-your-grid-power-meters",
+    # (#935) files from an install that came before this one
+    "previous_install_leftovers": "files-from-a-previous-sem-install",
     "sensor_stale": "a-sensor-stopped-updating-stale",
     "no_forecast_integration": "no-solar-forecast-integration-found",
     "no_recorder": "the-recorder-is-not-available",

--- a/coordinator/repair_issues.py
+++ b/coordinator/repair_issues.py
@@ -1564,7 +1564,13 @@ def raise_previous_install_leftovers(hass: HomeAssistant, removed: int) -> None:
             domain=DOMAIN,
             issue_id=_PREVIOUS_INSTALL_ISSUE_ID,
             is_fixable=False,
-            is_persistent=False,
+            # Persistent, though the sweep that raises it runs once: the card
+            # is about state that OUTLIVES it — the user's statistics are
+            # still on disk — and nothing re-raises it, because after the
+            # sweep there are no orphans left to find. Non-persistent, the
+            # message would vanish at the next restart, quite possibly before
+            # anyone read it (seen on the .46 rig, 12.09).
+            is_persistent=True,
             severity=ir.IssueSeverity.WARNING,
             translation_key="previous_install_leftovers",
             learn_more_url=next_step_url(

--- a/devices/base.py
+++ b/devices/base.py
@@ -3212,7 +3212,13 @@ class CurrentControlDevice(ControllableDevice):
         except (Exception, asyncio.TimeoutError) as e:  # noqa: BLE001
             _LOGGER.debug("release_to_user(%s): failsafe reset skipped: %s",
                           self.name, e)
-        self._sem_parked = False
+        # (#935, live on PROD 13.09) Clear the RECORD, not just the flag. The
+        # hand-back set `_sem_parked = False` and left
+        # `sem.parked.<entry>` still naming this charger, so the next setup
+        # adopted a park that had already been handed back — and the next
+        # disable would "enable" a box SEM had not disabled. The debt is paid;
+        # the ledger has to say so.
+        await self._remember_parked(False)
         if not did:
             return None
         said = f"{self.name}: handed back on {reason} — " + ", ".join(did)

--- a/devices/base.py
+++ b/devices/base.py
@@ -70,6 +70,12 @@ FAILSAFE_TIMEOUT_S = 600
 # turned off over UDP — so point it at 0 instead of fighting it.
 FAILSAFE_OFF_TIMEOUT_S = 10
 
+#: (#935) How long a teardown will wait on a charger before giving up on it.
+#: ``hass.services.async_call`` is unbounded, and a removal that hangs on a
+#: stalled integration never completes — HA awaits ``async_remove_entry``
+#: holding the entry's setup lock. Handing a box back is best-effort.
+_RELEASE_TIMEOUT_S = 15.0
+
 # #553/#545 — the quota-stop margin. Live-proven on the real P30
 # (2026-08-08): a target just ABOVE the session counter, written before
 # enable, terminates the charge at the target and HOLDS — the box's own
@@ -3021,7 +3027,7 @@ class CurrentControlDevice(ControllableDevice):
                     await self.send(domain, "enable", {})
 
             self._session_active = True
-            self._sem_parked = False   # (#935) SEM said yes again
+            await self._remember_parked(False)   # (#935) SEM said yes again
             _LOGGER.info("Charging session started for %s", self.name)
         except Exception as e:
             _LOGGER.error("Failed to start session on %s: %s", self.name, e)
@@ -3039,9 +3045,11 @@ class CurrentControlDevice(ControllableDevice):
         every charge — which is why a plug-in never auto-started for him.
         """
         domain = (self.charger_service or "").split(".", 1)[0]
+        _parked_it = False
         try:
             if domain and self.hass.services.has_service(domain, "disable"):
                 await self.send(domain, "disable", {})
+                _parked_it = True
                 _LOGGER.info(
                     "%s: parked OFF on disconnect via %s.disable — the box "
                     "holds the no until the next charge", self.name, domain)
@@ -3049,6 +3057,7 @@ class CurrentControlDevice(ControllableDevice):
                 sdomain = self.start_stop_entity.split(".")[0]
                 if sdomain in ("switch", "input_boolean"):
                     await self.send(sdomain, "turn_off", {"entity_id": self.start_stop_entity})
+                    _parked_it = True
         except Exception as e:  # noqa: BLE001 — surfaced, never fatal
             _LOGGER.error("park_off(%s): disable failed: %s", self.name, e)
 
@@ -3056,7 +3065,15 @@ class CurrentControlDevice(ControllableDevice):
         # yes when SEM goes away. Recorded explicitly rather than inferred
         # from the intent enum: ``command_disable`` and ``command_park_off``
         # both end at DISABLE, and only one of them means "SEM parked it".
-        self._sem_parked = True
+        #
+        # (#935 review) And ONLY when a park actually landed. Set
+        # unconditionally, a charger with no disable service and no
+        # start/stop entity — the documented "stop is unenforceable" config —
+        # took the flag without a single write, and the teardown would then
+        # "hand back" a box SEM had never touched. That is the #908 rule
+        # inverted, by the code that exists to honour it.
+        if _parked_it:
+            await self._remember_parked(True)
 
         # SEM is done with this session whether or not every write landed —
         # set the bookkeeping first so a best-effort failure below cannot
@@ -3079,6 +3096,42 @@ class CurrentControlDevice(ControllableDevice):
             await self.arm_failsafe_off()
         except Exception as e:  # noqa: BLE001
             _LOGGER.debug("park_off(%s): dead-man arm skipped: %s", self.name, e)
+
+    async def _remember_parked(self, parked: bool) -> None:
+        """(#935 review) The park debt, written where it outlives this process.
+
+        ``_sem_parked`` alone was an instance attribute rebuilt False on every
+        setup, and the reconciler cannot re-derive it: ``PARK_OFF`` fires on
+        the connect→disconnect EDGE, and a box that is already empty at boot
+        is a steady state, not an edge (``charger_reconciler``: "an empty box
+        at boot has nothing to park"). So park → restart → remove left the
+        charger disabled with its persisted dead-man failsafe holding 0 A and
+        nothing on the system that knew why — the precise sentence this whole
+        issue opens with. Same hole #949 had just closed one layer over, for
+        the inverter's charge limit.
+        """
+        self._sem_parked = bool(parked)
+        store = getattr(self, "_park_store", None)
+        if store is None:
+            return
+        try:
+            record = await store.async_load() or {}
+            ids = set(record.get("parked") or [])
+            key = str(getattr(self, "charger_id", "") or self.name)
+            if parked:
+                ids.add(key)
+            else:
+                ids.discard(key)
+            await store.async_save({"parked": sorted(ids)})
+        except Exception:  # noqa: BLE001 — a record never costs a command
+            _LOGGER.debug("%s: could not record the park state", self.name,
+                          exc_info=True)
+
+    def adopt_park_state(self, parked_ids) -> None:
+        """Take over a park this install left behind in a previous lifetime."""
+        key = str(getattr(self, "charger_id", "") or self.name)
+        if key in set(parked_ids or ()):
+            self._sem_parked = True
 
     async def release_to_user(self, *, reason: str = "removal") -> Optional[str]:
         """(#935) Hand the box back when SEM goes away for good.
@@ -3114,39 +3167,49 @@ class CurrentControlDevice(ControllableDevice):
         if not getattr(self, "_sem_parked", False):
             return None
         did: list[str] = []
+        # (#935 review) BOUNDED. ``hass.services.async_call`` takes no timeout
+        # and neither did anything here, so a charger integration whose
+        # handler stalls — an ordinary failure for a cloud-backed one — hung
+        # ``async_remove_entry``, which HA awaits while holding the entry's
+        # setup lock. The removal would simply never finish. A hand-back is
+        # best-effort by nature; nothing here is worth blocking a removal.
+        async def _bounded(coro):
+            return await asyncio.wait_for(coro, timeout=_RELEASE_TIMEOUT_S)
+
         try:
             if self.start_service:
                 domain, service = self.start_service.split(".", 1)
                 data = dict(self.start_service_data or {})
                 if self.service_device_id:
                     data["device_id"] = self.service_device_id
-                await self.send(domain, service, data)
+                await _bounded(self.send(domain, service, data))
                 did.append(self.start_service)
             elif self.charge_mode_entity and self.charge_mode_start:
-                await self.send("select", "select_option", {
+                await _bounded(self.send("select", "select_option", {
                     "entity_id": self.charge_mode_entity,
-                    "option": self.charge_mode_start})
+                    "option": self.charge_mode_start}))
                 did.append(f"{self.charge_mode_entity}={self.charge_mode_start}")
             elif self.start_stop_entity:
                 domain = self.start_stop_entity.split(".")[0]
                 if domain in ("switch", "input_boolean"):
-                    await self.send(domain, "turn_on",
-                                    {"entity_id": self.start_stop_entity})
+                    await _bounded(self.send(
+                        domain, "turn_on",
+                        {"entity_id": self.start_stop_entity}))
                     did.append(f"{self.start_stop_entity} on")
             elif self.charger_service:
                 domain = self.charger_service.split(".", 1)[0]
                 if self.hass.services.has_service(domain, "enable"):
-                    await self.send(domain, "enable", {})
+                    await _bounded(self.send(domain, "enable", {}))
                     did.append(f"{domain}.enable")
-        except Exception as e:  # noqa: BLE001 — a teardown always completes
+        except (Exception, asyncio.TimeoutError) as e:  # noqa: BLE001
             _LOGGER.warning("release_to_user(%s): enable failed: %s",
                             self.name, e)
         try:
             # Puts the charging fallback back over the dead-man OFF. Its own
             # opt-out check means this is a no-op on a box SEM never armed.
-            await self.arm_failsafe()
+            await _bounded(self.arm_failsafe())
             did.append("failsafe → charging fallback")
-        except Exception as e:  # noqa: BLE001
+        except (Exception, asyncio.TimeoutError) as e:  # noqa: BLE001
             _LOGGER.debug("release_to_user(%s): failsafe reset skipped: %s",
                           self.name, e)
         self._sem_parked = False
@@ -3302,8 +3365,12 @@ class CurrentControlDevice(ControllableDevice):
             # the box's own standing "no" for the window where SEM is not
             # there to say it.
             await self.arm_failsafe_off()
-            # (#935) Same standing "no" as park_off, so the same debt.
-            self._sem_parked = True
+            # (#935) Same standing "no" as park_off, so the same debt — and
+            # only when a stop mechanism actually fired (``stop_method`` is
+            # None when SEM relied on _set_current(0) alone and wrote no
+            # standing refusal to undo).
+            if stop_method is not None:
+                await self._remember_parked(True)
             self._session_active = False
             self._status.state = DeviceState.IDLE
             self._status.current_consumption_w = 0.0

--- a/devices/base.py
+++ b/devices/base.py
@@ -2173,6 +2173,10 @@ class CurrentControlDevice(ControllableDevice):
         # persistent Repair left by a previous device instance.
         self._stale_repair_checked: bool = False
         self._session_active: bool = False
+        #: (#935) True while SEM is the reason this box is refusing to charge
+        #: — a park or a stop SEM itself issued. Read at teardown, so SEM can
+        #: hand a box back that it, and only it, told to say no.
+        self._sem_parked: bool = False
         # #553 — SEM's belief that the KEBA runaway-cap energy target is
         # armed (set by stop_session, cleared by start_session). Surfaced in
         # the diagnose service's ev_actuation block.
@@ -3017,6 +3021,7 @@ class CurrentControlDevice(ControllableDevice):
                     await self.send(domain, "enable", {})
 
             self._session_active = True
+            self._sem_parked = False   # (#935) SEM said yes again
             _LOGGER.info("Charging session started for %s", self.name)
         except Exception as e:
             _LOGGER.error("Failed to start session on %s: %s", self.name, e)
@@ -3047,6 +3052,12 @@ class CurrentControlDevice(ControllableDevice):
         except Exception as e:  # noqa: BLE001 — surfaced, never fatal
             _LOGGER.error("park_off(%s): disable failed: %s", self.name, e)
 
+        # (#935) SEM is the reason this box is saying no, so SEM owes it a
+        # yes when SEM goes away. Recorded explicitly rather than inferred
+        # from the intent enum: ``command_disable`` and ``command_park_off``
+        # both end at DISABLE, and only one of them means "SEM parked it".
+        self._sem_parked = True
+
         # SEM is done with this session whether or not every write landed —
         # set the bookkeeping first so a best-effort failure below cannot
         # leave the session falsely "active" (a partial box in a unit test,
@@ -3068,6 +3079,82 @@ class CurrentControlDevice(ControllableDevice):
             await self.arm_failsafe_off()
         except Exception as e:  # noqa: BLE001
             _LOGGER.debug("park_off(%s): dead-man arm skipped: %s", self.name, e)
+
+    async def release_to_user(self, *, reason: str = "removal") -> Optional[str]:
+        """(#935) Hand the box back when SEM goes away for good.
+
+        A parked box holds its "no" three ways: the contactor is disabled, the
+        stored current is 0 A, and a PERSISTED dead-man failsafe re-asserts
+        0 A every few minutes. Together that is exactly the point — the box
+        keeps refusing while SEM is not there to say otherwise (#740). It is
+        also why removing SEM leaves a charger that will not start and gives
+        no reason: the standing no outlives the thing that meant it.
+
+        So on removal and on disable, SEM undoes its own three:
+
+        1. **enable** — the same four-way ``start_session`` uses: the profile's
+           start service, a charge-mode select, a start/stop switch, or the
+           charger domain's own ``enable``. Never the domain's *authorise*
+           call: authorisation is the owner's, not ours, and SEM has never
+           touched it.
+        2. **failsafe** — re-armed at the CHARGING fallback rather than 0 A,
+           so a box left alone lands on its floor instead of on a standing
+           off. Skipped entirely when SEM never armed it (the arm-failsafe
+           option off), because then there is nothing of SEM's to undo.
+        3. **nothing else** — no current is written, no session is opened, no
+           energy target is set. Handing a box back is not starting a charge.
+
+        Gated on ``_sem_parked``: a box SEM never parked is left exactly as
+        found. That is #908's rule, which #936 extended to batteries and #949
+        to the inverter's charge limit; the charger is the last one.
+
+        Returns a one-line description of what it did, or None when there was
+        nothing to undo. Never raises — a teardown must always complete.
+        """
+        if not getattr(self, "_sem_parked", False):
+            return None
+        did: list[str] = []
+        try:
+            if self.start_service:
+                domain, service = self.start_service.split(".", 1)
+                data = dict(self.start_service_data or {})
+                if self.service_device_id:
+                    data["device_id"] = self.service_device_id
+                await self.send(domain, service, data)
+                did.append(self.start_service)
+            elif self.charge_mode_entity and self.charge_mode_start:
+                await self.send("select", "select_option", {
+                    "entity_id": self.charge_mode_entity,
+                    "option": self.charge_mode_start})
+                did.append(f"{self.charge_mode_entity}={self.charge_mode_start}")
+            elif self.start_stop_entity:
+                domain = self.start_stop_entity.split(".")[0]
+                if domain in ("switch", "input_boolean"):
+                    await self.send(domain, "turn_on",
+                                    {"entity_id": self.start_stop_entity})
+                    did.append(f"{self.start_stop_entity} on")
+            elif self.charger_service:
+                domain = self.charger_service.split(".", 1)[0]
+                if self.hass.services.has_service(domain, "enable"):
+                    await self.send(domain, "enable", {})
+                    did.append(f"{domain}.enable")
+        except Exception as e:  # noqa: BLE001 — a teardown always completes
+            _LOGGER.warning("release_to_user(%s): enable failed: %s",
+                            self.name, e)
+        try:
+            # Puts the charging fallback back over the dead-man OFF. Its own
+            # opt-out check means this is a no-op on a box SEM never armed.
+            await self.arm_failsafe()
+            did.append("failsafe → charging fallback")
+        except Exception as e:  # noqa: BLE001
+            _LOGGER.debug("release_to_user(%s): failsafe reset skipped: %s",
+                          self.name, e)
+        self._sem_parked = False
+        if not did:
+            return None
+        said = f"{self.name}: handed back on {reason} — " + ", ".join(did)
+        _LOGGER.info("#935 %s", said)
+        return said
 
     async def stop_session(self) -> None:
         """Stop the charging session.
@@ -3215,6 +3302,8 @@ class CurrentControlDevice(ControllableDevice):
             # the box's own standing "no" for the window where SEM is not
             # there to say it.
             await self.arm_failsafe_off()
+            # (#935) Same standing "no" as park_off, so the same debt.
+            self._sem_parked = True
             self._session_active = False
             self._status.state = DeviceState.IDLE
             self._status.current_consumption_w = 0.0

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1089,3 +1089,37 @@ you set at 80%.
 **To fix it:** Settings → Devices & Services → SEM → Configure → Battery,
 or the Configuration tab on the SEM dashboard. Any values are fine as long
 as Priority ≤ Buffer ≤ Auto-start.
+
+### Files from a previous SEM install
+
+**Repair:** *Files from a previous SEM install were found*
+
+SEM found storage files belonging to a config entry that no longer exists —
+almost always because SEM was removed and added again on a version that could
+not clean up after itself. Those files were SEM's own, and SEM deleted them.
+The Repair is about the part it did **not** delete.
+
+**What was cleaned automatically**
+
+Per-entry storage: energy and daily totals, the version marker, the
+charge-pacing record, per-battery snapshots. A file SEM does not recognise is
+named in the log and left exactly where it is — a cleanup that deletes files
+it cannot identify is a worse problem than the one it solves.
+
+**What is still there, because it is yours**
+
+- **Long-term statistics** for the old install's sensors. This is what Spook
+  reports as leftover entries after an uninstall. They are your recorded
+  history, and SEM will not delete a year of solar yield on its own initiative.
+- **The generated dashboard**, which you may have edited.
+
+**What to do**
+
+Nothing, if you want to keep your history — the Repair can be dismissed and
+nothing further is deleted.
+
+To clear them, run **Developer tools → Actions → *SEM: Remove leftovers***.
+`statistics` is on by default, `dashboard` is off. Both are irreversible.
+
+If you are about to uninstall SEM, run that action **first** — afterwards
+there is no SEM left to run it.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -1617,3 +1617,47 @@ SEM resets daily energy counters at **sunrise**, not midnight. This is intention
 - This may not align with utility billing periods that reset at midnight
 
 The sunrise time comes from HA's `sun.sun` entity (fallback: 06:00 if unavailable).
+
+## Removing SEM
+
+SEM cleans up after itself, and asks before touching anything of yours.
+
+**What SEM takes automatically, when you remove it**
+
+- Its own storage files — energy and daily totals, the version marker, the
+  charge-pacing record, per-battery snapshots.
+- Its Repair issues.
+- The dashboard resources it registered. Without this every page load kept
+  fetching a card bundle that no longer existed.
+- **Hardware it had commanded.** A load SEM switched on is switched off, a
+  battery goes back to normal, a charge-power limit SEM wrote is restored, and
+  a wallbox **SEM parked** is re-enabled. A device SEM never commanded is left
+  exactly as it was — SEM only ever undoes its own instructions.
+
+The wallbox one is worth spelling out. While SEM is running it deliberately
+leaves a parked charger disabled with a dead-man failsafe, so the box keeps
+refusing across restarts and network drops. Once SEM is gone that standing
+"no" has nobody to lift it, and the symptom is a charger that will not start
+and gives no reason. Removal now lifts it. SEM never touches your charger's
+*authorisation* — that is yours and always has been.
+
+**What SEM leaves alone unless you ask**
+
+Your history. The long-term statistics of SEM's sensors and the dashboard SEM
+generated are yours — you may have spent a year filling one and an afternoon
+editing the other.
+
+To clear them, run **Developer tools → Actions → *SEM: Remove leftovers*
+**before** you uninstall** — afterwards there is no SEM left to run it.
+
+| Option | Default | What it does |
+|---|---|---|
+| `statistics` | on | Clears the recorder's long-term statistics for SEM's sensors. This is what Spook reports as leftover entries after an uninstall. |
+| `dashboard` | off | Deletes the generated SEM dashboard and its sidebar entry, including any edits you made. |
+
+**Re-installing after an older version**
+
+SEM versions before this one could not clean up, so a re-install may find
+storage files from installs that came before. Those are swept on setup and a
+Repair tells you how many, and offers the same action for the parts that are
+yours. A file SEM does not recognise is named in the log and left where it is.

--- a/services.yaml
+++ b/services.yaml
@@ -677,3 +677,36 @@ backfill_battery_nights:
           min: 14
           max: 730
           unit_of_measurement: days
+
+remove_leftovers:
+  name: Remove leftovers
+  description: >-
+    Delete the things SEM created that belong to YOU, before you remove SEM.
+
+    SEM takes its own files when it is removed — its stores, its Repairs, the
+    dashboard resources it registered. It deliberately does NOT take your
+    history: the long-term statistics of SEM's sensors and the dashboard it
+    generated are yours, and a year of solar yield is not SEM's to throw away
+    because it is being uninstalled. This service is how you say "take those
+    too". Run it BEFORE removing SEM — afterwards there is no SEM left to run
+    it.
+  fields:
+    statistics:
+      name: Long-term statistics
+      description: >-
+        Clear the recorder's long-term statistics for SEM's own sensors. This
+        is the ~119 leftover entries Spook reports after an uninstall. Cannot
+        be undone.
+      required: false
+      default: true
+      selector:
+        boolean:
+    dashboard:
+      name: Generated dashboard
+      description: >-
+        Delete the SEM dashboard and its sidebar entry. Off by default because
+        you may have edited it — any changes you made are lost with it.
+      required: false
+      default: false
+      selector:
+        boolean:

--- a/strings.json
+++ b/strings.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/tests/test_831_repair_next_step.py
+++ b/tests/test_831_repair_next_step.py
@@ -30,6 +30,10 @@ TROUBLESHOOTING = Path(__file__).resolve().parent.parent / "docs" / "TROUBLESHOO
 
 DOCS_SIDE = {
     "split_grid_guessed",   # (#911) set the two grid power entities
+    # (#935) files from an older SEM install were found and SEM's own were
+    # cleaned. The next step is a CHOICE about the user's own history, and
+    # the docs are where the two options and their consequences live.
+    "previous_install_leftovers",
     # (#870) the three SOC zones are out of ascending order — the docs say
     # what each zone means and that any values are fine as long as they rise
     "soc_zones_out_of_order",

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -16,6 +16,8 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 
 from custom_components.solar_energy_management import cleanup
 
@@ -209,25 +211,17 @@ class TestTheFrontendResources:
 
 
 class TestStatisticsAreTheUsersUntilTheySaySo:
-    def test_clearing_asks_the_recorder_with_sems_own_ids(self):
-        hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
-        n = _run(cleanup.async_clear_statistics(
-            hass, ["sensor.sem_solar_power", "sensor.sem_battery_soc"]))
-        assert n == 2
-        call = hass.services.async_call.await_args
-        assert call.args[0] == "recorder" and call.args[1] == "clear_statistics"
-        assert call.args[2]["statistic_ids"] == [
-            "sensor.sem_solar_power", "sensor.sem_battery_soc"]
-
     def test_nothing_to_clear_calls_nothing(self):
         hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
         assert _run(cleanup.async_clear_statistics(hass, [])) == 0
         assert hass.services.async_call.await_count == 0
 
-    def test_a_missing_recorder_is_reported_not_raised(self):
-        hass = SimpleNamespace(services=SimpleNamespace(
-            async_call=AsyncMock(side_effect=RuntimeError("no recorder"))))
-        assert _run(cleanup.async_clear_statistics(hass, ["sensor.x"])) == 0
+    def test_a_missing_recorder_is_reported_not_raised(self, monkeypatch):
+        monkeypatch.setattr(
+            "homeassistant.components.recorder.get_instance",
+            MagicMock(side_effect=RuntimeError("no recorder")))
+        assert _run(cleanup.async_clear_statistics(
+            SimpleNamespace(), ["sensor.x"])) == 0
 
 
 class TestTheDashboardIsOfferedNeverTaken:
@@ -404,3 +398,89 @@ class TestTheSweepOnlyEverTakesARealEntrysStore:
                      "sem_device_mappings", "sem_device_mappings.bak",
                      "semaphore_state", "sem_seen_version_", "sem.pacing."):
             assert self._swept([name]) == [], name
+
+
+class TestTheServiceCannotBeArmedByAccident:
+    """Fault injection, 13.09: the service was registered without a schema,
+    so `dashboard: 12345` reached `bool(12345)` and the off-by-default
+    destructive option armed itself. The rig's dashboard was deleted by a
+    junk value. The asymmetry of the two defaults IS the safety, so it has
+    to survive a caller who sends nonsense."""
+
+    def _schema(self):
+        import voluptuous as vol
+
+        return vol.Schema({
+            vol.Optional("statistics", default=True): bool,
+            vol.Optional("dashboard", default=False): bool,
+        })
+
+    def test_the_registered_schema_is_this_one(self):
+        """Pinned by the AST so a rename cannot quietly drop it."""
+        import ast
+        import inspect
+
+        from custom_components import solar_energy_management as sem
+
+        src = inspect.getsource(sem._async_register_services)
+        tree = ast.parse(src.lstrip())
+        registered = [
+            n for n in ast.walk(tree)
+            if isinstance(n, ast.Call)
+            and getattr(n.func, "attr", "") == "async_register"
+            and any(isinstance(a, ast.Constant) and a.value == "remove_leftovers"
+                    for a in n.args)
+        ]
+        assert registered, "the service must still be registered"
+        assert any(k.arg == "schema" for k in registered[0].keywords), (
+            "remove_leftovers must be registered WITH a schema")
+
+    def test_junk_cannot_turn_the_dashboard_option_on(self):
+        import voluptuous as vol
+
+        # cv.boolean would pass 12345 and 2.5 — any non-zero number is
+        # "true" to it, and a truthy number is not consent to a delete.
+        for junk in (12345, "maybe", [], {"x": 1}, 2.5, 1, 0, "true"):
+            with pytest.raises(vol.Invalid):
+                self._schema()({"dashboard": junk})
+
+    def test_the_defaults_keep_their_asymmetry(self):
+        out = self._schema()({})
+        assert out["statistics"] is True, "the leftover statistics are the ask"
+        assert out["dashboard"] is False, "the dashboard may hold their edits"
+
+    def test_a_real_boolean_still_works(self):
+        assert self._schema()({"dashboard": True})["dashboard"] is True
+        assert self._schema()({"statistics": False})["statistics"] is False
+
+
+class TestStatisticsGoThroughTheRecordersOwnApi:
+    """`recorder.clear_statistics` is not a service — the recorder publishes
+    purge / purge_entities / enable / disable / get_statistics and clears
+    statistics over its websocket API. The first cut called the service, so
+    every call failed, warned "recorder may be disabled" about a recorder
+    that was loaded and running, and reported nothing cleared (.46, 13.09)."""
+
+    def test_it_hands_the_ids_to_the_recorder_instance(self, monkeypatch):
+        handed = {}
+
+        class FakeInstance:
+            def async_clear_statistics(self, ids, **kw):
+                handed["ids"] = list(ids)
+
+        monkeypatch.setattr("homeassistant.components.recorder.get_instance",
+                            lambda hass: FakeInstance())
+        hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
+        n = _run(cleanup.async_clear_statistics(
+            hass, ["sensor.sem_solar_power", "sensor.sem_battery_soc"]))
+        assert n == 2
+        assert handed["ids"] == ["sensor.sem_solar_power", "sensor.sem_battery_soc"]
+        assert hass.services.async_call.await_count == 0, (
+            "never through a service that does not exist")
+
+    def test_a_missing_recorder_reports_zero(self, monkeypatch):
+        monkeypatch.setattr(
+            "homeassistant.components.recorder.get_instance",
+            MagicMock(side_effect=RuntimeError("recorder not loaded")))
+        assert _run(cleanup.async_clear_statistics(
+            SimpleNamespace(), ["sensor.x"])) == 0

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -1,0 +1,226 @@
+"""#935 — SEM hands the house back as it found it and takes its own files.
+
+@markusschloesser ran Spook after removing SEM (#908) and found 119 leftover
+long-term statistics. The statistics turned out to be the smallest part:
+removal deleted a config entry and released the loads SEM had started, and
+left behind every store it had written, its version marker, its Repairs, the
+Lovelace resources pointing at files that were about to vanish, and a wallbox
+SEM had parked — holding "no" with nothing left on the system to say "yes".
+
+The three rules under test: hand the hardware back (and ONLY what SEM
+commanded), take SEM's own files, and merely OFFER what is the user's.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.solar_energy_management import cleanup
+
+ENTRY = "01ABCDEFGHIJKLMNOPQRSTUVWX"
+OTHER = "01ZZZZZZZZZZZZZZZZZZZZZZZZ"
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _hass_with_storage(tmp_path, names=()):
+    storage = tmp_path / ".storage"
+    storage.mkdir(exist_ok=True)
+    for n in names:
+        (storage / n).write_text("{}")
+    return SimpleNamespace(
+        config=SimpleNamespace(config_dir=str(tmp_path)),
+        services=SimpleNamespace(async_call=AsyncMock()),
+    )
+
+
+class TestTheInventoryKnowsWhatThisEntryOwns:
+    def test_every_per_entry_store_is_named(self):
+        keys = cleanup.per_entry_store_keys(ENTRY)
+        assert f"solar_energy_management_{ENTRY}_energy" in keys
+        assert f"solar_energy_management_{ENTRY}_daily" in keys
+        assert f"sem_seen_version_{ENTRY}" in keys
+        assert f"sem.pacing.{ENTRY}" in keys, "#949's record is SEM's too"
+
+    def test_the_second_scoped_stores_are_prefixes(self):
+        pre = cleanup.per_entry_store_prefixes(ENTRY)
+        assert f"sem.deye.snapshot.{ENTRY}." in pre
+        assert f"sem.deye.unsafe.{ENTRY}." in pre
+
+    def test_an_empty_entry_id_owns_nothing(self):
+        """A degenerate id would prefix-match every entry's stores — the
+        #709 scope rule, on the delete side where it costs more."""
+        assert cleanup.per_entry_store_keys("") == []
+        assert cleanup.per_entry_store_prefixes("") == []
+
+    def test_install_wide_stores_are_separate(self):
+        wide = cleanup.install_wide_store_keys()
+        assert "sem_device_mappings" in wide
+        assert "solar_energy_management_load_management_devices" in wide
+        # the retired names, still live on PROD
+        assert "solar_energy_management_daily_storage" in wide
+        assert "solar_energy_management_energy_totals" in wide
+
+    def test_no_per_entry_key_is_also_install_wide(self):
+        assert not (set(cleanup.per_entry_store_keys(ENTRY))
+                    & set(cleanup.install_wide_store_keys()))
+
+
+class TestTheOrphanSweep:
+    def test_a_removed_entrys_stores_are_orphans(self, tmp_path):
+        hass = _hass_with_storage(tmp_path, [
+            f"solar_energy_management_{ENTRY}_energy",
+            f"solar_energy_management_{ENTRY}_daily",
+            f"sem_seen_version_{ENTRY}",
+            f"solar_energy_management_{OTHER}_energy",
+            f"sem_seen_version_{OTHER}",
+        ])
+        orphans = cleanup.orphan_store_keys(hass, [ENTRY])
+        assert sorted(orphans) == sorted([
+            f"solar_energy_management_{OTHER}_energy",
+            f"sem_seen_version_{OTHER}",
+        ])
+
+    def test_a_live_entrys_stores_are_never_orphans(self, tmp_path):
+        hass = _hass_with_storage(tmp_path, [
+            f"solar_energy_management_{ENTRY}_daily",
+            f"sem.pacing.{ENTRY}",
+            f"sem.deye.snapshot.{ENTRY}.battery_1",
+        ])
+        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+
+    def test_install_wide_stores_survive_the_sweep(self, tmp_path):
+        hass = _hass_with_storage(tmp_path, [
+            "sem_device_mappings",
+            "solar_energy_management_load_management_devices",
+            "solar_energy_management_daily_storage",
+        ])
+        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+
+    def test_a_store_nobody_taught_it_about_is_left_alone(self, tmp_path):
+        """Deleting an unrecognised file is how a cleanup becomes the problem
+        it was written to solve."""
+        hass = _hass_with_storage(tmp_path, ["sem_something_new_entirely"])
+        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+
+    def test_backups_are_not_swept(self, tmp_path):
+        hass = _hass_with_storage(tmp_path, [
+            f"solar_energy_management_{OTHER}_energy.bak.1780495914",
+            f"solar_energy_management_{OTHER}_energy.bak",
+        ])
+        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+
+    def test_no_storage_directory_is_not_a_crash(self):
+        hass = SimpleNamespace(config=SimpleNamespace(config_dir="/nope/nope"))
+        assert cleanup.existing_store_files(hass) == []
+        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+
+
+class TestRepairsGoWithTheIntegration:
+    def _registry(self, keys):
+        return SimpleNamespace(issues={k: object() for k in keys})
+
+    def test_every_sem_issue_is_deleted_and_nothing_else(self, monkeypatch):
+        deleted = []
+        reg = self._registry([
+            ("solar_energy_management", "split_grid_guessed"),
+            ("solar_energy_management", "soc_zones_out_of_order"),
+            ("some_other_integration", "not_ours"),
+        ])
+        monkeypatch.setattr(
+            "homeassistant.helpers.issue_registry.async_get",
+            lambda hass: reg)
+        monkeypatch.setattr(
+            "homeassistant.helpers.issue_registry.async_delete_issue",
+            lambda hass, domain, issue_id: deleted.append((domain, issue_id)))
+        n = cleanup.delete_repairs(SimpleNamespace())
+        assert n == 2
+        assert ("some_other_integration", "not_ours") not in deleted
+        assert sorted(i for _, i in deleted) == [
+            "soc_zones_out_of_order", "split_grid_guessed"]
+
+    def test_an_unreadable_registry_reports_zero_not_a_crash(self, monkeypatch):
+        monkeypatch.setattr(
+            "homeassistant.helpers.issue_registry.async_get",
+            MagicMock(side_effect=RuntimeError("no registry")))
+        assert cleanup.delete_repairs(SimpleNamespace()) == 0
+
+
+class TestTheFrontendResources:
+    def test_sems_own_resources_are_recognised(self):
+        assert cleanup._is_sem_resource(
+            "/solar_energy_management/dashboard/card/dist/sem-cards.js?v=2.1.0-abc")
+        assert cleanup._is_sem_resource(
+            "/solar_energy_management/dashboard/card/sem-localize.js")
+
+    def test_someone_elses_resource_is_not(self):
+        assert not cleanup._is_sem_resource("/hacsfiles/mushroom/mushroom.js")
+        assert not cleanup._is_sem_resource("/local/my-own/sem-cards.js")
+        assert not cleanup._is_sem_resource("")
+        assert not cleanup._is_sem_resource(None)
+
+
+class TestStatisticsAreTheUsersUntilTheySaySo:
+    def test_clearing_asks_the_recorder_with_sems_own_ids(self):
+        hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
+        n = _run(cleanup.async_clear_statistics(
+            hass, ["sensor.sem_solar_power", "sensor.sem_battery_soc"]))
+        assert n == 2
+        call = hass.services.async_call.await_args
+        assert call.args[0] == "recorder" and call.args[1] == "clear_statistics"
+        assert call.args[2]["statistic_ids"] == [
+            "sensor.sem_solar_power", "sensor.sem_battery_soc"]
+
+    def test_nothing_to_clear_calls_nothing(self):
+        hass = SimpleNamespace(services=SimpleNamespace(async_call=AsyncMock()))
+        assert _run(cleanup.async_clear_statistics(hass, [])) == 0
+        assert hass.services.async_call.await_count == 0
+
+    def test_a_missing_recorder_is_reported_not_raised(self):
+        hass = SimpleNamespace(services=SimpleNamespace(
+            async_call=AsyncMock(side_effect=RuntimeError("no recorder"))))
+        assert _run(cleanup.async_clear_statistics(hass, ["sensor.x"])) == 0
+
+
+class TestTheDashboardIsOfferedNeverTaken:
+    def test_both_halves_go_together(self, monkeypatch):
+        """The view config and the sidebar row are separate files; leaving
+        either behind gives a broken sidebar entry or an invisible orphan."""
+        removed_keys = []
+        saved = {}
+
+        class FakeStore:
+            def __init__(self, hass, version, key):
+                self.key = key
+
+            async def async_remove(self):
+                removed_keys.append(self.key)
+
+            async def async_load(self):
+                return {"items": [{"id": "sem-dashboard"}, {"id": "mine"}]}
+
+            async def async_save(self, data):
+                saved.update(data)
+
+        monkeypatch.setattr("homeassistant.helpers.storage.Store", FakeStore)
+        assert _run(cleanup.async_remove_dashboard(SimpleNamespace())) is True
+        assert "lovelace.sem-dashboard" in removed_keys
+        assert [i["id"] for i in saved["items"]] == ["mine"], (
+            "someone else's dashboard must survive")
+
+    def test_it_is_not_part_of_the_automatic_teardown(self):
+        """Nothing in the removal path may call it — a year of solar yield is
+        not SEM's to throw away because a config entry is being deleted."""
+        import inspect
+
+        from custom_components import solar_energy_management as sem
+
+        src = inspect.getsource(sem._async_take_sems_own_files)
+        assert "async_remove_dashboard" not in src
+        assert "async_clear_statistics" not in src

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -356,3 +356,51 @@ class TestTheWallboxIsHandedBack:
         dev.send = AsyncMock(side_effect=RuntimeError("UDP is gone"))
         assert _run(dev.release_to_user()) is not None or True
         assert dev._sem_parked is False, "the debt is cleared either way"
+
+
+class TestTheSweepOnlyEverTakesARealEntrysStore:
+    """Found by fault injection on the .46 rig, 13.09: the first cut accepted
+    ANY middle segment as a config-entry id, so a file the user had copied
+    aside by hand — `solar_energy_management_mybackup_energy` — was swept as
+    an orphaned install's store. A cleanup that deletes someone's own file is
+    the exact problem this module exists to avoid."""
+
+    REAL = "01M2BQ1A7MWSNS021PMT5XQMQA"          # a live rig entry id (ULID)
+    OLD = "0123456789abcdef0123456789abcdef"     # the 32-hex ids older installs carry
+
+    def _swept(self, names, live=()):
+        return cleanup.orphan_store_keys(names, live)
+
+    def test_a_hand_made_backup_is_not_an_orphan(self):
+        for name in (
+            "solar_energy_management_mybackup_energy",
+            "solar_energy_management_backup_daily",
+            "solar_energy_management_before_upgrade_energy",
+            "solar_energy_management_copy_daily",
+        ):
+            assert self._swept([name]) == [], name
+
+    def test_a_real_entrys_store_still_is(self):
+        for name in (
+            f"solar_energy_management_{self.REAL}_energy",
+            f"solar_energy_management_{self.OLD}_daily",
+            f"sem_seen_version_{self.REAL}",
+            f"sem.pacing.{self.REAL}",
+            f"sem.deye.snapshot.{self.REAL}.battery_1",
+        ):
+            assert self._swept([name]) == [name], name
+
+    def test_a_lowercase_or_short_middle_is_not_an_entry_id(self):
+        """ULIDs are 26 uppercase alphanumerics; anything else is a word."""
+        for middle in ("01direntry", "backup", "01M2BQ1A7MWSNS021PMT5XQMQ",
+                       "01M2BQ1A7MWSNS021PMT5XQMQAA", "x" * 26):
+            name = f"solar_energy_management_{middle}_daily"
+            assert self._swept([name]) == [], middle
+
+    def test_the_rigs_real_neighbours_survive(self):
+        """The other SEM-ish names actually sitting in the rig's .storage."""
+        for name in ("core.config_entries.bak.sem257", "energy.backup_sem",
+                     "lovelace.sem-dashboard", "lovelace.test_sem",
+                     "sem_device_mappings", "sem_device_mappings.bak",
+                     "semaphore_state", "sem_seen_version_", "sem.pacing."):
+            assert self._swept([name]) == [], name

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -13,11 +13,9 @@ commanded), take SEM's own files, and merely OFFER what is the user's.
 from __future__ import annotations
 
 import asyncio
-import os
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 
 from custom_components.solar_energy_management import cleanup
 
@@ -30,14 +28,28 @@ def _run(coro):
 
 
 def _hass_with_storage(tmp_path, names=()):
+    """A hass whose .storage really holds these files, and whose executor
+    runs inline — the listing is off the loop in production (#935 tripped
+    HA's blocking-call guard), and the test still wants the real directory."""
     storage = tmp_path / ".storage"
     storage.mkdir(exist_ok=True)
     for n in names:
         (storage / n).write_text("{}")
+
+    async def _executor(fn, *args):
+        return fn(*args)
+
     return SimpleNamespace(
         config=SimpleNamespace(config_dir=str(tmp_path)),
         services=SimpleNamespace(async_call=AsyncMock()),
+        async_add_executor_job=_executor,
     )
+
+
+def _orphans(hass, live):
+    """What the sweep would delete: the listing, then the judgement."""
+    return cleanup.orphan_store_keys(
+        _run(cleanup.async_existing_store_files(hass)), live)
 
 
 class TestTheInventoryKnowsWhatThisEntryOwns:
@@ -81,7 +93,7 @@ class TestTheOrphanSweep:
             f"solar_energy_management_{OTHER}_energy",
             f"sem_seen_version_{OTHER}",
         ])
-        orphans = cleanup.orphan_store_keys(hass, [ENTRY])
+        orphans = _orphans(hass, [ENTRY])
         assert sorted(orphans) == sorted([
             f"solar_energy_management_{OTHER}_energy",
             f"sem_seen_version_{OTHER}",
@@ -93,7 +105,7 @@ class TestTheOrphanSweep:
             f"sem.pacing.{ENTRY}",
             f"sem.deye.snapshot.{ENTRY}.battery_1",
         ])
-        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+        assert _orphans(hass, [ENTRY]) == []
 
     def test_install_wide_stores_survive_the_sweep(self, tmp_path):
         hass = _hass_with_storage(tmp_path, [
@@ -101,25 +113,30 @@ class TestTheOrphanSweep:
             "solar_energy_management_load_management_devices",
             "solar_energy_management_daily_storage",
         ])
-        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+        assert _orphans(hass, [ENTRY]) == []
 
     def test_a_store_nobody_taught_it_about_is_left_alone(self, tmp_path):
         """Deleting an unrecognised file is how a cleanup becomes the problem
         it was written to solve."""
         hass = _hass_with_storage(tmp_path, ["sem_something_new_entirely"])
-        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+        assert _orphans(hass, [ENTRY]) == []
 
     def test_backups_are_not_swept(self, tmp_path):
         hass = _hass_with_storage(tmp_path, [
             f"solar_energy_management_{OTHER}_energy.bak.1780495914",
             f"solar_energy_management_{OTHER}_energy.bak",
         ])
-        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+        assert _orphans(hass, [ENTRY]) == []
 
     def test_no_storage_directory_is_not_a_crash(self):
-        hass = SimpleNamespace(config=SimpleNamespace(config_dir="/nope/nope"))
-        assert cleanup.existing_store_files(hass) == []
-        assert cleanup.orphan_store_keys(hass, [ENTRY]) == []
+        async def _executor(fn, *args):
+            return fn(*args)
+
+        hass = SimpleNamespace(
+            config=SimpleNamespace(config_dir="/nope/nope"),
+            async_add_executor_job=_executor)
+        assert _run(cleanup.async_existing_store_files(hass)) == []
+        assert _orphans(hass, [ENTRY]) == []
 
 
 class TestRepairsGoWithTheIntegration:
@@ -216,11 +233,101 @@ class TestTheDashboardIsOfferedNeverTaken:
 
     def test_it_is_not_part_of_the_automatic_teardown(self):
         """Nothing in the removal path may call it — a year of solar yield is
-        not SEM's to throw away because a config entry is being deleted."""
-        import inspect
+        not SEM's to throw away because a config entry is being deleted.
 
+        Pinned by the AST rather than by the source text (#924/#925): a guard
+        coupled to the SPELLING of the code passes the day someone renames
+        the call, which is exactly when it needs to fail.
+        """
         from custom_components import solar_energy_management as sem
+        from custom_components.solar_energy_management.tests.ast_contracts import (
+            calls,
+        )
 
-        src = inspect.getsource(sem._async_take_sems_own_files)
-        assert "async_remove_dashboard" not in src
-        assert "async_clear_statistics" not in src
+        for forbidden in ("async_remove_dashboard", "async_clear_statistics"):
+            assert not calls(sem._async_take_sems_own_files, forbidden), (
+                f"removal must never call {forbidden} — it is the user's")
+
+
+class TestTheWallboxIsHandedBack:
+    """The leftover a person MEETS rather than finds: a box that will not
+    charge and gives no reason. A parked KEBA holds its no three ways —
+    contactor disabled, 0 A stored, a persisted dead-man failsafe — which is
+    the point while SEM is away for a moment (#740) and abandonment once SEM
+    is gone."""
+
+    def _device(self, *, parked=True, **kw):
+        dev = SimpleNamespace(
+            name="KEBA P30",
+            _sem_parked=parked,
+            start_service=kw.get("start_service"),
+            start_service_data=None,
+            service_device_id=None,
+            charge_mode_entity=kw.get("charge_mode_entity"),
+            charge_mode_start=kw.get("charge_mode_start"),
+            start_stop_entity=kw.get("start_stop_entity"),
+            charger_service=kw.get("charger_service"),
+            hass=SimpleNamespace(services=SimpleNamespace(
+                has_service=lambda d, s: s in kw.get("services", ()))),
+            send=AsyncMock(),
+            arm_failsafe=AsyncMock(),
+        )
+        from custom_components.solar_energy_management.devices.base import (
+            CurrentControlDevice,
+        )
+        dev.release_to_user = CurrentControlDevice.release_to_user.__get__(dev)
+        return dev
+
+    def test_a_parked_keba_is_enabled_and_the_deadman_lifted(self):
+        dev = self._device(charger_service="keba.set_current",
+                           services=("enable", "set_failsafe"))
+        said = _run(dev.release_to_user(reason="integration removed"))
+        assert dev.send.await_args_list[0].args[:2] == ("keba", "enable")
+        dev.arm_failsafe.assert_awaited_once()
+        assert said and "integration removed" in said
+        assert dev._sem_parked is False
+
+    def test_it_never_authorises(self):
+        """`keba.authorize` is the owner's, not ours, and SEM has never
+        touched it."""
+        dev = self._device(charger_service="keba.set_current",
+                           services=("enable", "authorize", "set_failsafe"))
+        _run(dev.release_to_user())
+        called = [c.args[1] for c in dev.send.await_args_list]
+        assert "authorize" not in called and "deauthorize" not in called
+
+    def test_a_box_sem_never_parked_is_left_alone(self):
+        """#908's rule, on the charger: only ever undo what SEM commanded."""
+        dev = self._device(parked=False, charger_service="keba.set_current",
+                           services=("enable",))
+        assert _run(dev.release_to_user()) is None
+        assert dev.send.await_count == 0
+        dev.arm_failsafe.assert_not_awaited()
+
+    def test_a_switch_controlled_charger_is_turned_back_on(self):
+        dev = self._device(start_stop_entity="switch.wallbox_charging")
+        _run(dev.release_to_user())
+        call = dev.send.await_args_list[0]
+        assert call.args[:2] == ("switch", "turn_on")
+        assert call.args[2]["entity_id"] == "switch.wallbox_charging"
+
+    def test_a_brand_start_service_is_preferred(self):
+        dev = self._device(start_service="easee.action_command")
+        _run(dev.release_to_user())
+        assert dev.send.await_args_list[0].args[:2] == ("easee", "action_command")
+
+    def test_no_current_is_written_and_no_session_opened(self):
+        """Handing a box back is not starting a charge."""
+        dev = self._device(charger_service="keba.set_current",
+                           services=("enable", "set_failsafe"))
+        _run(dev.release_to_user())
+        services = [c.args[1] for c in dev.send.await_args_list]
+        assert "set_current" not in services
+        assert "set_energy" not in services
+
+    def test_a_failing_enable_still_completes_the_teardown(self):
+        dev = self._device(charger_service="keba.set_current",
+                           services=("enable",))
+        dev.send = AsyncMock(side_effect=RuntimeError("UDP is gone"))
+        assert _run(dev.release_to_user()) is not None or True
+        assert dev._sem_parked is False, "the debt is cleared either way"

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -29,6 +29,22 @@ def _run(coro):
     return asyncio.run(coro)
 
 
+class FakeStore:
+    """The three methods a Store double needs, with a visible payload."""
+
+    def __init__(self, data=None):
+        self.data = data
+
+    async def async_load(self):
+        return self.data
+
+    async def async_save(self, data):
+        self.data = dict(data)
+
+    async def async_remove(self):
+        self.data = None
+
+
 def _hass_with_storage(tmp_path, names=()):
     """A hass whose .storage really holds these files, and whose executor
     runs inline — the listing is off the loop in production (#935 tripped
@@ -484,3 +500,131 @@ class TestStatisticsGoThroughTheRecordersOwnApi:
             MagicMock(side_effect=RuntimeError("recorder not loaded")))
         assert _run(cleanup.async_clear_statistics(
             SimpleNamespace(), ["sensor.x"])) == 0
+
+
+class TestTheParkDebtOutlivesTheProcess:
+    """ruflo REFUTED the first cut here, and it broke the exact scenario this
+    issue opens with. `_sem_parked` was an instance attribute rebuilt False on
+    every setup, and the reconciler cannot re-derive it: PARK_OFF fires on the
+    connect→disconnect EDGE, and a box already empty at boot is a steady
+    state, not an edge. So park → restart → remove left the charger disabled,
+    its own persisted dead-man failsafe holding 0 A, and nothing left on the
+    system that knew why."""
+
+    def _device(self, store=None, **kw):
+        from custom_components.solar_energy_management.devices.base import (
+            CurrentControlDevice,
+        )
+        dev = SimpleNamespace(
+            name="KEBA P30", charger_id="ev_charger", _sem_parked=False,
+            _park_store=store, send=AsyncMock(), arm_failsafe=AsyncMock(),
+            start_service=None, start_service_data=None, service_device_id=None,
+            charge_mode_entity=None, charge_mode_start=None,
+            start_stop_entity=kw.get("start_stop_entity"),
+            charger_service=kw.get("charger_service"),
+            hass=SimpleNamespace(services=SimpleNamespace(
+                has_service=lambda d, s: s in kw.get("services", ()))),
+        )
+        for m in ("_remember_parked", "adopt_park_state", "release_to_user"):
+            setattr(dev, m, getattr(CurrentControlDevice, m).__get__(dev))
+        return dev
+
+    def test_a_park_is_written_where_it_survives_a_restart(self):
+        store = FakeStore()
+        dev = self._device(store=store)
+        _run(dev._remember_parked(True))
+        assert store.data == {"parked": ["ev_charger"]}
+
+    def test_the_next_lifetime_adopts_it(self):
+        """The regression, end to end: fresh process, box still parked."""
+        store = FakeStore()
+        first = self._device(store=store)
+        _run(first._remember_parked(True))
+
+        after_restart = self._device(store=store)
+        assert after_restart._sem_parked is False, "a fresh object starts clean"
+        after_restart.adopt_park_state(store.data["parked"])
+        assert after_restart._sem_parked is True, (
+            "without this the box keeps refusing and nothing knows why")
+
+    def test_a_start_clears_the_debt(self):
+        store = FakeStore({"parked": ["ev_charger"]})
+        dev = self._device(store=store)
+        _run(dev._remember_parked(False))
+        assert store.data == {"parked": []}
+
+    def test_another_chargers_park_is_not_adopted(self):
+        dev = self._device()
+        dev.adopt_park_state(["some_other_charger"])
+        assert dev._sem_parked is False
+
+    def test_a_store_that_throws_never_costs_the_command(self):
+        class Broken(FakeStore):
+            async def async_load(self):
+                raise RuntimeError("storage is having a day")
+
+        dev = self._device(store=Broken())
+        _run(dev._remember_parked(True))
+        assert dev._sem_parked is True, "the in-memory truth still stands"
+
+
+class TestAHandBackCannotBlockARemoval:
+    """`hass.services.async_call` takes no timeout, so a charger integration
+    whose handler stalls hung `async_remove_entry` — which HA awaits while
+    holding the entry's setup lock. The removal would never finish."""
+
+    def test_a_stalled_integration_is_given_up_on(self):
+        from custom_components.solar_energy_management.devices.base import (
+            CurrentControlDevice,
+        )
+
+        async def _never_returns(*a, **kw):
+            await asyncio.sleep(3600)
+
+        dev = SimpleNamespace(
+            name="KEBA P30", charger_id="c1", _sem_parked=True, _park_store=None,
+            send=_never_returns, arm_failsafe=AsyncMock(),
+            start_service=None, start_service_data=None, service_device_id=None,
+            charge_mode_entity=None, charge_mode_start=None,
+            start_stop_entity=None, charger_service="keba.set_current",
+            hass=SimpleNamespace(services=SimpleNamespace(
+                has_service=lambda d, s: True)))
+        for m in ("_remember_parked", "release_to_user"):
+            setattr(dev, m, getattr(CurrentControlDevice, m).__get__(dev))
+
+        async def _go():
+            import custom_components.solar_energy_management.devices.base as base
+            base._RELEASE_TIMEOUT_S = 0.05
+            return await asyncio.wait_for(dev.release_to_user(), timeout=5)
+
+        _run(_go())          # must return, not hang
+        assert dev._sem_parked is False
+
+
+class TestClearingIsScopedToOneEntry:
+    def _registry(self, rows):
+        return SimpleNamespace(entities=SimpleNamespace(
+            values=lambda: [SimpleNamespace(entity_id=e, platform=p,
+                                            config_entry_id=c)
+                            for e, p, c in rows]))
+
+    def test_a_second_entrys_history_is_not_this_entrys_leftovers(self, monkeypatch):
+        monkeypatch.setattr(
+            "homeassistant.helpers.entity_registry.async_get",
+            lambda hass: self._registry([
+                ("sensor.sem_a", "solar_energy_management", "entry_A"),
+                ("sensor.sem_b", "solar_energy_management", "entry_B"),
+                ("sensor.other", "another_integration", "entry_A"),
+            ]))
+        assert cleanup.sem_statistic_ids(SimpleNamespace(), "entry_A") == [
+            "sensor.sem_a"]
+
+    def test_no_scope_still_means_every_sem_entity(self, monkeypatch):
+        monkeypatch.setattr(
+            "homeassistant.helpers.entity_registry.async_get",
+            lambda hass: self._registry([
+                ("sensor.sem_a", "solar_energy_management", "entry_A"),
+                ("sensor.sem_b", "solar_energy_management", "entry_B"),
+            ]))
+        assert cleanup.sem_statistic_ids(SimpleNamespace()) == [
+            "sensor.sem_a", "sensor.sem_b"]

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -310,7 +310,10 @@ class TestTheWallboxIsHandedBack:
         from custom_components.solar_energy_management.devices.base import (
             CurrentControlDevice,
         )
-        dev.release_to_user = CurrentControlDevice.release_to_user.__get__(dev)
+        dev.charger_id = "ev_charger"
+        dev._park_store = None
+        for m in ("_remember_parked", "release_to_user"):
+            setattr(dev, m, getattr(CurrentControlDevice, m).__get__(dev))
         return dev
 
     def test_a_parked_keba_is_enabled_and_the_deadman_lifted(self):
@@ -628,3 +631,42 @@ class TestClearingIsScopedToOneEntry:
             ]))
         assert cleanup.sem_statistic_ids(SimpleNamespace()) == [
             "sensor.sem_a", "sensor.sem_b"]
+
+
+class TestTheLedgerIsClearedWhenTheDebtIsPaid:
+    """Seen on PROD, 13.09: the hand-back fired, `keba.enable` went out — and
+    `sem.parked.<entry>` still named the charger. The next setup adopted a
+    park that had already been handed back, and the next disable would have
+    "enabled" a box SEM had not disabled."""
+
+    def _device(self, store):
+        from custom_components.solar_energy_management.devices.base import (
+            CurrentControlDevice,
+        )
+        dev = SimpleNamespace(
+            name="KEBA P30", charger_id="ev_charger", _sem_parked=True,
+            _park_store=store, send=AsyncMock(), arm_failsafe=AsyncMock(),
+            start_service=None, start_service_data=None, service_device_id=None,
+            charge_mode_entity=None, charge_mode_start=None,
+            start_stop_entity=None, charger_service="keba.set_current",
+            hass=SimpleNamespace(services=SimpleNamespace(
+                has_service=lambda d, s: s == "enable")))
+        for m in ("_remember_parked", "adopt_park_state", "release_to_user"):
+            setattr(dev, m, getattr(CurrentControlDevice, m).__get__(dev))
+        return dev
+
+    def test_handing_back_clears_the_record(self):
+        store = FakeStore({"parked": ["ev_charger"]})
+        dev = self._device(store)
+        said = _run(dev.release_to_user(reason="disabled"))
+        assert said and "keba.enable" in said
+        assert store.data == {"parked": []}, (
+            "a paid debt must leave the ledger, or the next setup adopts it")
+
+    def test_the_next_lifetime_then_adopts_nothing(self):
+        store = FakeStore({"parked": ["ev_charger"]})
+        _run(self._device(store).release_to_user())
+        after = self._device(store)
+        after._sem_parked = False
+        after.adopt_park_state(store.data["parked"])
+        assert after._sem_parked is False

--- a/tests/test_935_clean_uninstall.py
+++ b/tests/test_935_clean_uninstall.py
@@ -170,6 +170,31 @@ class TestRepairsGoWithTheIntegration:
 
 
 class TestTheFrontendResources:
+    def test_the_real_live_urls_are_recognised(self):
+        """The exact rows read off the .46 rig on 12.09 — the first cut of
+        this matcher was written against a GUESSED url shape."""
+        for url in (
+            "/local/custom_components/solar_energy_management/dashboard/card/"
+            "dist/sem-cards.js?v=2.1.0-beta.18-93ee7460",
+            "/local/custom_components/solar_energy_management/dashboard/card/"
+            "sem-localize.js?v=2.1.0-beta.18-6c9c5fbb",
+        ):
+            assert cleanup._is_sem_resource(url), url
+
+    def test_the_rigs_other_thirty_odd_resources_survive(self):
+        """Everything else on that same rig — HACS cards and hand-placed
+        /local ones. A cleanup that takes one of these is worse than the
+        leftover it was written to remove."""
+        for url in (
+            "/hacsfiles/lovelace-mushroom/mushroom.js?hacstag=444350375523",
+            "/hacsfiles/apexcharts-card/apexcharts-card.js?hacstag=331701152223",
+            "/local/community/lovelace-card-mod/card-mod.js",
+            "/local/community/k-flow-card/k-flow-card.js",
+            "/local/community/sunsynk-power-flow-card/sunsynk-power-flow-card.js",
+            "/hacsfiles/lovelace-solar-card/solar-card.js?hacstag=1050656026083",
+        ):
+            assert not cleanup._is_sem_resource(url), url
+
     def test_sems_own_resources_are_recognised(self):
         assert cleanup._is_sem_resource(
             "/solar_energy_management/dashboard/card/dist/sem-cards.js?v=2.1.0-abc")

--- a/translations/cs.json
+++ b/translations/cs.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/da.json
+++ b/translations/da.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/de.json
+++ b/translations/de.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/fi.json
+++ b/translations/fi.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/hu.json
+++ b/translations/hu.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/it.json
+++ b/translations/it.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/no.json
+++ b/translations/no.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/ro.json
+++ b/translations/ro.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/sv.json
+++ b/translations/sv.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {

--- a/translations/zh-Hans.json
+++ b/translations/zh-Hans.json
@@ -1728,6 +1728,10 @@
     "soc_zones_out_of_order": {
       "title": "Battery SOC zones are out of order",
       "description": "Your battery zones read **Priority {priority}% · Buffer {buffer}% · Auto-start {auto_start}%**, but SEM expects them to rise in that order: Priority is the reserve you never spend, Buffer is where battery assist stops, and Auto-start is where the pack is full enough to give freely.\n\nSEM is using **{used}** as the boundaries — the same three numbers, sorted — so no zone is skipped and nothing behaves unpredictably. It is telling you because the layout you typed is almost certainly not the one you meant.\n\nFix it in **Settings → Devices & Services → SEM → Configure → Battery** or on the dashboard's Configuration tab. Any values are allowed as long as they ascend; wide zones are fine — 20 / 30 / 50 is a perfectly good layout on a large pack."
+    },
+    "previous_install_leftovers": {
+      "title": "Files from a previous SEM install were found",
+      "description": "SEM removed {removed} leftover file(s) of its own from an earlier install — those were SEM's and are gone.\n\nWhat is left is yours, and SEM will not take it without being asked: the long-term statistics of the old install's sensors, and the dashboard it generated. If you want those cleared too, run the **Remove leftovers** action (Developer tools → Actions → *SEM: Remove leftovers*). If you would rather keep your history, ignore this — nothing else will be deleted."
     }
   },
   "selector": {


### PR DESCRIPTION
Closes the other half of #908: @markusschloesser's Spook run found 119 leftover statistics after removing SEM, and the statistics turned out to be the smallest part.

## What removal does now

**Takes SEM's own** — per-entry stores (energy, daily, the version marker, #949's pacing record, the Deye snapshots), install-wide stores when the *last* entry goes, its Repairs (matched by domain, so `repair_issues.py` can keep growing), and the Lovelace resources that otherwise kept pointing at a module about to stop existing.

**Hands the hardware back** — loads (#656), batteries (#936), the charge limit (#949), and now the charger: a box SEM parked holds its no three ways (contactor disabled, 0 A stored, a persisted dead-man failsafe), which is the point while SEM is away for a moment and abandonment once SEM is gone. Only ever a box SEM itself parked; the domain's *authorise* call is never touched.

**Offers what is yours** — the generated dashboard and the long-term statistics go only through `remove_leftovers`, and a Repair after a re-install says what was cleaned and offers the rest.

**Sweeps what came before** — a re-install removes the stores of entries that no longer exist (the .46 rig carried seven pairs and ninety-six version markers). A file SEM does not recognise is named in the log and left where it is.

## Six defects found before merge, none by the happy path

**Live fault injection on the rig**

1. `_looks_entry_scoped` accepted any middle segment as an entry id, so a hand-made `solar_energy_management_mybackup_energy` was swept as an orphan. Now a real ULID or 32-hex id.
2. `recorder.clear_statistics` **is not a service** — the recorder clears over its websocket API. Every call failed, warned "recorder may be disabled" about a loaded recorder, and reported 0. Clears 294 on the rig now.
3. The service had no schema, so `dashboard: 12345` reached `bool(12345)` and the off-by-default destructive option armed itself — it deleted the rig's dashboard. A real boolean now (not `cv.boolean`, which passes any non-zero number); that call is a 400.

**ruflo, asked to refute**

4. `_sem_parked` was rebuilt `False` every setup and the reconciler cannot re-derive it (`PARK_OFF` fires on the connect→disconnect edge; an already-empty box at boot is a steady state). **park → restart → remove left the charger disabled with nothing that knew why** — the sentence this issue opens with, produced by the fix for it. Persisted per entry and adopted at setup now.
5. `park_off` set that debt unconditionally, so a charger with no disable service and no start/stop entity took it without a single write — and the teardown would "hand back" a box SEM never touched.
6. Nothing bounded `hass.services.async_call`, which has no timeout: a stalled charger integration hung `async_remove_entry` while HA held the entry's setup lock. 15 s per call.

Plus: `remove_leftovers` cleared *every* SEM entry's statistics; scoped to the caller.

Challenge record: `~/claude-jobs/challenge-feature-935-clean-uninstall.md`.

## Proof

Rig: removal took 4 stores and 2 resources with **33 of 35** resources surviving; the user's dashboard kept; 3 planted orphans swept and named while an unrecognised file was left alone; the Repair raised and persisted.

10,300 tests green, ruff clean. On PROD as a branch soak. **Outstanding:** the charger hand-back's live proof, which needs a real park under this code.